### PR TITLE
Add audit workflow that calls cargo-deny

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -1,0 +1,27 @@
+name: Audit
+on:
+  push:
+    branches:
+      - trunk
+  pull_request:
+    branches:
+      - trunk
+  schedule:
+    - cron: "0 0 * * WED"
+jobs:
+  rust:
+    name: Audit Rust Dependencies
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Fetch cargo-audit
+        run: |
+          curl -sL "$RELEASE" | sudo tar xvz -C /usr/local/bin/ --strip-components=1
+        env:
+          RELEASE: "https://github.com/EmbarkStudios/cargo-deny/releases/download/0.6.8/cargo-deny-0.6.8-x86_64-unknown-linux-musl.tar.gz"
+
+      - name: Run cargo-deny
+        run: cargo-deny check

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,32 @@
+[advisories]
+vulnerability = "deny"
+unmaintained = "deny"
+notice = "warn"
+ignore = []
+
+[licenses]
+unlicensed = "deny"
+allow = [
+  "MIT",
+]
+deny = []
+copyleft = "deny"
+allow-osi-fsf-free = "neither"
+default = "deny"
+confidence-threshold = 0.8
+
+[bans]
+multiple-versions = "deny"
+highlight = "all"
+allow = []
+deny = []
+skip = []
+skip-tree = []
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = [
+  "https://github.com/rust-lang/crates.io-index",
+]
+allow-git = []


### PR DESCRIPTION
cargo-deny enables restricting the licenses intaglio has in its
dependency graph.

cargo-deny checks intaglio's dependency graph for security vulnerabilities
and unmaintained crates.

This workflow runs for each PR and trunk merge and weekly.

This workflow and its jobs are do not block PRs from merging.