### PR TITLE
Run drop tests with Miri

### DIFF
--- a/.github/workflows/miri.yaml
+++ b/.github/workflows/miri.yaml
@@ -1,0 +1,35 @@
+name: Miri
+on:
+  push:
+    branches:
+      - trunk
+  pull_request:
+    branches:
+      - trunk
+  schedule:
+    - cron: "0 0 * * WED"
+jobs:
+  miri:
+    name: Test with Miri
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: -D warnings
+      RUST_BACKTRACE: 1
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          profile: minimal
+          override: true
+          components: miri, rust-src
+
+      - name: Miri setup
+        run: cargo miri setup
+
+      - name: Test unsafe code with Miri
+        run: cargo miri test -- -- drop


### PR DESCRIPTION
The only unsafe code in intaglio is in the Drop impls, so test them
with Miri to check for memory unsafety.