### PR TITLE
Reorganize public API to make it easier to add cargo features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,17 +3,29 @@ name = "intaglio"
 version = "0.1.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2018"
-description = "Bytestring interner and symbol table"
-repository = "https://github.com/artichoke/artichoke"
+description = "UTF-8 string and bytestring interner and symbol table"
+repository = "https://github.com/artichoke/intaglio"
 readme = "README.md"
 license = "MIT"
-keywords = ["artichoke", "bytestring", "intern", "interner", "symbol"]
+keywords = ["bytestring", "intern", "interner", "symbol", "utf8"]
 categories = ["caching", "data-structures"]
 include = [
   "src/**/*.rs",
   "LICENSE",
   "README.md"
 ]
+
+[[bench]]
+name = "benchmarks"
+harness = false
+
+[features]
+# All features are enabled by default.
+default = ["bytes"]
+# `bytes` feature enables an additional symbol table implementation for
+# interning bytestrings (`Vec<u8>` and `&'static [u8]`). When this feature is
+# enabled, Intaglio will depend on [`bstr`].
+bytes = ["bstr"]
 
 [dependencies]
 # The dependency on bstr is not strictly necessary, but `intaglio` uses the
@@ -24,7 +36,7 @@ include = [
 # characters. The UTF-8 invalid parts will be shown as e.g. \xFF escape codes
 # which is also an improvement of how `std` implements `fmt::Debug` for byte
 # slices.
-bstr = { version = "0.2", default-features = false }
+bstr = { version = "0.2", default-features = false, optional = true }
 
 [dev-dependencies]
 # Benchmarking support on stable Rust.
@@ -41,7 +53,3 @@ version-sync = "0.9"
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 # `libc::getrusage` is used to check for memory leaks on Linux in CI.
 libc = "0.2"
-
-[[bench]]
-name = "benchmarks"
-harness = false

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 [![API](https://docs.rs/intaglio/badge.svg)](https://docs.rs/intaglio)
 [![API trunk](https://img.shields.io/badge/docs-trunk-blue.svg)](https://artichoke.github.io/intaglio/intaglio/)
 
-UTF-8 and bytestring interner and symbol table. Used to implement storage for
-the [Ruby `Symbol`][symbol] table and the constant name table in [Artichoke
+UTF-8 string and bytestring interner and symbol table. Used to implement storage
+for the [Ruby `Symbol`][symbol] table and the constant name table in [Artichoke
 Ruby][artichoke].
 
 > Symbol objects represent names and some strings inside the Ruby interpreter.
@@ -29,8 +29,6 @@ _Intaglio_ is an alternate name for an _engraved gem_, a gemstone that has been
 carved with an image. The Intaglio crate is used to implement an immutable
 Symbol store in Artichoke Ruby.
 
-This crate depends on [`bstr`].
-
 ## Usage
 
 Add this to your `Cargo.toml`:
@@ -40,25 +38,11 @@ Add this to your `Cargo.toml`:
 intaglio = "0.1"
 ```
 
-Then intern bytestrings like:
+Then intern UTF-8 strings like:
 
 ```rust
 fn intern_and_get() -> Result<(), Box<dyn std::error::Error>> {
     let mut table = intaglio::SymbolTable::new();
-    let name: &'static [u8] = b"abc";
-    let sym = table.intern(name)?;
-    let retrieved = table.get(sym);
-    assert_eq!(Some(name), retrieved);
-    assert_eq!(sym, table.intern(b"abc".to_vec())?);
-    Ok(())
-}
-```
-
-Or intern UTF-8 strings like:
-
-```rust
-fn intern_and_get() -> Result<(), Box<dyn std::error::Error>> {
-    let mut table = intaglio::str::SymbolTable::new();
     let name: &'static str = "abc";
     let sym = table.intern(name)?;
     let retrieved = table.get(sym);
@@ -68,11 +52,33 @@ fn intern_and_get() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
+Or intern bytestrings like:
+
+```rust
+fn intern_and_get() -> Result<(), Box<dyn std::error::Error>> {
+    let mut table = intaglio::bytes::SymbolTable::new();
+    let name: &'static [u8] = b"abc";
+    let sym = table.intern(name)?;
+    let retrieved = table.get(sym);
+    assert_eq!(Some(name), retrieved);
+    assert_eq!(sym, table.intern(b"abc".to_vec())?);
+    Ok(())
+}
+```
+
 ## Implementation
 
 Intaglio interns owned and borrowed strings with no additional copying by
 leveraging `Cow` and `Box::leak`. This requires unsafe code in the `Drop`
 implementation of `SymbolTable`. CI runs `drop` tests under Miri.
+
+## Crate features
+
+All features are enabled by default.
+
+- **bytes** - Enables an additional symbol table implementation for interning
+  bytestrings (`Vec<u8>` and `&'static [u8]`). Disabling this drops the [`bstr`]
+  dependency.
 
 ## License
 

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -1,8 +1,9 @@
 use criterion::{criterion_group, criterion_main};
 
+#[cfg(feature = "bytes")]
 mod bytestring {
     use criterion::{BatchSize, Criterion, Throughput};
-    use intaglio::SymbolTable;
+    use intaglio::bytes::SymbolTable;
 
     pub fn bench_allocate(c: &mut Criterion) {
         let mut group = c.benchmark_group("SymbolTable constructors");
@@ -85,7 +86,7 @@ mod bytestring {
 
 mod utf8string {
     use criterion::{BatchSize, Criterion, Throughput};
-    use intaglio::str::SymbolTable;
+    use intaglio::SymbolTable;
 
     pub fn bench_allocate(c: &mut Criterion) {
         let mut group = c.benchmark_group("str::SymbolTable constructors");
@@ -166,6 +167,7 @@ mod utf8string {
     }
 }
 
+#[cfg(feature = "bytes")]
 criterion_group!(
     bytes,
     bytestring::bench_allocate,
@@ -176,4 +178,7 @@ criterion_group!(
     utf8string::bench_allocate,
     utf8string::bench_repeatedly_intern,
 );
+#[cfg(feature = "bytes")]
 criterion_main!(bytes, utf8);
+#[cfg(not(feature = "bytes"))]
+criterion_main!(utf8);

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -13,9 +13,9 @@
 //! # use intaglio::bytes::SymbolTable;
 //! # fn example() -> Result<(), Box<dyn std::error::Error>> {
 //! let mut table = SymbolTable::new();
-//! let sym_id = table.intern(&b"abc"[..])?;
-//! assert_eq!(sym_id, table.intern(b"abc".to_vec())?);
-//! assert_eq!(Some(&b"abc"[..]), table.get(sym_id));
+//! let sym = table.intern(&b"abc"[..])?;
+//! assert_eq!(sym, table.intern(b"abc".to_vec())?);
+//! assert_eq!(Some(&b"abc"[..]), table.get(sym));
 //! # Ok(())
 //! # }
 //! ```
@@ -27,10 +27,10 @@
 //! # use intaglio::bytes::{Symbol, SymbolTable};
 //! # fn example() -> Result<(), Box<dyn std::error::Error>> {
 //! let mut table = SymbolTable::new();
-//! let sym_id = table.intern(&b"abc"[..])?;
+//! let sym = table.intern(&b"abc"[..])?;
 //! // Retrieve set of `Symbol`s.
 //! let all_symbols = table.all_symbols();
-//! assert_eq!(vec![sym_id], all_symbols.collect::<Vec<_>>());
+//! assert_eq!(vec![sym], all_symbols.collect::<Vec<_>>());
 //!
 //! let mut map = HashMap::new();
 //! map.insert(Symbol::new(0), &b"abc"[..]);
@@ -203,9 +203,9 @@ impl Borrow<[u8]> for &mut Slice {
 /// # use intaglio::bytes::SymbolTable;
 /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let mut table = SymbolTable::new();
-/// let sym_id = table.intern(&b"abc"[..])?;
+/// let sym = table.intern(&b"abc"[..])?;
 /// let all_symbols = table.all_symbols();
-/// assert_eq!(vec![sym_id], all_symbols.collect::<Vec<_>>());
+/// assert_eq!(vec![sym], all_symbols.collect::<Vec<_>>());
 /// # Ok(())
 /// # }
 /// ```
@@ -300,7 +300,7 @@ impl<'a> FusedIterator for AllSymbols<'a> {}
 /// # use intaglio::bytes::SymbolTable;
 /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let mut table = SymbolTable::new();
-/// let sym_id = table.intern(b"abc".to_vec())?;
+/// let sym = table.intern(b"abc".to_vec())?;
 /// let bytestrings = table.bytestrings();
 /// assert_eq!(vec![&b"abc"[..]], bytestrings.collect::<Vec<_>>());
 /// # Ok(())
@@ -381,7 +381,7 @@ impl<'a> FusedIterator for Bytestrings<'a> {}
 /// # use intaglio::bytes::{Symbol, SymbolTable};
 /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let mut table = SymbolTable::new();
-/// let sym_id = table.intern(b"abc".to_vec())?;
+/// let sym = table.intern(b"abc".to_vec())?;
 /// let iter = table.iter();
 /// let mut map = HashMap::new();
 /// map.insert(Symbol::new(0), &b"abc"[..]);
@@ -451,9 +451,9 @@ impl<'a> IntoIterator for &'a SymbolTable {
 /// # use intaglio::bytes::SymbolTable;
 /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let mut table = SymbolTable::new();
-/// let sym_id = table.intern(&b"abc"[..])?;
-/// assert_eq!(sym_id, table.intern(b"abc".to_vec())?);
-/// assert!(table.contains(sym_id));
+/// let sym = table.intern(&b"abc"[..])?;
+/// assert_eq!(sym, table.intern(b"abc".to_vec())?);
+/// assert!(table.contains(sym));
 /// assert!(table.is_interned(b"abc"));
 /// # Ok(())
 /// # }
@@ -980,30 +980,30 @@ mod tests {
     #[quickcheck]
     fn intern_twice_symbol_equality(bytes: Vec<u8>) -> bool {
         let mut table = SymbolTable::new();
-        let sym_id = table.intern(bytes.clone()).unwrap();
-        let sym_again_id = table.intern(bytes).unwrap();
-        sym_id == sym_again_id
+        let sym = table.intern(bytes.clone()).unwrap();
+        let sym_again = table.intern(bytes).unwrap();
+        sym == sym_again
     }
 
     #[quickcheck]
     fn intern_get_roundtrip(bytes: Vec<u8>) -> bool {
         let mut table = SymbolTable::new();
-        let sym_id = table.intern(bytes.clone()).unwrap();
-        let retrieved_bytes = table.get(sym_id).unwrap();
+        let sym = table.intern(bytes.clone()).unwrap();
+        let retrieved_bytes = table.get(sym).unwrap();
         bytes == retrieved_bytes
     }
 
     #[quickcheck]
     fn table_contains_sym(bytes: Vec<u8>) -> bool {
         let mut table = SymbolTable::new();
-        let sym_id = table.intern(bytes).unwrap();
-        table.contains(sym_id)
+        let sym = table.intern(bytes).unwrap();
+        table.contains(sym)
     }
 
     #[quickcheck]
-    fn table_does_not_contain_missing_symbol_ids(sym_id: u32) -> bool {
+    fn table_does_not_contain_missing_symbol_ids(sym: u32) -> bool {
         let table = SymbolTable::new();
-        !table.contains(sym_id.into())
+        !table.contains(sym.into())
     }
 
     #[quickcheck]

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -10,7 +10,7 @@
 //! # Example: intern bytestring
 //!
 //! ```
-//! # use intaglio::bytes::bytes::SymbolTable;
+//! # use intaglio::bytes::SymbolTable;
 //! # fn example() -> Result<(), Box<dyn std::error::Error>> {
 //! let mut table = SymbolTable::new();
 //! let sym_id = table.intern(&b"abc"[..])?;
@@ -24,7 +24,7 @@
 //!
 //! ```
 //! # use std::collections::HashMap;
-//! # use intaglio::bytes::bytes::SymbolTable;
+//! # use intaglio::bytes::{Symbol, SymbolTable};
 //! # fn example() -> Result<(), Box<dyn std::error::Error>> {
 //! let mut table = SymbolTable::new();
 //! let sym_id = table.intern(&b"abc"[..])?;
@@ -33,8 +33,8 @@
 //! assert_eq!(vec![sym_id], all_symbols.collect::<Vec<_>>());
 //!
 //! let mut map = HashMap::new();
-//! map.insert(SymnolId::new(0), &b"abc"[..]);
-//! map.insert(SymnolId::new(1), &b"xyz"[..]);
+//! map.insert(Symbol::new(0), &b"abc"[..]);
+//! map.insert(Symbol::new(1), &b"xyz"[..]);
 //! // Retrieve symbol to byte content mappings.
 //! let iter = table.iter();
 //! assert_eq!(map, iter.collect::<HashMap<_, _>>());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,65 +5,21 @@
 #![warn(missing_debug_implementations)]
 #![warn(rust_2018_idioms)]
 
-//! String interner for bytes and UTF-8 strings.
+//! This crate provides a library for interning strings.
 //!
-//! Intaglio is a string interner:
+//! The primary API is a symbol table. Its API is similar to a
+//! bimap in that symbols can resolve an underlying string and a string slice
+//! can retrieve its associated symbol.
 //!
-//! > String interning is a method of storing only one copy of each distinct
-//! > string value, which must be immutable.
+//! For more specific details on the API for interning strings into a symbol
+//! table, please see the documentation for the [`SymbolTable`] type.
 //!
-//! This crate has two implementations of the interner:
-//!
-//! - [`SymbolTable`] operates on raw bytes through `&'static [u8]` and
-//!   [`Vec`]`<u8>`.
-//! - [`str::SymbolTable`] operates on UTF-8 strings through `&'static str` and
-//!   [`String`].
-//!
-//! Intaglio `SymbolTable`s store at most one copy of a string. All requests to
-//! intern a string that is already present in the table, regardless of whether
-//! the string is owned (e.g. `Vec<u8>` or `String`) or borrowed (e.g.
-//! `&'static [u8]` or `&'static str`), will return the same immutable
-//! [`SymbolId`].
-//!
-//! [`SymbolId`]s are u32 indexes into a `SymbolTable` that are cheap to
-//! compare, copy, store, and send.
-//!
-//! # Allocations
-//!
-//! Intaglio's `SymbolTable`s is backed by a [`Vec`] and [`HashMap`] which grow
-//! to accommodate growth in the number of stored bytestrings.
-//!
-//! The `SymbolTable`s expose several APIs for tuning the memory usage of the
-//! table which wrap the underlying data structures such as
-//! [`SymbolTable::reserve`] and [`SymbolTable::shrink_to_fit`].
-//!
-//! [`SymbolTable::intern`] and [`str::SymbolTable::intern`] do not clone or
-//! copy interned strings and take ownership of the string contents with no
-//! additional allocations. Owned strings are leaked with [`Box::leak`] and
-//! recovered and deallocated when the table is dropped.
-//!
-//! # Usage
-//!
-//! ## Bytestring
+//! # Example
 //!
 //! ```
 //! # use intaglio::SymbolTable;
 //! # fn example() -> Result<(), Box<dyn std::error::Error>> {
 //! let mut table = SymbolTable::new();
-//! let sym_id = table.intern(&b"abc"[..])?;
-//! assert_eq!(sym_id, table.intern(b"abc".to_vec())?);
-//! assert!(table.contains(sym_id));
-//! assert!(table.is_interned(b"abc"));
-//! # Ok(())
-//! # }
-//! ```
-//!
-//! ## UTF-8 String
-//!
-//! ```
-//! # use intaglio::str;
-//! # fn example() -> Result<(), Box<dyn std::error::Error>> {
-//! let mut table = str::SymbolTable::new();
 //! let sym_id = table.intern("abc")?;
 //! assert_eq!(sym_id, table.intern("abc".to_string())?);
 //! assert!(table.contains(sym_id));
@@ -71,31 +27,53 @@
 //! # Ok(())
 //! # }
 //! ```
+//!
+//! # String interning
+//!
+//! Intaglio `SymbolTable`s store at most one copy of a string. All requests to
+//! intern a string that is already present in the table, regardless of whether
+//! the string is an owned `String` or borrowed `&'static str`, will return the
+//! same immutable [`Symbol`].
+//!
+//! [`Symbol`]s are `u32` indexes into a `SymbolTable` that are cheap to
+//! compare, copy, store, and send.
+//!
+//! # Allocations
+//!
+//! `SymbolTable` exposes several constructors for tuning the initial allocated
+//! size of the table. It also exposes several APIs for tuning the table's
+//! memory usage such as [`SymbolTable::reserve`] and
+//! [`SymbolTable::shrink_to_fit`].
+//!
+//! [`SymbolTable::intern`] does not clone or copy interned strings. It takes
+//! ownership of the string contents with no additional allocations. Owned
+//! strings are leaked with [`Box::leak`] and recovered and deallocated when the
+//! table is dropped.
+//!
+//! # Crate features
+//!
+//! All features are enabled by default.
+//!
+//! - **bytes** - Enables an additional symbol table implementation for
+//!   interning bytestrings (`Vec<u8>` and `&'static [u8]`). Disabling this
+//!   drops the `bstr` dependency.
 
 #![doc(html_root_url = "https://docs.rs/intaglio/0.1.0")]
 
-#[cfg(doctest)]
+#[cfg(all(doctest, feature = "bytes"))]
 doc_comment::doctest!("../README.md");
 
-use bstr::{BStr, ByteSlice};
-use core::borrow::Borrow;
-use core::cmp;
-use core::convert::{TryFrom, TryInto};
+use core::convert::TryFrom;
 use core::fmt;
-use core::hash::{BuildHasher, Hash, Hasher};
-use core::iter::{self, FusedIterator};
-use core::marker::PhantomData;
-use core::mem::{self, size_of};
+use core::mem::size_of;
 use core::num::{NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize, TryFromIntError};
-use core::ops::{Deref, Range, RangeInclusive};
-use core::slice;
-use std::borrow::Cow;
-use std::collections::hash_map::RandomState;
-use std::collections::HashMap;
 use std::error;
 
-/// An intaglio interner for UTF-8 strings.
-pub mod str;
+#[cfg(feature = "bytes")]
+pub mod bytes;
+mod str;
+
+pub use crate::str::SymbolTable;
 
 // To prevent overflows when indexing into the backing `Vec`, `intaglio`
 // requires `usize` to be at least as big as `u32`.
@@ -113,12 +91,12 @@ pub const DEFAULT_SYMBOL_TABLE_CAPACITY: usize = 4096;
 /// `u32::MAX` symbols are stored in the table, no more identifiers can be
 /// generated. Any subsequent inserts into the table will fail with this error.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct SymbolIdOverflowError {
+pub struct SymbolOverflowError {
     max_capacity: usize,
     source: TryFromIntError,
 }
 
-impl SymbolIdOverflowError {
+impl SymbolOverflowError {
     /// Return the maximum capacity of the [`SymbolTable`] that returned this
     /// error.
     #[must_use]
@@ -127,7 +105,7 @@ impl SymbolIdOverflowError {
     }
 }
 
-impl From<TryFromIntError> for SymbolIdOverflowError {
+impl From<TryFromIntError> for SymbolOverflowError {
     fn from(err: TryFromIntError) -> Self {
         Self {
             max_capacity: u32::MAX as usize,
@@ -136,72 +114,71 @@ impl From<TryFromIntError> for SymbolIdOverflowError {
     }
 }
 
-impl fmt::Display for SymbolIdOverflowError {
+impl fmt::Display for SymbolOverflowError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Symbol ID overflow")
     }
 }
 
-impl error::Error for SymbolIdOverflowError {
+impl error::Error for SymbolOverflowError {
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         Some(&self.source)
     }
 }
 
-/// Identifier bound to an interned bytestring.
+/// Identifier bound to an interned string.
 ///
-/// [`SymbolTable`] is guaranteed to return an equivalent `SymbolId` each time
-/// an equivalent `&[u8]` is interned.
+/// [`SymbolTable`] is guaranteed to return an equivalent `Symbol` each time
+/// an equivalent string is interned.
 ///
-/// A `SymbolId` allows retrieving a reference to the original interned
-/// bytestring.
+/// A `Symbol` allows retrieving a reference to the original interned string.
 ///
-/// `SymbolId`s are based on a `u32` index.
+/// `Symbol`s are based on a `u32` index.
 ///
-/// `SymbolId`s are not associated with the `SymbolTable` which created them. No
-/// runtime checks ensure that [`SymbolTable::get`] is called with a `SymbolId`
+/// `Symbol`s are not constrained to the `SymbolTable` which created them.  No
+/// runtime checks ensure that [`SymbolTable::get`] is called with a `Symbol`
 /// that the table itself issued.
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct SymbolId(u32);
+pub struct Symbol(u32);
 
-impl From<u8> for SymbolId {
+impl From<u8> for Symbol {
     fn from(sym: u8) -> Self {
         Self(sym.into())
     }
 }
 
-impl From<NonZeroU8> for SymbolId {
+impl From<NonZeroU8> for Symbol {
     fn from(sym: NonZeroU8) -> Self {
         Self(sym.get().into())
     }
 }
 
-impl From<u16> for SymbolId {
+impl From<u16> for Symbol {
     fn from(sym: u16) -> Self {
         Self(sym.into())
     }
 }
 
-impl From<NonZeroU16> for SymbolId {
+impl From<NonZeroU16> for Symbol {
     fn from(sym: NonZeroU16) -> Self {
         Self(sym.get().into())
     }
 }
 
-impl From<u32> for SymbolId {
+impl From<u32> for Symbol {
     fn from(sym: u32) -> Self {
         Self(sym)
     }
 }
 
-impl From<NonZeroU32> for SymbolId {
+impl From<NonZeroU32> for Symbol {
     fn from(sym: NonZeroU32) -> Self {
         Self(sym.get())
     }
 }
 
-impl TryFrom<u64> for SymbolId {
-    type Error = SymbolIdOverflowError;
+impl TryFrom<u64> for Symbol {
+    type Error = SymbolOverflowError;
 
     fn try_from(value: u64) -> Result<Self, Self::Error> {
         let id = u32::try_from(value)?;
@@ -209,8 +186,8 @@ impl TryFrom<u64> for SymbolId {
     }
 }
 
-impl TryFrom<NonZeroU64> for SymbolId {
-    type Error = SymbolIdOverflowError;
+impl TryFrom<NonZeroU64> for Symbol {
+    type Error = SymbolOverflowError;
 
     fn try_from(value: NonZeroU64) -> Result<Self, Self::Error> {
         let id = u32::try_from(value.get())?;
@@ -218,8 +195,8 @@ impl TryFrom<NonZeroU64> for SymbolId {
     }
 }
 
-impl TryFrom<usize> for SymbolId {
-    type Error = SymbolIdOverflowError;
+impl TryFrom<usize> for Symbol {
+    type Error = SymbolOverflowError;
 
     fn try_from(value: usize) -> Result<Self, Self::Error> {
         let id = u32::try_from(value)?;
@@ -227,8 +204,8 @@ impl TryFrom<usize> for SymbolId {
     }
 }
 
-impl TryFrom<NonZeroUsize> for SymbolId {
-    type Error = SymbolIdOverflowError;
+impl TryFrom<NonZeroUsize> for Symbol {
+    type Error = SymbolOverflowError;
 
     fn try_from(value: NonZeroUsize) -> Result<Self, Self::Error> {
         let id = u32::try_from(value.get())?;
@@ -236,992 +213,35 @@ impl TryFrom<NonZeroUsize> for SymbolId {
     }
 }
 
-impl From<SymbolId> for u32 {
-    fn from(sym: SymbolId) -> Self {
+impl From<Symbol> for u32 {
+    fn from(sym: Symbol) -> Self {
         sym.0
     }
 }
 
-impl From<SymbolId> for u64 {
-    fn from(sym: SymbolId) -> Self {
+impl From<Symbol> for u64 {
+    fn from(sym: Symbol) -> Self {
         sym.0.into()
     }
 }
 
-impl From<SymbolId> for usize {
-    fn from(sym: SymbolId) -> Self {
+impl From<Symbol> for usize {
+    fn from(sym: Symbol) -> Self {
         sym.0 as usize
     }
 }
 
-impl SymbolId {
-    /// Construct a new `SymbolId` from the given `u32`.
+impl Symbol {
+    /// Construct a new `Symbol` from the given `u32`.
     ///
-    /// `SymbolId`s constructed outside of a [`SymbolTable`] may fail to
-    /// resolve to an underlying bytestring using [`SymbolTable::get`].
+    /// `Symbol`s constructed outside of a [`SymbolTable`] may fail to
+    /// resolve to an underlying string using [`SymbolTable::get`].
     ///
-    /// `SymbolId`s are not associated with the `SymbolTable` which created
-    /// them. No runtime checks ensure that [`SymbolTable::get`] is called with
-    /// a `SymbolId` that the table itself issued.
+    /// `Symbol`s are not constrained to the `SymbolTable` which created them.
+    /// No runtime checks ensure that [`SymbolTable::get`] is called with a
+    /// `Symbol` that the table itself issued.
     #[must_use]
     pub fn new(sym: u32) -> Self {
         Self::from(sym)
-    }
-}
-
-/// Wrapper around `&'static [u8]` that supports deallocating references created
-/// via [`Box::leak`].
-///
-/// # Safety
-///
-/// Must not be `Clone` or `Copy` because the Drop logic assumes this enum is the
-/// unique owner of a leaked boxed slice. The lack of `Clone` and `Copy` impls is
-/// necessary to prevent double frees.
-#[derive(Debug)]
-enum Slice {
-    /// True `'static` references.
-    Static(&'static BStr),
-    /// `'static` references created by [`Box::leak`].
-    ///
-    /// These references can be deallocated by coercing the reference to a
-    /// pointer and reconstituting the `Box` with [`Box::from_raw`] on drop.
-    Leaked(&'static BStr),
-}
-
-impl Slice {
-    /// Return a reference to the inner `'static` byteslice.
-    fn as_slice(&self) -> &'static [u8] {
-        match self {
-            Self::Static(global) => global,
-            Self::Leaked(leaked) => leaked,
-        }
-    }
-}
-
-impl Default for Slice {
-    fn default() -> Self {
-        Self::Static(<_>::default())
-    }
-}
-
-impl Drop for Slice {
-    fn drop(&mut self) {
-        // If the slice was created via `Box::leak`, turn it back into a boxed
-        // slice and drop it to free the underlying bytes.
-        //
-        // Safety:
-        //
-        // Do not `mem::take(self)` to move out the leaked slice. This causes a
-        // double free reported by miri.
-        //
-        // Instead, replace the contents of the `Leaked` variant with a truly
-        // &'static [u8] that can be safely dropped when it goes out of scope.
-        if let Slice::Leaked(mut slice) = self {
-            // Move the leaked &'static mut [u8] out of the leaked variant and
-            // replace with a truly static empty "".
-            let slice = mem::take(&mut slice).as_ref();
-            // Safety:
-            //
-            // `slice` contained in `Slice::Leaked(_)` was created by
-            // `Box::leak` which returns `&'static mut [u8]` which is uniquely
-            // owned by this enum.
-            //
-            // Copies of this reference are handed out by `SymbolTable::get`,
-            // but they have lifetime bound to the `SymbolTable`. This drop can
-            // only occur while the `SymbolTable` is being dropped which
-            // requires unique access and thus no outstanding borrows of this
-            // reference.
-            let boxed = unsafe { Box::from_raw(slice as *const [u8] as *mut [u8]) };
-            drop(boxed);
-        }
-    }
-}
-
-impl Deref for Slice {
-    type Target = [u8];
-
-    fn deref(&self) -> &Self::Target {
-        self.as_slice()
-    }
-}
-
-impl PartialEq<Slice> for Slice {
-    fn eq(&self, other: &Self) -> bool {
-        self.as_slice() == other.as_slice()
-    }
-}
-
-impl PartialEq<[u8]> for Slice {
-    fn eq(&self, other: &[u8]) -> bool {
-        self.as_slice() == other
-    }
-}
-
-impl PartialEq<Slice> for [u8] {
-    fn eq(&self, other: &Slice) -> bool {
-        self == other.as_slice()
-    }
-}
-
-impl PartialEq<Vec<u8>> for Slice {
-    fn eq(&self, other: &Vec<u8>) -> bool {
-        self.as_slice() == other.as_slice()
-    }
-}
-
-impl PartialEq<Slice> for Vec<u8> {
-    fn eq(&self, other: &Slice) -> bool {
-        self.as_slice() == other.as_slice()
-    }
-}
-
-impl Eq for Slice {}
-
-impl Hash for Slice {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.as_slice().hash(state);
-    }
-}
-
-impl Borrow<[u8]> for Slice {
-    fn borrow(&self) -> &[u8] {
-        self.as_slice()
-    }
-}
-
-impl Borrow<[u8]> for &Slice {
-    fn borrow(&self) -> &[u8] {
-        self.as_slice()
-    }
-}
-
-impl Borrow<[u8]> for &mut Slice {
-    fn borrow(&self) -> &[u8] {
-        self.as_slice()
-    }
-}
-
-/// An iterator over all [`SymbolId`]s in a [`SymbolTable`].
-///
-/// # Usage
-///
-/// ```
-/// # use intaglio::SymbolTable;
-/// # fn example() -> Result<(), Box<dyn std::error::Error>> {
-/// let mut table = SymbolTable::new();
-/// let sym_id = table.intern(&b"abc"[..])?;
-/// let all_symbols = table.all_symbols();
-/// assert_eq!(vec![sym_id], all_symbols.collect::<Vec<_>>());
-/// # Ok(())
-/// # }
-/// ```
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
-pub struct AllSymbols<'a> {
-    // this Result is being used as an Either type.
-    range: Result<Range<u32>, RangeInclusive<u32>>,
-    // Hold a shared reference to the underlying `SymbolTable` to ensure the
-    // table is not modified while we are iterating which would make the results
-    // not match the real state.
-    phantom: PhantomData<&'a SymbolTable>,
-}
-
-impl<'a> Iterator for AllSymbols<'a> {
-    type Item = SymbolId;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        match self.range {
-            Ok(ref mut range) => range.next().map(SymbolId::from),
-            Err(ref mut range) => range.next().map(SymbolId::from),
-        }
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        match self.range {
-            Ok(ref range) => range.size_hint(),
-            Err(ref range) => range.size_hint(),
-        }
-    }
-
-    fn count(self) -> usize
-    where
-        Self: Sized,
-    {
-        match self.range {
-            Ok(range) => range.count(),
-            Err(range) => range.count(),
-        }
-    }
-
-    fn last(self) -> Option<Self::Item>
-    where
-        Self: Sized,
-    {
-        match self.range {
-            Ok(range) => range.last().map(SymbolId::from),
-            Err(range) => range.last().map(SymbolId::from),
-        }
-    }
-
-    fn nth(&mut self, n: usize) -> Option<Self::Item> {
-        match self.range {
-            Ok(ref mut range) => range.nth(n).map(SymbolId::from),
-            Err(ref mut range) => range.nth(n).map(SymbolId::from),
-        }
-    }
-
-    fn collect<B: iter::FromIterator<Self::Item>>(self) -> B
-    where
-        Self: Sized,
-    {
-        match self.range {
-            Ok(range) => range.map(SymbolId::from).collect(),
-            Err(range) => range.map(SymbolId::from).collect(),
-        }
-    }
-}
-
-impl<'a> DoubleEndedIterator for AllSymbols<'a> {
-    fn next_back(&mut self) -> Option<Self::Item> {
-        match self.range {
-            Ok(ref mut range) => range.next_back().map(SymbolId::from),
-            Err(ref mut range) => range.next_back().map(SymbolId::from),
-        }
-    }
-
-    fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
-        match self.range {
-            Ok(ref mut range) => range.nth_back(n).map(SymbolId::from),
-            Err(ref mut range) => range.nth_back(n).map(SymbolId::from),
-        }
-    }
-}
-
-impl<'a> FusedIterator for AllSymbols<'a> {}
-
-/// An iterator over all interned bytestrings in a [`SymbolTable`].
-///
-/// # Usage
-///
-/// ```
-/// # use intaglio::SymbolTable;
-/// # fn example() -> Result<(), Box<dyn std::error::Error>> {
-/// let mut table = SymbolTable::new();
-/// let sym_id = table.intern(b"abc".to_vec())?;
-/// let bytestrings = table.bytestrings();
-/// assert_eq!(vec![&b"abc"[..]], bytestrings.collect::<Vec<_>>());
-/// # Ok(())
-/// # }
-/// ```
-#[derive(Debug, Clone)]
-pub struct Bytestrings<'a>(slice::Iter<'a, Slice>);
-
-impl<'a> Iterator for Bytestrings<'a> {
-    type Item = &'a [u8];
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.0.next().map(Deref::deref)
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        self.0.size_hint()
-    }
-
-    fn count(self) -> usize
-    where
-        Self: Sized,
-    {
-        self.0.count()
-    }
-
-    fn last(self) -> Option<Self::Item>
-    where
-        Self: Sized,
-    {
-        self.0.last().map(Deref::deref)
-    }
-
-    fn nth(&mut self, n: usize) -> Option<Self::Item> {
-        self.0.nth(n).map(Deref::deref)
-    }
-
-    fn collect<B: iter::FromIterator<Self::Item>>(self) -> B
-    where
-        Self: Sized,
-    {
-        self.0.map(Deref::deref).collect()
-    }
-}
-
-impl<'a> DoubleEndedIterator for Bytestrings<'a> {
-    fn next_back(&mut self) -> Option<Self::Item> {
-        self.0.next_back().map(Deref::deref)
-    }
-
-    fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
-        self.0.nth_back(n).map(Deref::deref)
-    }
-
-    fn rfold<B, F>(self, accum: B, f: F) -> B
-    where
-        Self: Sized,
-        F: FnMut(B, Self::Item) -> B,
-    {
-        self.0.map(Deref::deref).rfold(accum, f)
-    }
-}
-
-impl<'a> ExactSizeIterator for Bytestrings<'a> {
-    fn len(&self) -> usize {
-        self.0.len()
-    }
-}
-
-impl<'a> FusedIterator for Bytestrings<'a> {}
-
-/// An iterator over all symbols and interned bytestrings in a [`SymbolTable`].
-///
-/// # Usage
-///
-/// ```
-/// # use std::collections::HashMap;
-/// # use intaglio::{SymbolId, SymbolTable};
-/// # fn example() -> Result<(), Box<dyn std::error::Error>> {
-/// let mut table = SymbolTable::new();
-/// let sym_id = table.intern(b"abc".to_vec())?;
-/// let iter = table.iter();
-/// let mut map = HashMap::new();
-/// map.insert(SymbolId::new(0), &b"abc"[..]);
-/// assert_eq!(map, iter.collect::<HashMap<_, _>>());
-/// # Ok(())
-/// # }
-/// ```
-#[derive(Debug, Clone)]
-pub struct Iter<'a>(iter::Zip<AllSymbols<'a>, Bytestrings<'a>>);
-
-impl<'a> Iterator for Iter<'a> {
-    type Item = (SymbolId, &'a [u8]);
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.0.next()
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        self.0.size_hint()
-    }
-
-    fn count(self) -> usize
-    where
-        Self: Sized,
-    {
-        self.0.count()
-    }
-
-    fn last(self) -> Option<Self::Item>
-    where
-        Self: Sized,
-    {
-        self.0.last()
-    }
-
-    fn nth(&mut self, n: usize) -> Option<Self::Item> {
-        self.0.nth(n)
-    }
-
-    fn collect<B: iter::FromIterator<Self::Item>>(self) -> B
-    where
-        Self: Sized,
-    {
-        self.0.collect()
-    }
-}
-
-impl<'a> FusedIterator for Iter<'a> {}
-
-impl<'a> IntoIterator for &'a SymbolTable {
-    type Item = (SymbolId, &'a [u8]);
-    type IntoIter = Iter<'a>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.iter()
-    }
-}
-
-/// Byte string interner.
-///
-/// This symbol table is implemented by leaking bytestrings with a fast path for
-/// `&[u8]` that are already `'static`.
-///
-/// # Usage
-///
-/// ```
-/// # use intaglio::SymbolTable;
-/// # fn example() -> Result<(), Box<dyn std::error::Error>> {
-/// let mut table = SymbolTable::new();
-/// let sym_id = table.intern(&b"abc"[..])?;
-/// assert_eq!(sym_id, table.intern(b"abc".to_vec())?);
-/// assert!(table.contains(sym_id));
-/// assert!(table.is_interned(b"abc"));
-/// # Ok(())
-/// # }
-/// ```
-#[derive(Default, Debug)]
-pub struct SymbolTable<S = RandomState> {
-    map: HashMap<&'static BStr, SymbolId, S>,
-    vec: Vec<Slice>,
-}
-
-impl SymbolTable<RandomState> {
-    /// Constructs a new, empty `SymbolTable` with
-    /// [default capacity](DEFAULT_SYMBOL_TABLE_CAPACITY).
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use intaglio::SymbolTable;
-    /// let table = SymbolTable::new();
-    /// assert_eq!(0, table.len());
-    /// assert!(table.capacity() >= 4096);
-    /// ```
-    #[must_use]
-    pub fn new() -> Self {
-        Self::with_capacity(DEFAULT_SYMBOL_TABLE_CAPACITY)
-    }
-
-    /// Constructs a new, empty `SymbolTable` with the specified capacity.
-    ///
-    /// The symbol table will be able to hold at least `capacity` bytestrings
-    /// without reallocating. If `capacity` is 0, the symbol table will not
-    /// allocate.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use intaglio::SymbolTable;
-    /// let table = SymbolTable::with_capacity(10);
-    /// assert_eq!(0, table.len());
-    /// assert!(table.capacity() >= 10);
-    /// ```
-    #[must_use]
-    pub fn with_capacity(capacity: usize) -> Self {
-        let capacity = capacity.next_power_of_two();
-        Self {
-            map: HashMap::with_capacity(capacity),
-            vec: Vec::with_capacity(capacity),
-        }
-    }
-}
-
-impl<S> SymbolTable<S> {
-    /// Constructs a new, empty `SymbolTable` with
-    /// [default capacity](DEFAULT_SYMBOL_TABLE_CAPACITY) and the given hash
-    /// builder.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use std::collections::hash_map::RandomState;
-    /// # use intaglio::SymbolTable;
-    /// let hash_builder = RandomState::new();
-    /// let table = SymbolTable::with_hasher(hash_builder);
-    /// assert_eq!(0, table.len());
-    /// assert!(table.capacity() >= 4096);
-    /// ```
-    pub fn with_hasher(hash_builder: S) -> Self {
-        Self::with_capacity_and_hasher(DEFAULT_SYMBOL_TABLE_CAPACITY, hash_builder)
-    }
-
-    /// Constructs a new, empty `SymbolTable` with the specified capacity and
-    /// the given hash builder.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use std::collections::hash_map::RandomState;
-    /// # use intaglio::SymbolTable;
-    /// let hash_builder = RandomState::new();
-    /// let table = SymbolTable::with_capacity_and_hasher(10, hash_builder);
-    /// assert_eq!(0, table.len());
-    /// assert!(table.capacity() >= 10);
-    /// ```
-    pub fn with_capacity_and_hasher(capacity: usize, hash_builder: S) -> Self {
-        Self {
-            vec: Vec::with_capacity(capacity),
-            map: HashMap::with_capacity_and_hasher(capacity, hash_builder),
-        }
-    }
-
-    /// Returns the number of bytestrings the table can hold without
-    /// reallocating.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use intaglio::SymbolTable;
-    /// let table = SymbolTable::with_capacity(10);
-    /// assert!(table.capacity() >= 10);
-    /// ```
-    pub fn capacity(&self) -> usize {
-        cmp::min(self.vec.capacity(), self.map.capacity())
-    }
-
-    /// Returns the number of interned bytestrings in the table.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use intaglio::SymbolTable;
-    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut table = SymbolTable::new();
-    /// assert_eq!(0, table.len());
-    ///
-    /// table.intern(b"abc".to_vec())?;
-    /// // only uniquely interned bytestrings grow the symbol table.
-    /// table.intern(b"abc".to_vec())?;
-    /// table.intern(b"xyz".to_vec())?;
-    /// assert_eq!(2, table.len());
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub fn len(&self) -> usize {
-        self.vec.len()
-    }
-
-    /// Returns `true` if the symbol table contains no interned bytestrings.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use intaglio::SymbolTable;
-    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut table = SymbolTable::new();
-    /// assert!(table.is_empty());
-    ///
-    /// table.intern(b"abc".to_vec())?;
-    /// assert!(!table.is_empty());
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub fn is_empty(&self) -> bool {
-        self.vec.is_empty()
-    }
-
-    /// Returns `true` if the symbol table contains the given symbol.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use intaglio::{SymbolId, SymbolTable};
-    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut table = SymbolTable::new();
-    /// assert!(!table.contains(SymbolId::new(0)));
-    ///
-    /// let sym = table.intern(b"abc".to_vec())?;
-    /// assert!(table.contains(SymbolId::new(0)));
-    /// assert!(table.contains(sym));
-    /// # Ok(())
-    /// # }
-    /// ```
-    #[must_use]
-    pub fn contains(&self, id: SymbolId) -> bool {
-        self.get(id).is_some()
-    }
-
-    /// Returns a reference to the byte string associated with the given symbol.
-    ///
-    /// If the given symbol does not exist in the underlying symbol table,
-    /// `None` is returned.
-    ///
-    /// The lifetime of the returned reference is bound to the symbol table.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use intaglio::{SymbolId, SymbolTable};
-    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut table = SymbolTable::new();
-    /// assert!(!table.get(SymbolId::new(0)).is_none());
-    ///
-    /// let sym = table.intern(b"abc".to_vec())?;
-    /// assert_eq!(Some(&b"abc"[..]), table.get(SymbolId::new(0)));
-    /// assert_eq!(Some(&b"abc"[..]), table.get(sym));
-    /// # Ok(())
-    /// # }
-    /// ```
-    #[must_use]
-    pub fn get(&self, id: SymbolId) -> Option<&[u8]> {
-        let bytes = self.vec.get(usize::from(id))?;
-        Some(bytes.as_slice())
-    }
-
-    /// Returns an iterator over all [`SymbolId`]s and bytestrings in the
-    /// [`SymbolTable`].
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use std::collections::HashMap;
-    /// # use intaglio::{SymbolId, SymbolTable};
-    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut table = SymbolTable::new();
-    /// table.intern(b"abc".to_vec())?;
-    /// table.intern(b"xyz".to_vec())?;
-    /// table.intern(b"123".to_vec())?;
-    /// table.intern(b"789".to_vec())?;
-    ///
-    /// let iter = table.iter();
-    /// let mut map = HashMap::new();
-    /// map.insert(SymbolId::new(0), &b"abc"[..]);
-    /// map.insert(SymbolId::new(1), &b"xyz"[..]);
-    /// map.insert(SymbolId::new(2), &b"123"[..]);
-    /// map.insert(SymbolId::new(3), &b"789"[..]);
-    /// assert_eq!(map, iter.collect::<HashMap<_, _>>());
-    /// # Ok(())
-    /// # }
-    /// ```
-    ///
-    /// ```
-    /// # use intaglio::SymbolTable;
-    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut table = SymbolTable::new();
-    /// table.intern(b"abc".to_vec())?;
-    /// table.intern(b"xyz".to_vec())?;
-    /// table.intern(b"123".to_vec())?;
-    /// table.intern(b"789".to_vec())?;
-    ///
-    /// let iter = table.iter();
-    /// assert_eq!(table.len(), iter.count());
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub fn iter(&self) -> Iter<'_> {
-        Iter(self.all_symbols().zip(self.bytestrings()))
-    }
-
-    /// Returns an iterator over all [`SymbolId`]s in the [`SymbolTable`].
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use intaglio::{SymbolId, SymbolTable};
-    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut table = SymbolTable::new();
-    /// table.intern(b"abc".to_vec())?;
-    /// table.intern(b"xyz".to_vec())?;
-    /// table.intern(b"123".to_vec())?;
-    /// table.intern(b"789".to_vec())?;
-    ///
-    /// let mut all_symbols = table.all_symbols();
-    /// assert_eq!(Some(SymbolId::new(0)), all_symbols.next());
-    /// assert_eq!(Some(SymbolId::new(1)), all_symbols.nth_back(2));
-    /// assert_eq!(None, all_symbols.next());
-    /// # Ok(())
-    /// # }
-    /// ```
-    ///
-    /// ```
-    /// # use intaglio::SymbolTable;
-    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut table = SymbolTable::new();
-    /// table.intern(b"abc".to_vec())?;
-    /// table.intern(b"xyz".to_vec())?;
-    /// table.intern(b"123".to_vec())?;
-    /// table.intern(b"789".to_vec())?;
-    ///
-    /// let all_symbols = table.all_symbols();
-    /// assert_eq!(table.len(), all_symbols.count());
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub fn all_symbols(&self) -> AllSymbols<'_> {
-        if self.len() == u32::MAX as usize {
-            AllSymbols {
-                range: Err(0..=u32::MAX),
-                phantom: PhantomData,
-            }
-        } else {
-            let upper_bound = self.len() as u32;
-            AllSymbols {
-                range: Ok(0..upper_bound),
-                phantom: PhantomData,
-            }
-        }
-    }
-
-    /// Returns an iterator over all bytestrings in the [`SymbolTable`].
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use intaglio::SymbolTable;
-    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut table = SymbolTable::new();
-    /// table.intern(b"abc".to_vec())?;
-    /// table.intern(b"xyz".to_vec())?;
-    /// table.intern(b"123".to_vec())?;
-    /// table.intern(b"789".to_vec())?;
-    ///
-    /// let mut bytestrings = table.bytestrings();
-    /// assert_eq!(Some(&b"abc"[..]), bytestrings.next());
-    /// assert_eq!(Some(&b"xyz"[..]), bytestrings.nth_back(2));
-    /// assert_eq!(None, bytestrings.next());
-    /// # Ok(())
-    /// # }
-    /// ```
-    ///
-    /// ```
-    /// # use intaglio::SymbolTable;
-    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut table = SymbolTable::new();
-    /// table.intern(b"abc".to_vec())?;
-    /// table.intern(b"xyz".to_vec())?;
-    /// table.intern(b"123".to_vec())?;
-    /// table.intern(b"789".to_vec())?;
-    ///
-    /// let  bytestrings = table.bytestrings();
-    /// assert_eq!(table.len(), bytestrings.count());
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub fn bytestrings(&self) -> Bytestrings<'_> {
-        Bytestrings(self.vec.iter())
-    }
-
-    /// Transform owned bytes into a leaked boxed slice and return the resulting
-    /// `'static` reference which is suitable for storing in the list of
-    /// symbols.
-    ///
-    /// The reference is wrapped in a `Slice::Leaked` which will convert the
-    /// reference back into a `Box` to be deallocated on `drop`.
-    ///
-    /// # Safety
-    ///
-    /// This function is not marked unsafe because the only side effect is
-    /// leaking memory. Memory leaks are not unsafe.
-    #[must_use]
-    fn alloc(contents: Vec<u8>) -> Slice {
-        let boxed_slice = contents.into_boxed_slice();
-        let slice = Box::leak(boxed_slice);
-        Slice::Leaked(slice.as_bstr())
-    }
-}
-
-impl<S> SymbolTable<S>
-where
-    S: BuildHasher,
-{
-    /// Intern a bytestring for the lifetime of the symbol table.
-    ///
-    /// The returned `SymbolId` allows retrieving of the underlying bytes.
-    /// Equal bytestrings will be inserted into the symbol table exactly once.
-    ///
-    /// # Errors
-    ///
-    /// If the symbol table would grow larger than `u32::MAX` interned
-    /// bytestrings, the [`SymbolId`] counter would overflow and a
-    /// [`SymbolIdOverflowError`] is returned.
-    pub fn intern<T>(&mut self, contents: T) -> Result<SymbolId, SymbolIdOverflowError>
-    where
-        T: Into<Cow<'static, [u8]>>,
-    {
-        let contents = contents.into();
-        if let Some(&id) = self.map.get(contents.as_ref().as_bstr()) {
-            return Ok(id);
-        }
-        let name = match contents {
-            Cow::Borrowed(contents) => Slice::Static(contents.as_bstr()),
-            Cow::Owned(contents) => Self::alloc(contents),
-        };
-        let id = self.map.len().try_into()?;
-        let slice = name.as_slice();
-
-        self.map.insert(slice.as_bstr(), id);
-        self.vec.push(name);
-
-        debug_assert!(self.get(id) == Some(slice));
-        debug_assert!(self.intern(slice) == Ok(id));
-
-        Ok(id)
-    }
-
-    /// Returns `true` if the given byte string has been interned before.
-    ///
-    /// This method does not modify the symbol table.
-    ///
-    /// ```
-    /// # use intaglio::SymbolTable;
-    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut table = SymbolTable::new();
-    /// assert!(!table.is_interned(b"abc"));
-    ///
-    /// table.intern(b"abc".to_vec())?;
-    /// assert!(table.is_interned(b"abc"));
-    /// # Ok(())
-    /// # }
-    /// ```
-    #[must_use]
-    pub fn is_interned(&self, contents: &[u8]) -> bool {
-        self.map.contains_key(contents.as_bstr())
-    }
-
-    /// Reserves capacity for at least additional more elements to be inserted
-    /// in the given `SymbolTable`. The collection may reserve more space to
-    /// avoid frequent reallocations. After calling reserve, capacity will be
-    /// greater than or equal to `self.len() + additional`. Does nothing if
-    /// capacity is already sufficient.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the new capacity overflows `usize`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use intaglio::SymbolTable;
-    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut table = SymbolTable::with_capacity(1);
-    /// table.intern(b"abc".to_vec())?;
-    /// table.reserve(10);
-    /// assert!(table.capacity() >= 11);
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub fn reserve(&mut self, additional: usize) {
-        self.vec.reserve(additional);
-        self.map.reserve(additional);
-    }
-
-    /// Shrinks the capacity of the symbol table as much as possible.
-    ///
-    /// It will drop down as close as possible to the length but the allocator
-    /// may still inform the symbol table that there is space for a few more
-    /// elements.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use intaglio::SymbolTable;
-    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut table = SymbolTable::with_capacity(10);
-    /// table.intern(b"abc".to_vec());
-    /// table.intern(b"xyz".to_vec());
-    /// table.intern(b"123".to_vec());
-    /// table.shrink_to_fit();
-    /// assert!(table.capacity() >= 3);
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub fn shrink_to_fit(&mut self) {
-        self.vec.shrink_to_fit();
-        self.map.shrink_to_fit();
-    }
-}
-
-#[cfg(test)]
-#[allow(clippy::needless_pass_by_value)]
-mod tests {
-    use quickcheck_macros::quickcheck;
-
-    use crate::SymbolTable;
-
-    #[test]
-    fn alloc_drop_new() {
-        let table = SymbolTable::new();
-        drop(table);
-    }
-
-    #[test]
-    fn alloc_drop_with_capacity() {
-        let table = SymbolTable::with_capacity(1 << 14);
-        drop(table);
-    }
-
-    #[test]
-    fn drop_with_true_static_data() {
-        let mut table = SymbolTable::new();
-        table.intern(&b"1"[..]).unwrap();
-        table.intern(&b"2"[..]).unwrap();
-        table.intern(&b"3"[..]).unwrap();
-        table.intern(&b"4"[..]).unwrap();
-        table.intern(&b"5"[..]).unwrap();
-        drop(table);
-    }
-
-    #[test]
-    fn drop_with_owned_data() {
-        let mut table = SymbolTable::new();
-        table.intern(b"1".to_vec()).unwrap();
-        table.intern(b"2".to_vec()).unwrap();
-        table.intern(b"3".to_vec()).unwrap();
-        table.intern(b"4".to_vec()).unwrap();
-        table.intern(b"5".to_vec()).unwrap();
-        drop(table);
-    }
-
-    #[test]
-    fn set_owned_value_and_get_with_owned_and_borrowed() {
-        let mut table = SymbolTable::new();
-        // intern an owned value
-        let sym = table.intern(b"abc".to_vec()).unwrap();
-        // retrieve bytes
-        assert_eq!(&b"abc"[..], table.get(sym).unwrap());
-        // intern owned value again
-        assert_eq!(sym, table.intern(b"abc".to_vec()).unwrap());
-        // intern borrowed value
-        assert_eq!(sym, table.intern(&b"abc"[..]).unwrap());
-    }
-
-    #[test]
-    fn set_borrowed_value_and_get_with_owned_and_borrowed() {
-        let mut table = SymbolTable::new();
-        // intern a borrowed value
-        let sym = table.intern(&b"abc"[..]).unwrap();
-        // retrieve bytes
-        assert_eq!(&b"abc"[..], table.get(sym).unwrap());
-        // intern owned value
-        assert_eq!(sym, table.intern(b"abc".to_vec()).unwrap());
-        // intern borrowed value again
-        assert_eq!(sym, table.intern(&b"abc"[..]).unwrap());
-    }
-
-    #[quickcheck]
-    fn intern_twice_symbol_equality(bytes: Vec<u8>) -> bool {
-        let mut table = SymbolTable::new();
-        let sym_id = table.intern(bytes.clone()).unwrap();
-        let sym_again_id = table.intern(bytes).unwrap();
-        sym_id == sym_again_id
-    }
-
-    #[quickcheck]
-    fn intern_get_roundtrip(bytes: Vec<u8>) -> bool {
-        let mut table = SymbolTable::new();
-        let sym_id = table.intern(bytes.clone()).unwrap();
-        let retrieved_bytes = table.get(sym_id).unwrap();
-        bytes == retrieved_bytes
-    }
-
-    #[quickcheck]
-    fn table_contains_sym(bytes: Vec<u8>) -> bool {
-        let mut table = SymbolTable::new();
-        let sym_id = table.intern(bytes).unwrap();
-        table.contains(sym_id)
-    }
-
-    #[quickcheck]
-    fn table_does_not_contain_missing_symbol_ids(sym_id: u32) -> bool {
-        let table = SymbolTable::new();
-        !table.contains(sym_id.into())
-    }
-
-    #[quickcheck]
-    fn empty_table_does_not_report_any_interned_bytestrings(bytes: Vec<u8>) -> bool {
-        let table = SymbolTable::new();
-        !table.is_interned(bytes.as_slice())
-    }
-
-    #[quickcheck]
-    fn table_reports_interned_bytestrings_as_interned(bytes: Vec<u8>) -> bool {
-        let mut table = SymbolTable::new();
-        table.intern(bytes.clone()).unwrap();
-        table.is_interned(bytes.as_slice())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,7 +116,7 @@ impl From<TryFromIntError> for SymbolOverflowError {
 
 impl fmt::Display for SymbolOverflowError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Symbol ID overflow")
+        write!(f, "Symbol overflow")
     }
 }
 

--- a/src/str.rs
+++ b/src/str.rs
@@ -178,9 +178,9 @@ impl Borrow<[u8]> for &mut Slice {
 /// # use intaglio::SymbolTable;
 /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let mut table = SymbolTable::new();
-/// let sym_id = table.intern("abc")?;
+/// let sym = table.intern("abc")?;
 /// let all_symbols = table.all_symbols();
-/// assert_eq!(vec![sym_id], all_symbols.collect::<Vec<_>>());
+/// assert_eq!(vec![sym], all_symbols.collect::<Vec<_>>());
 /// # Ok(())
 /// # }
 /// ```
@@ -275,7 +275,7 @@ impl<'a> FusedIterator for AllSymbols<'a> {}
 /// # use intaglio::SymbolTable;
 /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let mut table = SymbolTable::new();
-/// let sym_id = table.intern("abc")?;
+/// let sym = table.intern("abc")?;
 /// let strings = table.strings();
 /// assert_eq!(vec!["abc"], strings.collect::<Vec<_>>());
 /// # Ok(())
@@ -356,7 +356,7 @@ impl<'a> FusedIterator for Strings<'a> {}
 /// # use intaglio::{Symbol, SymbolTable};
 /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let mut table = SymbolTable::new();
-/// let sym_id = table.intern("abc")?;
+/// let sym = table.intern("abc")?;
 /// let iter = table.iter();
 /// let mut map = HashMap::new();
 /// map.insert(Symbol::new(0), "abc");
@@ -426,9 +426,9 @@ impl<'a> IntoIterator for &'a SymbolTable {
 /// # use intaglio::SymbolTable;
 /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let mut table = SymbolTable::new();
-/// let sym_id = table.intern("abc")?;
-/// assert_eq!(sym_id, table.intern("abc".to_string())?);
-/// assert!(table.contains(sym_id));
+/// let sym = table.intern("abc")?;
+/// assert_eq!(sym, table.intern("abc".to_string())?);
+/// assert!(table.contains(sym));
 /// assert!(table.is_interned("abc"));
 /// # Ok(())
 /// # }
@@ -955,30 +955,30 @@ mod tests {
     #[quickcheck]
     fn intern_twice_symbol_equality(string: String) -> bool {
         let mut table = SymbolTable::new();
-        let sym_id = table.intern(string.clone()).unwrap();
-        let sym_again_id = table.intern(string).unwrap();
-        sym_id == sym_again_id
+        let sym = table.intern(string.clone()).unwrap();
+        let sym_again = table.intern(string).unwrap();
+        sym == sym_again
     }
 
     #[quickcheck]
     fn intern_get_roundtrip(string: String) -> bool {
         let mut table = SymbolTable::new();
-        let sym_id = table.intern(string.clone()).unwrap();
-        let retrieved_bytes = table.get(sym_id).unwrap();
+        let sym = table.intern(string.clone()).unwrap();
+        let retrieved_bytes = table.get(sym).unwrap();
         string == retrieved_bytes
     }
 
     #[quickcheck]
     fn table_contains_sym(string: String) -> bool {
         let mut table = SymbolTable::new();
-        let sym_id = table.intern(string).unwrap();
-        table.contains(sym_id)
+        let sym = table.intern(string).unwrap();
+        table.contains(sym)
     }
 
     #[quickcheck]
-    fn table_does_not_contain_missing_symbol_ids(sym_id: u32) -> bool {
+    fn table_does_not_contain_missing_symbol_ids(sym: u32) -> bool {
         let table = SymbolTable::new();
-        !table.contains(sym_id.into())
+        !table.contains(sym.into())
     }
 
     #[quickcheck]

--- a/tests/leak_drop_symbol_table_bytes.rs
+++ b/tests/leak_drop_symbol_table_bytes.rs
@@ -1,7 +1,8 @@
 #![deny(clippy::all)]
 #![deny(clippy::pedantic)]
+#![cfg(feature = "bytes")]
 
-use intaglio::SymbolTable;
+use intaglio::bytes::SymbolTable;
 
 mod leak;
 
@@ -11,25 +12,25 @@ const ITERATIONS: usize = 100_000;
 const LEAK_TOLERANCE: i64 = 1024 * 1024 * 50;
 
 #[test]
-fn dealloc_owned_data_str() {
+fn dealloc_owned_data_bytes() {
     let table = SymbolTable::with_capacity(0);
-    Looper::new("dealloc_owned_data_str", table)
+    Looper::new("dealloc_owned_data_bytes", table)
         .with_iterations(ITERATIONS)
         .with_tolerance(LEAK_TOLERANCE)
         .check_leaks_with_finalizer(
             |i, table| {
                 #[allow(clippy::cast_possible_truncation)]
-                let ch = char::from((i % 256) as u8);
+                let byte = (i % 256) as u8;
                 let len = (i / 256) + 100;
-                let symbol = vec![ch; len].into_iter().collect::<String>();
+                let symbol = vec![byte; len];
                 let sym_id = table.intern(symbol.clone()).unwrap();
                 assert!(table.is_interned(&symbol));
                 assert!(table.contains(sym_id));
-                assert_eq!(Some(symbol.as_str()), table.get(sym_id));
+                assert_eq!(Some(symbol.as_slice()), table.get(sym_id));
                 assert_eq!(sym_id, table.intern(symbol.clone()).unwrap());
                 assert!(table.is_interned(&symbol));
                 assert!(table.contains(sym_id));
-                assert_eq!(Some(symbol.as_str()), table.get(sym_id));
+                assert_eq!(Some(symbol.as_slice()), table.get(sym_id));
             },
             drop,
         );


### PR DESCRIPTION
Intaglio's only external dependencies are used by the bytestring
interner, so invert the crate organization to make the default exported
interner the UTF-8 string interner. This makes it easier to hide `bytes`
in a module that can be disabled.

This commit includes many other changes to prep for release:

- Fixup Cargo.toml description metadata to mention both UTF-8 and
  bytestring support.
- Fixup Cargo.toml repository metadata to point at the correct
  repository since this was broken out of artichoke/artichoke.
- Add `utf8` Cargo.toml keyword.

Add an optional `bytes` feature that is enabled by default. Enabling
this feature includes a `SymbolTable` that interns binary data.
Disabling this feature drops the `bstr` dependency.

Add documentation in `Cargo.toml` on the crate features with inline
comments.

Rework README to shift emphasis to UTF-8 string interner. Document
`bytes` crate feature in README.

Fixup benches to run when passed `--no-default-features`.

Fixup doctests to run when passed `--no-default-features`.

Rename `SymbolId` to `Symbol`. This undoes a hack to avoid name
collisions in Artichoke where `Symbol` refers to the core type and mruby
uses `sym_id` as the typedef for the identifiers boxed into the
`mrb_value`. This also caused a rename of `SymbolIdOverflowError` to
`SymbolOverflowError`.

Rework crate-level and module-level documentation to account for the
`bytes` module being optional. I used `regexp` and `regexp::bytes` as
inspiration here. This massively improves differentition between the
`str` and `bytes` interners.

Re-export crate-level types and constants, e.g. `Symbol`,
`SymbolOverflowError`, and `DEFAULT_SYMBOL_TABLE_CAPACITY` from `bytes`
module.

Restructure the crate-level docs to have this structure:

> this crate is a string interner.
> this api is like a bimap.
> refer to `SymbolTable` for more specific API documentation.
> example
> what is a string interner
> describe allocation behavior and knobs
> enumerate and describe cargo featutres