### PR TITLE
Bump crate version to 1.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "intaglio"
-version = "0.1.0"
+version = "1.0.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2018"
 description = "UTF-8 string and bytestring interner and symbol table"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-intaglio = "0.1"
+intaglio = "1.0"
 ```
 
 Then intern UTF-8 strings like:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@
 //!   interning bytestrings (`Vec<u8>` and `&'static [u8]`). Disabling this
 //!   drops the `bstr` dependency.
 
-#![doc(html_root_url = "https://docs.rs/intaglio/0.1.0")]
+#![doc(html_root_url = "https://docs.rs/intaglio/1.0.0")]
 
 #[cfg(all(doctest, feature = "bytes"))]
 doc_comment::doctest!("../README.md");


### PR DESCRIPTION
intaglio at this state has been used to successfully implement a symbol
table and the Symbol type in Artichoke Ruby. The API is sufficient for
this purpose and can be considered stable.