### PR TITLE
Replace doc_comment dev-dependency with a small inlined macro_rules macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,8 +43,6 @@ bstr = { version = "0.2", default-features = false, optional = true }
 [dev-dependencies]
 # Benchmarking support on stable Rust.
 criterion = "0.3"
-# Test that the examples in README.md compile.
-doc-comment = "0.3"
 # Property testing for interner getters and setters.
 quickcheck = { version = "0.9", default-features = false }
 quickcheck_macros = "0.9"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,8 +64,19 @@
 
 #![doc(html_root_url = "https://docs.rs/intaglio/1.0.1")]
 
+// Ensure code blocks in README.md compile
+#[cfg(doctest)]
+macro_rules! readme {
+    ($x:expr) => {
+        #[doc = $x]
+        mod readme {}
+    };
+    () => {
+        readme!(include_str!("../README.md"));
+    };
+}
 #[cfg(all(doctest, feature = "bytes"))]
-doc_comment::doctest!("../README.md");
+readme!();
 
 use core::convert::TryFrom;
 use core::fmt;


### PR DESCRIPTION
Remove a dev dep and avoid upgrading to doc-comment 0.4 based on proc-macros.