### PR TITLE
Add GitHub Action to declaratively manage repository issue labels

### DIFF
--- a/.github/labels.json
+++ b/.github/labels.json
@@ -1,0 +1,127 @@
+[
+  {
+    "name": "A-build",
+    "color": "f7e101",
+    "description": "Area: CI build infrastructure."
+  },
+  {
+    "name": "A-crate-features",
+    "color": "f7e101",
+    "description": "Area: Compile-time features or attributes."
+  },
+  {
+    "name": "A-bytestring-interner",
+    "color": "f7e101",
+    "description": "Area: Bytestring SymbolTable."
+  },
+  {
+    "name": "A-deps",
+    "color": "f7e101",
+    "description": "Area: Source and library dependencies."
+  },
+  {
+    "name": "A-performance",
+    "color": "f7e101",
+    "description": "Area: Performance improvements and optimizations."
+  },
+  {
+    "name": "A-project",
+    "color": "f7e101",
+    "description": "Area: Infrastructure for running an open source project."
+  },
+  {
+    "name": "A-release",
+    "color": "f7e101",
+    "description": "Area: crates.io releases and version bumps."
+  },
+  {
+    "name": "A-utf8-string-interner",
+    "color": "f7e101",
+    "description": "Area: UTF-8 String SymbolTable."
+  },
+  {
+    "name": "C-bug",
+    "color": "c1c8ff",
+    "description": "Category: This is a bug."
+  },
+  {
+    "name": "C-docs",
+    "color": "c1c8ff",
+    "description": "Category: Improvements or additions to documentation."
+  },
+  {
+    "name": "C-enhancement",
+    "color": "c1c8ff",
+    "description": "Category: New feature or request."
+  },
+  {
+    "name": "C-quality",
+    "color": "c1c8ff",
+    "description": "Category: Refactoring, cleanup, and quality improvements."
+  },
+  {
+    "name": "C-question",
+    "color": "c1c8ff",
+    "description": "Category: Further information is requested."
+  },
+  {
+    "name": "E-easy",
+    "color": "02e10c",
+    "description": "Call for participation: Experience needed to fix: Easy / not much."
+  },
+  {
+    "name": "E-medium",
+    "color": "02e10c",
+    "description": "Call for participation: Experience needed to fix: Medium / intermediate."
+  },
+  {
+    "name": "E-hard",
+    "color": "02e10c",
+    "description": "Call for participation: Experience needed to fix: Hard / a lot."
+  },
+  {
+    "name": "E-help-wanted",
+    "color": "02e10c",
+    "description": "Call for participation: Help is requested to fix this issue."
+  },
+  {
+    "name": "E-needs-test",
+    "color": "02e10c",
+    "description": "Call for participation: writing correctness tests."
+  },
+  {
+    "name": "S-blocked",
+    "color": "d3dddd",
+    "description": "Status: marked as blocked ❌ on something else such as other implementation work."
+  },
+  {
+    "name": "S-do-not-merge",
+    "color": "d3dddd",
+    "description": "Status: This pull request should not be merged."
+  },
+  {
+    "name": "S-duplicate",
+    "color": "d3dddd",
+    "description": "Status: This issue or pull request already exists."
+  },
+  {
+    "name": "S-invalid",
+    "color": "d3dddd",
+    "description": "Status: This issue or pull request is not well-formed."
+  },
+  {
+    "name": "S-speculative",
+    "color": "d3dddd",
+    "description": "Status: This is just an idea."
+  },
+  {
+    "name": "S-wip",
+    "color": "d3dddd",
+    "description": "Status: This pull request is a work in progress."
+  },
+  {
+    "name": "S-wontfix",
+    "color": "d3dddd",
+    "description": "Status: This issue or pull request will not be worked on."
+  }
+]

--- a/.github/workflows/repo-labels.yaml
+++ b/.github/workflows/repo-labels.yaml
@@ -1,0 +1,17 @@
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - .github/labels.json
+name: Create Repository Labels
+jobs:
+  labels:
+    name: Synchronize repository labels
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: lannonbr/issue-label-manager-action@2.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This is largely cargo culted from [artichoke/boba](https://github.com/artichoke/boba/blob/55124bf7d3e82ef274ceb6dbffe9e6a8a53adbc2/.github/labels.json).