### PR TITLE
Deploy rustdoc when built on trunk branch

### DIFF
--- a/.github/workflows/rustdoc.yaml
+++ b/.github/workflows/rustdoc.yaml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Deploy Docs
         uses: peaceiris/actions-gh-pages@v3
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/trunk'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./target/doc

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ rustup update stable
 
 ### Rust Crates
 
-Artichoke depends on several Rust libraries, or crates. Once you have the Rust
+Intaglio depends on several Rust libraries, or crates. Once you have the Rust
 toolchain installed, you can install the crates specified in
 [`Cargo.toml`](Cargo.toml) by running:
 
@@ -143,6 +143,7 @@ To see what crates are outdated, you can use
 
 If you need to pull in an updated version of a crate for a bugfix or a new
 feature, update the version number in `Cargo.toml`. See
-[GH-548](https://github.com/artichoke/artichoke/pull/548) for an example.
+[Artichoke GH-548](https://github.com/artichoke/artichoke/pull/548) for an
+example.
 
 Regular dependency bumps are handled by [@dependabot](https://dependabot.com/).

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 <br>
 [![Crate](https://img.shields.io/crates/v/intaglio.svg)](https://crates.io/crates/intaglio)
 [![API](https://docs.rs/intaglio/badge.svg)](https://docs.rs/intaglio)
-[![API master](https://img.shields.io/badge/docs-master-blue.svg)](https://artichoke.github.io/intaglio/intaglio/)
+[![API trunk](https://img.shields.io/badge/docs-trunk-blue.svg)](https://artichoke.github.io/intaglio/intaglio/)
 
 UTF-8 and bytestring interner and symbol table. Used to implement storage for
 the [Ruby `Symbol`][symbol] and the constant name table in [Artichoke


### PR DESCRIPTION
Fix copy paste error from importing the `rustdoc` workflow from `boba`.

Improve copy in `README.md` and `CONTRIBUTING.md`.