### PR TITLE
Publish cargo toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["caching", "data-structures"]
 include = [
   "src/**/*.rs",
   "benches/**/*.rs",
+  "tests/**/*.rs",
   "LICENSE",
   "README.md"
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["bytestring", "intern", "interner", "symbol", "utf8"]
 categories = ["caching", "data-structures"]
 include = [
   "src/**/*.rs",
+  "benches/**/*.rs",
   "LICENSE",
   "README.md"
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "intaglio"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2018"
 description = "UTF-8 string and bytestring interner and symbol table"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@
 //!   interning bytestrings (`Vec<u8>` and `&'static [u8]`). Disabling this
 //!   drops the `bstr` dependency.
 
-#![doc(html_root_url = "https://docs.rs/intaglio/1.0.0")]
+#![doc(html_root_url = "https://docs.rs/intaglio/1.0.1")]
 
 #[cfg(all(doctest, feature = "bytes"))]
 doc_comment::doctest!("../README.md");


### PR DESCRIPTION
Fix `Cargo.toml` metadata to make `cargo publish --dry-run` complete successfully.

Bump patch component to `v1.0.1`.