### PR TITLE
Add integration tests

### DIFF
--- a/tests/leak/mod.rs
+++ b/tests/leak/mod.rs
@@ -1,0 +1,74 @@
+#![allow(dead_code)]
+
+#[cfg(target_os = "linux")]
+use std::mem::MaybeUninit;
+
+#[derive(Debug)]
+pub struct Looper<'a, T> {
+    test: &'a str,
+    subject: T,
+    iterations: usize,
+    tolerance: i64, // in bytes
+}
+
+impl<'a, T> Looper<'a, T> {
+    pub fn new(test: &'a str, subject: T) -> Self {
+        Self {
+            test,
+            subject,
+            iterations: 0,
+            tolerance: 0,
+        }
+    }
+
+    pub fn with_iterations(mut self, iterations: usize) -> Self {
+        self.iterations = iterations;
+        self
+    }
+
+    pub fn with_tolerance(mut self, tolerance: i64) -> Self {
+        self.tolerance = tolerance;
+        self
+    }
+
+    pub fn check_leaks<F>(self, execute: F)
+    where
+        F: FnMut(usize, &mut T),
+    {
+        self.check_leaks_with_finalizer(execute, |_| {});
+    }
+
+    pub fn check_leaks_with_finalizer<F, G>(mut self, mut execute: F, finalize: G)
+    where
+        F: FnMut(usize, &mut T),
+        G: FnOnce(T),
+    {
+        let start_mem = resident_memsize();
+        for i in 0..self.iterations {
+            execute(i, &mut self.subject);
+        }
+        finalize(self.subject);
+        let end_mem = resident_memsize();
+        assert!(
+            end_mem <= start_mem + self.tolerance,
+            "Plausible memory leak in test {}!\nAfter {} iterations, usage before: {}, usage after: {}",
+            self.test,
+            self.iterations,
+            start_mem,
+            end_mem
+        );
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn resident_memsize() -> i64 {
+    let mut out = MaybeUninit::<libc::rusage>::uninit();
+    assert!(unsafe { libc::getrusage(libc::RUSAGE_SELF, out.as_mut_ptr()) } == 0);
+    let out = unsafe { out.assume_init() };
+    out.ru_maxrss
+}
+
+#[cfg(not(target_os = "linux"))]
+fn resident_memsize() -> i64 {
+    0
+}

--- a/tests/leak_drop_symbol_table.rs
+++ b/tests/leak_drop_symbol_table.rs
@@ -1,0 +1,61 @@
+#![deny(clippy::all)]
+#![deny(clippy::pedantic)]
+
+use intaglio::{str, SymbolTable};
+
+mod leak;
+
+use leak::Looper;
+
+const ITERATIONS: usize = 100_000;
+const LEAK_TOLERANCE: i64 = 1024 * 1024 * 50;
+
+#[test]
+fn dealloc_owned_data_bytes() {
+    let table = SymbolTable::with_capacity(0);
+    Looper::new("dealloc_owned_data_bytes", table)
+        .with_iterations(ITERATIONS)
+        .with_tolerance(LEAK_TOLERANCE)
+        .check_leaks_with_finalizer(
+            |i, table| {
+                #[allow(clippy::cast_possible_truncation)]
+                let byte = (i % 256) as u8;
+                let len = (i / 256) + 100;
+                let symbol = vec![byte; len];
+                let sym_id = table.intern(symbol.clone()).unwrap();
+                assert!(table.is_interned(&symbol));
+                assert!(table.contains(sym_id));
+                assert_eq!(Some(symbol.as_slice()), table.get(sym_id));
+                assert_eq!(sym_id, table.intern(symbol.clone()).unwrap());
+                assert!(table.is_interned(&symbol));
+                assert!(table.contains(sym_id));
+                assert_eq!(Some(symbol.as_slice()), table.get(sym_id));
+            },
+            drop,
+        );
+}
+
+#[test]
+fn dealloc_owned_data_str() {
+    let table = str::SymbolTable::with_capacity(0);
+    Looper::new("dealloc_owned_data_str", table)
+        .with_iterations(ITERATIONS)
+        .with_tolerance(LEAK_TOLERANCE)
+        .check_leaks_with_finalizer(
+            |i, table| {
+                #[allow(clippy::cast_possible_truncation)]
+                let ch = char::from((i % 256) as u8);
+                let len = (i / 256) + 100;
+                let symbol = vec![ch; len].into_iter().collect::<String>();
+                let sym_id = table.intern(symbol.clone()).unwrap();
+                assert!(table.is_interned(&symbol));
+                assert!(table.contains(sym_id));
+                assert_eq!(Some(symbol.as_str()), table.get(sym_id));
+                assert_eq!(sym_id, table.intern(symbol.clone()).unwrap());
+                assert!(table.is_interned(&symbol));
+                assert!(table.contains(sym_id));
+                assert_eq!(Some(symbol.as_str()), table.get(sym_id));
+            },
+            drop,
+        );
+}

--- a/tests/version_numbers.rs
+++ b/tests/version_numbers.rs
@@ -1,0 +1,9 @@
+#[test]
+fn test_readme_deps() {
+    version_sync::assert_markdown_deps_updated!("README.md");
+}
+
+#[test]
+fn test_html_root_url() {
+    version_sync::assert_html_root_url_updated!("src/lib.rs");
+}


### PR DESCRIPTION
- version_check ensures README and crate metadata point to the same version
  as is in Cargo.toml.
- leak test interns strings in a hot loop and checks for memory leaks using
  libc.