### PR TITLE
Improve crate rustdocs

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -11,6 +11,8 @@
 //!
 //! ```
 //! # use intaglio::bytes::SymbolTable;
+//! # fn main() { example().unwrap(); }
+//! #
 //! # fn example() -> Result<(), Box<dyn std::error::Error>> {
 //! let mut table = SymbolTable::new();
 //! let sym = table.intern(&b"abc"[..])?;
@@ -26,6 +28,8 @@
 //! # use std::collections::HashMap;
 //! # use intaglio::bytes::SymbolTable;
 //! # use intaglio::Symbol;
+//! # fn main() { example().unwrap(); }
+//! #
 //! # fn example() -> Result<(), Box<dyn std::error::Error>> {
 //! let mut table = SymbolTable::new();
 //! let sym = table.intern(&b"abc"[..])?;
@@ -33,6 +37,7 @@
 //! let all_symbols = table.all_symbols();
 //! assert_eq!(vec![sym], all_symbols.collect::<Vec<_>>());
 //!
+//! table.intern(&b"xyz"[..])?;
 //! let mut map = HashMap::new();
 //! map.insert(Symbol::new(0), &b"abc"[..]);
 //! map.insert(Symbol::new(1), &b"xyz"[..]);
@@ -203,6 +208,8 @@ impl Borrow<[u8]> for &mut Slice {
 ///
 /// ```
 /// # use intaglio::bytes::SymbolTable;
+/// # fn main() { example().unwrap(); }
+/// #
 /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let mut table = SymbolTable::new();
 /// let sym = table.intern(&b"abc"[..])?;
@@ -300,6 +307,8 @@ impl<'a> FusedIterator for AllSymbols<'a> {}
 ///
 /// ```
 /// # use intaglio::bytes::SymbolTable;
+/// # fn main() { example().unwrap(); }
+/// #
 /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let mut table = SymbolTable::new();
 /// let sym = table.intern(b"abc".to_vec())?;
@@ -382,6 +391,8 @@ impl<'a> FusedIterator for Bytestrings<'a> {}
 /// # use std::collections::HashMap;
 /// # use intaglio::bytes::SymbolTable;
 /// # use intaglio::Symbol;
+/// # fn main() { example().unwrap(); }
+/// #
 /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let mut table = SymbolTable::new();
 /// let sym = table.intern(b"abc".to_vec())?;
@@ -452,6 +463,8 @@ impl<'a> IntoIterator for &'a SymbolTable {
 ///
 /// ```
 /// # use intaglio::bytes::SymbolTable;
+/// # fn main() { example().unwrap(); }
+/// #
 /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let mut table = SymbolTable::new();
 /// let sym = table.intern(&b"abc"[..])?;
@@ -567,6 +580,8 @@ impl<S> SymbolTable<S> {
     ///
     /// ```
     /// # use intaglio::bytes::SymbolTable;
+    /// # fn main() { example().unwrap(); }
+    /// #
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// assert_eq!(0, table.len());
@@ -589,6 +604,8 @@ impl<S> SymbolTable<S> {
     ///
     /// ```
     /// # use intaglio::bytes::SymbolTable;
+    /// # fn main() { example().unwrap(); }
+    /// #
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// assert!(table.is_empty());
@@ -609,6 +626,8 @@ impl<S> SymbolTable<S> {
     /// ```
     /// # use intaglio::bytes::SymbolTable;
     /// # use intaglio::Symbol;
+    /// # fn main() { example().unwrap(); }
+    /// #
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// assert!(!table.contains(Symbol::new(0)));
@@ -636,9 +655,11 @@ impl<S> SymbolTable<S> {
     /// ```
     /// # use intaglio::bytes::SymbolTable;
     /// # use intaglio::Symbol;
+    /// # fn main() { example().unwrap(); }
+    /// #
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
-    /// assert!(!table.get(Symbol::new(0)).is_none());
+    /// assert!(table.get(Symbol::new(0)).is_none());
     ///
     /// let sym = table.intern(b"abc".to_vec())?;
     /// assert_eq!(Some(&b"abc"[..]), table.get(Symbol::new(0)));
@@ -661,6 +682,8 @@ impl<S> SymbolTable<S> {
     /// # use std::collections::HashMap;
     /// # use intaglio::bytes::SymbolTable;
     /// # use intaglio::Symbol;
+    /// # fn main() { example().unwrap(); }
+    /// #
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// table.intern(b"abc".to_vec())?;
@@ -681,6 +704,8 @@ impl<S> SymbolTable<S> {
     ///
     /// ```
     /// # use intaglio::bytes::SymbolTable;
+    /// # fn main() { example().unwrap(); }
+    /// #
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// table.intern(b"abc".to_vec())?;
@@ -704,6 +729,8 @@ impl<S> SymbolTable<S> {
     /// ```
     /// # use intaglio::bytes::SymbolTable;
     /// # use intaglio::Symbol;
+    /// # fn main() { example().unwrap(); }
+    /// #
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// table.intern(b"abc".to_vec())?;
@@ -721,6 +748,8 @@ impl<S> SymbolTable<S> {
     ///
     /// ```
     /// # use intaglio::bytes::SymbolTable;
+    /// # fn main() { example().unwrap(); }
+    /// #
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// table.intern(b"abc".to_vec())?;
@@ -754,6 +783,8 @@ impl<S> SymbolTable<S> {
     ///
     /// ```
     /// # use intaglio::bytes::SymbolTable;
+    /// # fn main() { example().unwrap(); }
+    /// #
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// table.intern(b"abc".to_vec())?;
@@ -771,6 +802,8 @@ impl<S> SymbolTable<S> {
     ///
     /// ```
     /// # use intaglio::bytes::SymbolTable;
+    /// # fn main() { example().unwrap(); }
+    /// #
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// table.intern(b"abc".to_vec())?;
@@ -854,6 +887,8 @@ where
     /// ```
     /// # use intaglio::bytes::SymbolTable;
     /// # use intaglio::Symbol;
+    /// # fn main() { example().unwrap(); }
+    /// #
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// assert!(!table.is_interned(b"abc"));
@@ -879,6 +914,8 @@ where
     /// ```
     /// # use intaglio::bytes::SymbolTable;
     /// # use intaglio::Symbol;
+    /// # fn main() { example().unwrap(); }
+    /// #
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// assert!(!table.is_interned(b"abc"));
@@ -909,6 +946,8 @@ where
     ///
     /// ```
     /// # use intaglio::bytes::SymbolTable;
+    /// # fn main() { example().unwrap(); }
+    /// #
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::with_capacity(1);
     /// table.intern(b"abc".to_vec())?;
@@ -932,6 +971,8 @@ where
     ///
     /// ```
     /// # use intaglio::bytes::SymbolTable;
+    /// # fn main() { example().unwrap(); }
+    /// #
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::with_capacity(10);
     /// table.intern(b"abc".to_vec());

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -12,7 +12,6 @@
 //! ```
 //! # use intaglio::bytes::SymbolTable;
 //! # fn main() { example().unwrap(); }
-//! #
 //! # fn example() -> Result<(), Box<dyn std::error::Error>> {
 //! let mut table = SymbolTable::new();
 //! let sym = table.intern(&b"abc"[..])?;
@@ -29,7 +28,6 @@
 //! # use intaglio::bytes::SymbolTable;
 //! # use intaglio::Symbol;
 //! # fn main() { example().unwrap(); }
-//! #
 //! # fn example() -> Result<(), Box<dyn std::error::Error>> {
 //! let mut table = SymbolTable::new();
 //! let sym = table.intern(&b"abc"[..])?;
@@ -209,7 +207,6 @@ impl Borrow<[u8]> for &mut Slice {
 /// ```
 /// # use intaglio::bytes::SymbolTable;
 /// # fn main() { example().unwrap(); }
-/// #
 /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let mut table = SymbolTable::new();
 /// let sym = table.intern(&b"abc"[..])?;
@@ -308,7 +305,6 @@ impl<'a> FusedIterator for AllSymbols<'a> {}
 /// ```
 /// # use intaglio::bytes::SymbolTable;
 /// # fn main() { example().unwrap(); }
-/// #
 /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let mut table = SymbolTable::new();
 /// let sym = table.intern(b"abc".to_vec())?;
@@ -392,7 +388,6 @@ impl<'a> FusedIterator for Bytestrings<'a> {}
 /// # use intaglio::bytes::SymbolTable;
 /// # use intaglio::Symbol;
 /// # fn main() { example().unwrap(); }
-/// #
 /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let mut table = SymbolTable::new();
 /// let sym = table.intern(b"abc".to_vec())?;
@@ -464,7 +459,6 @@ impl<'a> IntoIterator for &'a SymbolTable {
 /// ```
 /// # use intaglio::bytes::SymbolTable;
 /// # fn main() { example().unwrap(); }
-/// #
 /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let mut table = SymbolTable::new();
 /// let sym = table.intern(&b"abc"[..])?;
@@ -581,7 +575,6 @@ impl<S> SymbolTable<S> {
     /// ```
     /// # use intaglio::bytes::SymbolTable;
     /// # fn main() { example().unwrap(); }
-    /// #
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// assert_eq!(0, table.len());
@@ -605,7 +598,6 @@ impl<S> SymbolTable<S> {
     /// ```
     /// # use intaglio::bytes::SymbolTable;
     /// # fn main() { example().unwrap(); }
-    /// #
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// assert!(table.is_empty());
@@ -627,7 +619,6 @@ impl<S> SymbolTable<S> {
     /// # use intaglio::bytes::SymbolTable;
     /// # use intaglio::Symbol;
     /// # fn main() { example().unwrap(); }
-    /// #
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// assert!(!table.contains(Symbol::new(0)));
@@ -656,7 +647,6 @@ impl<S> SymbolTable<S> {
     /// # use intaglio::bytes::SymbolTable;
     /// # use intaglio::Symbol;
     /// # fn main() { example().unwrap(); }
-    /// #
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// assert!(table.get(Symbol::new(0)).is_none());
@@ -683,7 +673,6 @@ impl<S> SymbolTable<S> {
     /// # use intaglio::bytes::SymbolTable;
     /// # use intaglio::Symbol;
     /// # fn main() { example().unwrap(); }
-    /// #
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// table.intern(b"abc".to_vec())?;
@@ -705,7 +694,6 @@ impl<S> SymbolTable<S> {
     /// ```
     /// # use intaglio::bytes::SymbolTable;
     /// # fn main() { example().unwrap(); }
-    /// #
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// table.intern(b"abc".to_vec())?;
@@ -730,7 +718,6 @@ impl<S> SymbolTable<S> {
     /// # use intaglio::bytes::SymbolTable;
     /// # use intaglio::Symbol;
     /// # fn main() { example().unwrap(); }
-    /// #
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// table.intern(b"abc".to_vec())?;
@@ -749,7 +736,6 @@ impl<S> SymbolTable<S> {
     /// ```
     /// # use intaglio::bytes::SymbolTable;
     /// # fn main() { example().unwrap(); }
-    /// #
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// table.intern(b"abc".to_vec())?;
@@ -784,7 +770,6 @@ impl<S> SymbolTable<S> {
     /// ```
     /// # use intaglio::bytes::SymbolTable;
     /// # fn main() { example().unwrap(); }
-    /// #
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// table.intern(b"abc".to_vec())?;
@@ -803,7 +788,6 @@ impl<S> SymbolTable<S> {
     /// ```
     /// # use intaglio::bytes::SymbolTable;
     /// # fn main() { example().unwrap(); }
-    /// #
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// table.intern(b"abc".to_vec())?;
@@ -888,7 +872,6 @@ where
     /// # use intaglio::bytes::SymbolTable;
     /// # use intaglio::Symbol;
     /// # fn main() { example().unwrap(); }
-    /// #
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// assert!(!table.is_interned(b"abc"));
@@ -915,7 +898,6 @@ where
     /// # use intaglio::bytes::SymbolTable;
     /// # use intaglio::Symbol;
     /// # fn main() { example().unwrap(); }
-    /// #
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// assert!(!table.is_interned(b"abc"));
@@ -947,7 +929,6 @@ where
     /// ```
     /// # use intaglio::bytes::SymbolTable;
     /// # fn main() { example().unwrap(); }
-    /// #
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::with_capacity(1);
     /// table.intern(b"abc".to_vec())?;
@@ -972,7 +953,6 @@ where
     /// ```
     /// # use intaglio::bytes::SymbolTable;
     /// # fn main() { example().unwrap(); }
-    /// #
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::with_capacity(10);
     /// table.intern(b"abc".to_vec());

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -832,11 +832,32 @@ where
     /// The returned `Symbol` allows retrieving of the underlying bytes.
     /// Equal bytestrings will be inserted into the symbol table exactly once.
     ///
+    /// This function only allocates if the underlying symbol table has no
+    /// remaining capacity.
+    ///
     /// # Errors
     ///
     /// If the symbol table would grow larger than `u32::MAX` interned
     /// bytestrings, the [`Symbol`] counter would overflow and a
     /// [`SymbolOverflowError`] is returned.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use intaglio::bytes::SymbolTable;
+    /// # fn main() { example().unwrap(); }
+    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut table = SymbolTable::new();
+    /// let sym = table.intern(b"abc".to_vec())?;
+    /// table.intern(b"xyz".to_vec())?;
+    /// table.intern(&b"123"[..])?;
+    /// table.intern(&b"789"[..])?;
+    ///
+    /// assert_eq!(4, table.len());
+    /// assert_eq!(Some(&b"abc"[..]), table.get(sym));
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn intern<T>(&mut self, contents: T) -> Result<Symbol, SymbolOverflowError>
     where
         T: Into<Cow<'static, [u8]>>,

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -11,7 +11,6 @@
 //!
 //! ```
 //! # use intaglio::bytes::SymbolTable;
-//! # fn main() { example().unwrap(); }
 //! # fn example() -> Result<(), Box<dyn std::error::Error>> {
 //! let mut table = SymbolTable::new();
 //! let sym = table.intern(&b"abc"[..])?;
@@ -19,6 +18,7 @@
 //! assert_eq!(Some(&b"abc"[..]), table.get(sym));
 //! # Ok(())
 //! # }
+//! # example().unwrap();
 //! ```
 //!
 //! # Example: symbol iterators
@@ -27,7 +27,6 @@
 //! # use std::collections::HashMap;
 //! # use intaglio::bytes::SymbolTable;
 //! # use intaglio::Symbol;
-//! # fn main() { example().unwrap(); }
 //! # fn example() -> Result<(), Box<dyn std::error::Error>> {
 //! let mut table = SymbolTable::new();
 //! let sym = table.intern(&b"abc"[..])?;
@@ -44,6 +43,7 @@
 //! assert_eq!(map, iter.collect::<HashMap<_, _>>());
 //! # Ok(())
 //! # }
+//! # example().unwrap();
 //! ```
 //!
 //! # Performance
@@ -206,7 +206,6 @@ impl Borrow<[u8]> for &mut Slice {
 ///
 /// ```
 /// # use intaglio::bytes::SymbolTable;
-/// # fn main() { example().unwrap(); }
 /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let mut table = SymbolTable::new();
 /// let sym = table.intern(&b"abc"[..])?;
@@ -214,6 +213,7 @@ impl Borrow<[u8]> for &mut Slice {
 /// assert_eq!(vec![sym], all_symbols.collect::<Vec<_>>());
 /// # Ok(())
 /// # }
+/// # example().unwrap();
 /// ```
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub struct AllSymbols<'a> {
@@ -304,7 +304,6 @@ impl<'a> FusedIterator for AllSymbols<'a> {}
 ///
 /// ```
 /// # use intaglio::bytes::SymbolTable;
-/// # fn main() { example().unwrap(); }
 /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let mut table = SymbolTable::new();
 /// let sym = table.intern(b"abc".to_vec())?;
@@ -312,6 +311,7 @@ impl<'a> FusedIterator for AllSymbols<'a> {}
 /// assert_eq!(vec![&b"abc"[..]], bytestrings.collect::<Vec<_>>());
 /// # Ok(())
 /// # }
+/// # example().unwrap();
 /// ```
 #[derive(Debug, Clone)]
 pub struct Bytestrings<'a>(slice::Iter<'a, Slice>);
@@ -387,7 +387,6 @@ impl<'a> FusedIterator for Bytestrings<'a> {}
 /// # use std::collections::HashMap;
 /// # use intaglio::bytes::SymbolTable;
 /// # use intaglio::Symbol;
-/// # fn main() { example().unwrap(); }
 /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let mut table = SymbolTable::new();
 /// let sym = table.intern(b"abc".to_vec())?;
@@ -397,6 +396,7 @@ impl<'a> FusedIterator for Bytestrings<'a> {}
 /// assert_eq!(map, iter.collect::<HashMap<_, _>>());
 /// # Ok(())
 /// # }
+/// # example().unwrap();
 /// ```
 #[derive(Debug, Clone)]
 pub struct Iter<'a>(iter::Zip<AllSymbols<'a>, Bytestrings<'a>>);
@@ -458,7 +458,6 @@ impl<'a> IntoIterator for &'a SymbolTable {
 ///
 /// ```
 /// # use intaglio::bytes::SymbolTable;
-/// # fn main() { example().unwrap(); }
 /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let mut table = SymbolTable::new();
 /// let sym = table.intern(&b"abc"[..])?;
@@ -467,6 +466,7 @@ impl<'a> IntoIterator for &'a SymbolTable {
 /// assert!(table.is_interned(b"abc"));
 /// # Ok(())
 /// # }
+/// # example().unwrap();
 /// ```
 #[derive(Default, Debug)]
 pub struct SymbolTable<S = RandomState> {
@@ -574,7 +574,6 @@ impl<S> SymbolTable<S> {
     ///
     /// ```
     /// # use intaglio::bytes::SymbolTable;
-    /// # fn main() { example().unwrap(); }
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// assert_eq!(0, table.len());
@@ -586,6 +585,7 @@ impl<S> SymbolTable<S> {
     /// assert_eq!(2, table.len());
     /// # Ok(())
     /// # }
+    /// # example().unwrap();
     /// ```
     pub fn len(&self) -> usize {
         self.vec.len()
@@ -597,7 +597,6 @@ impl<S> SymbolTable<S> {
     ///
     /// ```
     /// # use intaglio::bytes::SymbolTable;
-    /// # fn main() { example().unwrap(); }
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// assert!(table.is_empty());
@@ -606,6 +605,7 @@ impl<S> SymbolTable<S> {
     /// assert!(!table.is_empty());
     /// # Ok(())
     /// # }
+    /// # example().unwrap();
     /// ```
     pub fn is_empty(&self) -> bool {
         self.vec.is_empty()
@@ -618,7 +618,6 @@ impl<S> SymbolTable<S> {
     /// ```
     /// # use intaglio::bytes::SymbolTable;
     /// # use intaglio::Symbol;
-    /// # fn main() { example().unwrap(); }
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// assert!(!table.contains(Symbol::new(0)));
@@ -628,6 +627,7 @@ impl<S> SymbolTable<S> {
     /// assert!(table.contains(sym));
     /// # Ok(())
     /// # }
+    /// # example().unwrap();
     /// ```
     #[must_use]
     pub fn contains(&self, id: Symbol) -> bool {
@@ -646,7 +646,6 @@ impl<S> SymbolTable<S> {
     /// ```
     /// # use intaglio::bytes::SymbolTable;
     /// # use intaglio::Symbol;
-    /// # fn main() { example().unwrap(); }
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// assert!(table.get(Symbol::new(0)).is_none());
@@ -656,6 +655,7 @@ impl<S> SymbolTable<S> {
     /// assert_eq!(Some(&b"abc"[..]), table.get(sym));
     /// # Ok(())
     /// # }
+    /// # example().unwrap();
     /// ```
     #[must_use]
     pub fn get(&self, id: Symbol) -> Option<&[u8]> {
@@ -672,7 +672,6 @@ impl<S> SymbolTable<S> {
     /// # use std::collections::HashMap;
     /// # use intaglio::bytes::SymbolTable;
     /// # use intaglio::Symbol;
-    /// # fn main() { example().unwrap(); }
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// table.intern(b"abc".to_vec())?;
@@ -689,11 +688,11 @@ impl<S> SymbolTable<S> {
     /// assert_eq!(map, iter.collect::<HashMap<_, _>>());
     /// # Ok(())
     /// # }
+    /// # example().unwrap();
     /// ```
     ///
     /// ```
     /// # use intaglio::bytes::SymbolTable;
-    /// # fn main() { example().unwrap(); }
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// table.intern(b"abc".to_vec())?;
@@ -705,6 +704,7 @@ impl<S> SymbolTable<S> {
     /// assert_eq!(table.len(), iter.count());
     /// # Ok(())
     /// # }
+    /// # example().unwrap();
     /// ```
     pub fn iter(&self) -> Iter<'_> {
         Iter(self.all_symbols().zip(self.bytestrings()))
@@ -717,7 +717,6 @@ impl<S> SymbolTable<S> {
     /// ```
     /// # use intaglio::bytes::SymbolTable;
     /// # use intaglio::Symbol;
-    /// # fn main() { example().unwrap(); }
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// table.intern(b"abc".to_vec())?;
@@ -731,11 +730,11 @@ impl<S> SymbolTable<S> {
     /// assert_eq!(None, all_symbols.next());
     /// # Ok(())
     /// # }
+    /// # example().unwrap();
     /// ```
     ///
     /// ```
     /// # use intaglio::bytes::SymbolTable;
-    /// # fn main() { example().unwrap(); }
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// table.intern(b"abc".to_vec())?;
@@ -747,6 +746,7 @@ impl<S> SymbolTable<S> {
     /// assert_eq!(table.len(), all_symbols.count());
     /// # Ok(())
     /// # }
+    /// # example().unwrap();
     /// ```
     pub fn all_symbols(&self) -> AllSymbols<'_> {
         if self.len() == u32::MAX as usize {
@@ -769,7 +769,6 @@ impl<S> SymbolTable<S> {
     ///
     /// ```
     /// # use intaglio::bytes::SymbolTable;
-    /// # fn main() { example().unwrap(); }
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// table.intern(b"abc".to_vec())?;
@@ -783,11 +782,11 @@ impl<S> SymbolTable<S> {
     /// assert_eq!(None, bytestrings.next());
     /// # Ok(())
     /// # }
+    /// # example().unwrap();
     /// ```
     ///
     /// ```
     /// # use intaglio::bytes::SymbolTable;
-    /// # fn main() { example().unwrap(); }
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// table.intern(b"abc".to_vec())?;
@@ -799,6 +798,7 @@ impl<S> SymbolTable<S> {
     /// assert_eq!(table.len(), bytestrings.count());
     /// # Ok(())
     /// # }
+    /// # example().unwrap();
     /// ```
     pub fn bytestrings(&self) -> Bytestrings<'_> {
         Bytestrings(self.vec.iter())
@@ -845,7 +845,6 @@ where
     ///
     /// ```
     /// # use intaglio::bytes::SymbolTable;
-    /// # fn main() { example().unwrap(); }
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// let sym = table.intern(b"abc".to_vec())?;
@@ -857,6 +856,7 @@ where
     /// assert_eq!(Some(&b"abc"[..]), table.get(sym));
     /// # Ok(())
     /// # }
+    /// # example().unwrap();
     /// ```
     pub fn intern<T>(&mut self, contents: T) -> Result<Symbol, SymbolOverflowError>
     where
@@ -892,7 +892,6 @@ where
     /// ```
     /// # use intaglio::bytes::SymbolTable;
     /// # use intaglio::Symbol;
-    /// # fn main() { example().unwrap(); }
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// assert!(!table.is_interned(b"abc"));
@@ -903,6 +902,7 @@ where
     /// assert_eq!(Some(Symbol::new(0)), table.check_interned(b"abc"));
     /// # Ok(())
     /// # }
+    /// # example().unwrap();
     /// ```
     #[must_use]
     pub fn check_interned(&self, contents: &[u8]) -> Option<Symbol> {
@@ -918,7 +918,6 @@ where
     /// ```
     /// # use intaglio::bytes::SymbolTable;
     /// # use intaglio::Symbol;
-    /// # fn main() { example().unwrap(); }
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// assert!(!table.is_interned(b"abc"));
@@ -929,6 +928,7 @@ where
     /// assert_eq!(Some(Symbol::new(0)), table.check_interned(b"abc"));
     /// # Ok(())
     /// # }
+    /// # example().unwrap();
     /// ```
     #[must_use]
     pub fn is_interned(&self, contents: &[u8]) -> bool {
@@ -949,7 +949,6 @@ where
     ///
     /// ```
     /// # use intaglio::bytes::SymbolTable;
-    /// # fn main() { example().unwrap(); }
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::with_capacity(1);
     /// table.intern(b"abc".to_vec())?;
@@ -957,6 +956,7 @@ where
     /// assert!(table.capacity() >= 11);
     /// # Ok(())
     /// # }
+    /// # example().unwrap();
     /// ```
     pub fn reserve(&mut self, additional: usize) {
         self.vec.reserve(additional);
@@ -973,7 +973,6 @@ where
     ///
     /// ```
     /// # use intaglio::bytes::SymbolTable;
-    /// # fn main() { example().unwrap(); }
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::with_capacity(10);
     /// table.intern(b"abc".to_vec());
@@ -983,6 +982,7 @@ where
     /// assert!(table.capacity() >= 3);
     /// # Ok(())
     /// # }
+    /// # example().unwrap();
     /// ```
     pub fn shrink_to_fit(&mut self) {
         self.vec.shrink_to_fit();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,6 @@
 //! ```
 //! # use intaglio::SymbolTable;
 //! # fn main() { example().unwrap(); }
-//! #
 //! # fn example() -> Result<(), Box<dyn std::error::Error>> {
 //! let mut table = SymbolTable::new();
 //! let sym_id = table.intern("abc")?;
@@ -300,7 +299,6 @@ impl Symbol {
     /// ```
     /// # use intaglio::SymbolTable;
     /// # fn main() { example().unwrap(); }
-    /// #
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// let sym = table.intern("intaglio")?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,8 @@
 //!
 //! ```
 //! # use intaglio::SymbolTable;
+//! # fn main() { example().unwrap(); }
+//! #
 //! # fn example() -> Result<(), Box<dyn std::error::Error>> {
 //! let mut table = SymbolTable::new();
 //! let sym_id = table.intern("abc")?;
@@ -278,6 +280,14 @@ impl Symbol {
     /// `Symbol`s are not constrained to the `SymbolTable` which created them.
     /// No runtime checks ensure that [`SymbolTable::get`] is called with a
     /// `Symbol` that the table itself issued.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use intaglio::Symbol;
+    /// let sym = Symbol::new(263);
+    /// assert_eq!(263, sym.id());
+    /// ```
     #[must_use]
     pub fn new(sym: u32) -> Self {
         Self::from(sym)
@@ -289,6 +299,8 @@ impl Symbol {
     ///
     /// ```
     /// # use intaglio::SymbolTable;
+    /// # fn main() { example().unwrap(); }
+    /// #
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// let sym = table.intern("intaglio")?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@
 //! For more specific details on the API for interning strings into a symbol
 //! table, please see the documentation for the [`SymbolTable`] type.
 //!
-//! # Example
+//! # Examples
 //!
 //! ```
 //! # use intaglio::SymbolTable;
@@ -280,7 +280,7 @@ impl Symbol {
     /// No runtime checks ensure that [`SymbolTable::get`] is called with a
     /// `Symbol` that the table itself issued.
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```
     /// # use intaglio::Symbol;
@@ -294,7 +294,7 @@ impl Symbol {
 
     /// Return the `u32` identifier from this `Symbol`.
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```
     /// # use intaglio::SymbolTable;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,6 @@
 //!
 //! ```
 //! # use intaglio::SymbolTable;
-//! # fn main() { example().unwrap(); }
 //! # fn example() -> Result<(), Box<dyn std::error::Error>> {
 //! let mut table = SymbolTable::new();
 //! let sym_id = table.intern("abc")?;
@@ -32,6 +31,7 @@
 //! assert!(table.is_interned("abc"));
 //! # Ok(())
 //! # }
+//! # example().unwrap();
 //! ```
 //!
 //! # String interning
@@ -298,13 +298,13 @@ impl Symbol {
     ///
     /// ```
     /// # use intaglio::SymbolTable;
-    /// # fn main() { example().unwrap(); }
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// let sym = table.intern("intaglio")?;
     /// assert_eq!(u32::from(sym), sym.id());
     /// # Ok(())
     /// # }
+    /// # example().unwrap();
     /// ```
     #[must_use]
     pub fn id(self) -> u32 {

--- a/src/str.rs
+++ b/src/str.rs
@@ -177,6 +177,8 @@ impl Borrow<[u8]> for &mut Slice {
 ///
 /// ```
 /// # use intaglio::SymbolTable;
+/// # fn main() { example().unwrap(); }
+/// #
 /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let mut table = SymbolTable::new();
 /// let sym = table.intern("abc")?;
@@ -274,6 +276,8 @@ impl<'a> FusedIterator for AllSymbols<'a> {}
 ///
 /// ```
 /// # use intaglio::SymbolTable;
+/// # fn main() { example().unwrap(); }
+/// #
 /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let mut table = SymbolTable::new();
 /// let sym = table.intern("abc")?;
@@ -355,6 +359,8 @@ impl<'a> FusedIterator for Strings<'a> {}
 /// ```
 /// # use std::collections::HashMap;
 /// # use intaglio::{Symbol, SymbolTable};
+/// # fn main() { example().unwrap(); }
+/// #
 /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let mut table = SymbolTable::new();
 /// let sym = table.intern("abc")?;
@@ -425,6 +431,8 @@ impl<'a> IntoIterator for &'a SymbolTable {
 ///
 /// ```
 /// # use intaglio::SymbolTable;
+/// # fn main() { example().unwrap(); }
+/// #
 /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let mut table = SymbolTable::new();
 /// let sym = table.intern("abc")?;
@@ -540,6 +548,8 @@ impl<S> SymbolTable<S> {
     ///
     /// ```
     /// # use intaglio::SymbolTable;
+    /// # fn main() { example().unwrap(); }
+    /// #
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// assert_eq!(0, table.len());
@@ -562,6 +572,8 @@ impl<S> SymbolTable<S> {
     ///
     /// ```
     /// # use intaglio::SymbolTable;
+    /// # fn main() { example().unwrap(); }
+    /// #
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// assert!(table.is_empty());
@@ -581,6 +593,8 @@ impl<S> SymbolTable<S> {
     ///
     /// ```
     /// # use intaglio::{Symbol, SymbolTable};
+    /// # fn main() { example().unwrap(); }
+    /// #
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// assert!(!table.contains(Symbol::new(0)));
@@ -607,9 +621,11 @@ impl<S> SymbolTable<S> {
     ///
     /// ```
     /// # use intaglio::{Symbol, SymbolTable};
+    /// # fn main() { example().unwrap(); }
+    /// #
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
-    /// assert!(!table.get(Symbol::new(0)).is_none());
+    /// assert!(table.get(Symbol::new(0)).is_none());
     ///
     /// let sym = table.intern("abc".to_string())?;
     /// assert_eq!(Some("abc"), table.get(Symbol::new(0)));
@@ -631,6 +647,8 @@ impl<S> SymbolTable<S> {
     /// ```
     /// # use std::collections::HashMap;
     /// # use intaglio::{Symbol, SymbolTable};
+    /// # fn main() { example().unwrap(); }
+    /// #
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// table.intern("abc")?;
@@ -651,6 +669,8 @@ impl<S> SymbolTable<S> {
     ///
     /// ```
     /// # use intaglio::SymbolTable;
+    /// # fn main() { example().unwrap(); }
+    /// #
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// table.intern("abc")?;
@@ -673,6 +693,8 @@ impl<S> SymbolTable<S> {
     ///
     /// ```
     /// # use intaglio::{Symbol, SymbolTable};
+    /// # fn main() { example().unwrap(); }
+    /// #
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// table.intern("abc")?;
@@ -690,6 +712,8 @@ impl<S> SymbolTable<S> {
     ///
     /// ```
     /// # use intaglio::SymbolTable;
+    /// # fn main() { example().unwrap(); }
+    /// #
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// table.intern("abc")?;
@@ -723,6 +747,8 @@ impl<S> SymbolTable<S> {
     ///
     /// ```
     /// # use intaglio::SymbolTable;
+    /// # fn main() { example().unwrap(); }
+    /// #
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// table.intern("abc")?;
@@ -740,6 +766,8 @@ impl<S> SymbolTable<S> {
     ///
     /// ```
     /// # use intaglio::SymbolTable;
+    /// # fn main() { example().unwrap(); }
+    /// #
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// table.intern("abc")?;
@@ -822,6 +850,8 @@ where
     ///
     /// ```
     /// # use intaglio::{SymbolTable, Symbol};
+    /// # fn main() { example().unwrap(); }
+    /// #
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// assert!(!table.is_interned("abc"));
@@ -846,6 +876,8 @@ where
     ///
     /// ```
     /// # use intaglio::{SymbolTable, Symbol};
+    /// # fn main() { example().unwrap(); }
+    /// #
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// assert!(!table.is_interned("abc"));
@@ -876,6 +908,8 @@ where
     ///
     /// ```
     /// # use intaglio::SymbolTable;
+    /// # fn main() { example().unwrap(); }
+    /// #
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::with_capacity(1);
     /// table.intern("abc")?;
@@ -899,6 +933,8 @@ where
     ///
     /// ```
     /// # use intaglio::SymbolTable;
+    /// # fn main() { example().unwrap(); }
+    /// #
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::with_capacity(10);
     /// table.intern("abc")?;

--- a/src/str.rs
+++ b/src/str.rs
@@ -1,9 +1,4 @@
 //! Intaglio interner for UTF-8 [`String`]s.
-//!
-//! See [`SymbolTable`].
-//!
-//! This module implements a nearly identical API to
-//! [`intaglio::SymbolTable`](crate::SymbolTable).
 
 use core::borrow::Borrow;
 use core::cmp;
@@ -178,7 +173,6 @@ impl Borrow<[u8]> for &mut Slice {
 /// ```
 /// # use intaglio::SymbolTable;
 /// # fn main() { example().unwrap(); }
-/// #
 /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let mut table = SymbolTable::new();
 /// let sym = table.intern("abc")?;
@@ -277,7 +271,6 @@ impl<'a> FusedIterator for AllSymbols<'a> {}
 /// ```
 /// # use intaglio::SymbolTable;
 /// # fn main() { example().unwrap(); }
-/// #
 /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let mut table = SymbolTable::new();
 /// let sym = table.intern("abc")?;
@@ -360,7 +353,6 @@ impl<'a> FusedIterator for Strings<'a> {}
 /// # use std::collections::HashMap;
 /// # use intaglio::{Symbol, SymbolTable};
 /// # fn main() { example().unwrap(); }
-/// #
 /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let mut table = SymbolTable::new();
 /// let sym = table.intern("abc")?;
@@ -432,7 +424,6 @@ impl<'a> IntoIterator for &'a SymbolTable {
 /// ```
 /// # use intaglio::SymbolTable;
 /// # fn main() { example().unwrap(); }
-/// #
 /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let mut table = SymbolTable::new();
 /// let sym = table.intern("abc")?;
@@ -549,7 +540,6 @@ impl<S> SymbolTable<S> {
     /// ```
     /// # use intaglio::SymbolTable;
     /// # fn main() { example().unwrap(); }
-    /// #
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// assert_eq!(0, table.len());
@@ -573,7 +563,6 @@ impl<S> SymbolTable<S> {
     /// ```
     /// # use intaglio::SymbolTable;
     /// # fn main() { example().unwrap(); }
-    /// #
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// assert!(table.is_empty());
@@ -594,7 +583,6 @@ impl<S> SymbolTable<S> {
     /// ```
     /// # use intaglio::{Symbol, SymbolTable};
     /// # fn main() { example().unwrap(); }
-    /// #
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// assert!(!table.contains(Symbol::new(0)));
@@ -622,7 +610,6 @@ impl<S> SymbolTable<S> {
     /// ```
     /// # use intaglio::{Symbol, SymbolTable};
     /// # fn main() { example().unwrap(); }
-    /// #
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// assert!(table.get(Symbol::new(0)).is_none());
@@ -648,7 +635,6 @@ impl<S> SymbolTable<S> {
     /// # use std::collections::HashMap;
     /// # use intaglio::{Symbol, SymbolTable};
     /// # fn main() { example().unwrap(); }
-    /// #
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// table.intern("abc")?;
@@ -670,7 +656,6 @@ impl<S> SymbolTable<S> {
     /// ```
     /// # use intaglio::SymbolTable;
     /// # fn main() { example().unwrap(); }
-    /// #
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// table.intern("abc")?;
@@ -694,7 +679,6 @@ impl<S> SymbolTable<S> {
     /// ```
     /// # use intaglio::{Symbol, SymbolTable};
     /// # fn main() { example().unwrap(); }
-    /// #
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// table.intern("abc")?;
@@ -713,7 +697,6 @@ impl<S> SymbolTable<S> {
     /// ```
     /// # use intaglio::SymbolTable;
     /// # fn main() { example().unwrap(); }
-    /// #
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// table.intern("abc")?;
@@ -748,7 +731,6 @@ impl<S> SymbolTable<S> {
     /// ```
     /// # use intaglio::SymbolTable;
     /// # fn main() { example().unwrap(); }
-    /// #
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// table.intern("abc")?;
@@ -767,7 +749,6 @@ impl<S> SymbolTable<S> {
     /// ```
     /// # use intaglio::SymbolTable;
     /// # fn main() { example().unwrap(); }
-    /// #
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// table.intern("abc")?;
@@ -851,7 +832,6 @@ where
     /// ```
     /// # use intaglio::{SymbolTable, Symbol};
     /// # fn main() { example().unwrap(); }
-    /// #
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// assert!(!table.is_interned("abc"));
@@ -877,7 +857,6 @@ where
     /// ```
     /// # use intaglio::{SymbolTable, Symbol};
     /// # fn main() { example().unwrap(); }
-    /// #
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// assert!(!table.is_interned("abc"));
@@ -909,7 +888,6 @@ where
     /// ```
     /// # use intaglio::SymbolTable;
     /// # fn main() { example().unwrap(); }
-    /// #
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::with_capacity(1);
     /// table.intern("abc")?;
@@ -934,7 +912,6 @@ where
     /// ```
     /// # use intaglio::SymbolTable;
     /// # fn main() { example().unwrap(); }
-    /// #
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::with_capacity(10);
     /// table.intern("abc")?;

--- a/src/str.rs
+++ b/src/str.rs
@@ -172,7 +172,6 @@ impl Borrow<[u8]> for &mut Slice {
 ///
 /// ```
 /// # use intaglio::SymbolTable;
-/// # fn main() { example().unwrap(); }
 /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let mut table = SymbolTable::new();
 /// let sym = table.intern("abc")?;
@@ -180,6 +179,7 @@ impl Borrow<[u8]> for &mut Slice {
 /// assert_eq!(vec![sym], all_symbols.collect::<Vec<_>>());
 /// # Ok(())
 /// # }
+/// # example().unwrap();
 /// ```
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub struct AllSymbols<'a> {
@@ -270,7 +270,6 @@ impl<'a> FusedIterator for AllSymbols<'a> {}
 ///
 /// ```
 /// # use intaglio::SymbolTable;
-/// # fn main() { example().unwrap(); }
 /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let mut table = SymbolTable::new();
 /// let sym = table.intern("abc")?;
@@ -278,6 +277,7 @@ impl<'a> FusedIterator for AllSymbols<'a> {}
 /// assert_eq!(vec!["abc"], strings.collect::<Vec<_>>());
 /// # Ok(())
 /// # }
+/// # example().unwrap();
 /// ```
 #[derive(Debug, Clone)]
 pub struct Strings<'a>(slice::Iter<'a, Slice>);
@@ -352,7 +352,6 @@ impl<'a> FusedIterator for Strings<'a> {}
 /// ```
 /// # use std::collections::HashMap;
 /// # use intaglio::{Symbol, SymbolTable};
-/// # fn main() { example().unwrap(); }
 /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let mut table = SymbolTable::new();
 /// let sym = table.intern("abc")?;
@@ -362,6 +361,7 @@ impl<'a> FusedIterator for Strings<'a> {}
 /// assert_eq!(map, iter.collect::<HashMap<_, _>>());
 /// # Ok(())
 /// # }
+/// # example().unwrap();
 /// ```
 #[derive(Debug, Clone)]
 pub struct Iter<'a>(iter::Zip<AllSymbols<'a>, Strings<'a>>);
@@ -423,7 +423,6 @@ impl<'a> IntoIterator for &'a SymbolTable {
 ///
 /// ```
 /// # use intaglio::SymbolTable;
-/// # fn main() { example().unwrap(); }
 /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let mut table = SymbolTable::new();
 /// let sym = table.intern("abc")?;
@@ -432,6 +431,7 @@ impl<'a> IntoIterator for &'a SymbolTable {
 /// assert!(table.is_interned("abc"));
 /// # Ok(())
 /// # }
+/// # example().unwrap();
 /// ```
 #[derive(Default, Debug)]
 pub struct SymbolTable<S = RandomState> {
@@ -539,7 +539,6 @@ impl<S> SymbolTable<S> {
     ///
     /// ```
     /// # use intaglio::SymbolTable;
-    /// # fn main() { example().unwrap(); }
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// assert_eq!(0, table.len());
@@ -551,6 +550,7 @@ impl<S> SymbolTable<S> {
     /// assert_eq!(2, table.len());
     /// # Ok(())
     /// # }
+    /// # example().unwrap();
     /// ```
     pub fn len(&self) -> usize {
         self.vec.len()
@@ -562,7 +562,6 @@ impl<S> SymbolTable<S> {
     ///
     /// ```
     /// # use intaglio::SymbolTable;
-    /// # fn main() { example().unwrap(); }
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// assert!(table.is_empty());
@@ -571,6 +570,7 @@ impl<S> SymbolTable<S> {
     /// assert!(!table.is_empty());
     /// # Ok(())
     /// # }
+    /// # example().unwrap();
     /// ```
     pub fn is_empty(&self) -> bool {
         self.vec.is_empty()
@@ -582,7 +582,6 @@ impl<S> SymbolTable<S> {
     ///
     /// ```
     /// # use intaglio::{Symbol, SymbolTable};
-    /// # fn main() { example().unwrap(); }
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// assert!(!table.contains(Symbol::new(0)));
@@ -592,6 +591,7 @@ impl<S> SymbolTable<S> {
     /// assert!(table.contains(sym));
     /// # Ok(())
     /// # }
+    /// # example().unwrap();
     /// ```
     #[must_use]
     pub fn contains(&self, id: Symbol) -> bool {
@@ -609,7 +609,6 @@ impl<S> SymbolTable<S> {
     ///
     /// ```
     /// # use intaglio::{Symbol, SymbolTable};
-    /// # fn main() { example().unwrap(); }
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// assert!(table.get(Symbol::new(0)).is_none());
@@ -619,6 +618,7 @@ impl<S> SymbolTable<S> {
     /// assert_eq!(Some("abc"), table.get(sym));
     /// # Ok(())
     /// # }
+    /// # example().unwrap();
     /// ```
     #[must_use]
     pub fn get(&self, id: Symbol) -> Option<&str> {
@@ -634,7 +634,6 @@ impl<S> SymbolTable<S> {
     /// ```
     /// # use std::collections::HashMap;
     /// # use intaglio::{Symbol, SymbolTable};
-    /// # fn main() { example().unwrap(); }
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// table.intern("abc")?;
@@ -651,11 +650,11 @@ impl<S> SymbolTable<S> {
     /// assert_eq!(map, iter.collect::<HashMap<_, _>>());
     /// # Ok(())
     /// # }
+    /// # example().unwrap();
     /// ```
     ///
     /// ```
     /// # use intaglio::SymbolTable;
-    /// # fn main() { example().unwrap(); }
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// table.intern("abc")?;
@@ -667,6 +666,7 @@ impl<S> SymbolTable<S> {
     /// assert_eq!(table.len(), iter.count());
     /// # Ok(())
     /// # }
+    /// # example().unwrap();
     /// ```
     pub fn iter(&self) -> Iter<'_> {
         Iter(self.all_symbols().zip(self.strings()))
@@ -678,7 +678,6 @@ impl<S> SymbolTable<S> {
     ///
     /// ```
     /// # use intaglio::{Symbol, SymbolTable};
-    /// # fn main() { example().unwrap(); }
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// table.intern("abc")?;
@@ -692,11 +691,11 @@ impl<S> SymbolTable<S> {
     /// assert_eq!(None, all_symbols.next());
     /// # Ok(())
     /// # }
+    /// # example().unwrap();
     /// ```
     ///
     /// ```
     /// # use intaglio::SymbolTable;
-    /// # fn main() { example().unwrap(); }
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// table.intern("abc")?;
@@ -708,6 +707,7 @@ impl<S> SymbolTable<S> {
     /// assert_eq!(table.len(), all_symbols.count());
     /// # Ok(())
     /// # }
+    /// # example().unwrap();
     /// ```
     pub fn all_symbols(&self) -> AllSymbols<'_> {
         if self.len() == u32::MAX as usize {
@@ -730,7 +730,6 @@ impl<S> SymbolTable<S> {
     ///
     /// ```
     /// # use intaglio::SymbolTable;
-    /// # fn main() { example().unwrap(); }
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// table.intern("abc")?;
@@ -744,11 +743,11 @@ impl<S> SymbolTable<S> {
     /// assert_eq!(None, strings.next());
     /// # Ok(())
     /// # }
+    /// # example().unwrap();
     /// ```
     ///
     /// ```
     /// # use intaglio::SymbolTable;
-    /// # fn main() { example().unwrap(); }
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// table.intern("abc")?;
@@ -760,6 +759,7 @@ impl<S> SymbolTable<S> {
     /// assert_eq!(table.len(), strings.count());
     /// # Ok(())
     /// # }
+    /// # example().unwrap();
     /// ```
     pub fn strings(&self) -> Strings<'_> {
         Strings(self.vec.iter())
@@ -806,7 +806,6 @@ where
     ///
     /// ```
     /// # use intaglio::SymbolTable;
-    /// # fn main() { example().unwrap(); }
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// let sym = table.intern("abc".to_string())?;
@@ -818,6 +817,7 @@ where
     /// assert_eq!(Some("abc"), table.get(sym));
     /// # Ok(())
     /// # }
+    /// # example().unwrap();
     /// ```
     pub fn intern<T>(&mut self, contents: T) -> Result<Symbol, SymbolOverflowError>
     where
@@ -852,7 +852,6 @@ where
     ///
     /// ```
     /// # use intaglio::{SymbolTable, Symbol};
-    /// # fn main() { example().unwrap(); }
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// assert!(!table.is_interned("abc"));
@@ -863,6 +862,7 @@ where
     /// assert_eq!(Some(Symbol::new(0)), table.check_interned("abc"));
     /// # Ok(())
     /// # }
+    /// # example().unwrap();
     /// ```
     #[must_use]
     pub fn check_interned(&self, contents: &str) -> Option<Symbol> {
@@ -877,7 +877,6 @@ where
     ///
     /// ```
     /// # use intaglio::{SymbolTable, Symbol};
-    /// # fn main() { example().unwrap(); }
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
     /// assert!(!table.is_interned("abc"));
@@ -888,6 +887,7 @@ where
     /// assert_eq!(Some(Symbol::new(0)), table.check_interned("abc"));
     /// # Ok(())
     /// # }
+    /// # example().unwrap();
     /// ```
     #[must_use]
     pub fn is_interned(&self, contents: &str) -> bool {
@@ -908,7 +908,6 @@ where
     ///
     /// ```
     /// # use intaglio::SymbolTable;
-    /// # fn main() { example().unwrap(); }
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::with_capacity(1);
     /// table.intern("abc")?;
@@ -916,6 +915,7 @@ where
     /// assert!(table.capacity() >= 11);
     /// # Ok(())
     /// # }
+    /// # example().unwrap();
     /// ```
     pub fn reserve(&mut self, additional: usize) {
         self.vec.reserve(additional);
@@ -932,7 +932,6 @@ where
     ///
     /// ```
     /// # use intaglio::SymbolTable;
-    /// # fn main() { example().unwrap(); }
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::with_capacity(10);
     /// table.intern("abc")?;
@@ -942,6 +941,7 @@ where
     /// assert!(table.capacity() >= 3);
     /// # Ok(())
     /// # }
+    /// # example().unwrap();
     /// ```
     pub fn shrink_to_fit(&mut self) {
         self.vec.shrink_to_fit();

--- a/src/str.rs
+++ b/src/str.rs
@@ -793,11 +793,32 @@ where
     /// The returned `Symbol` allows retrieving of the underlying bytes.
     /// Equal bytestrings will be inserted into the symbol table exactly once.
     ///
+    /// This function only allocates if the underlying symbol table has no
+    /// remaining capacity.
+    ///
     /// # Errors
     ///
     /// If the symbol table would grow larger than `u32::MAX` interned
     /// bytestrings, the [`Symbol`] counter would overflow and a
     /// [`SymbolOverflowError`] is returned.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use intaglio::SymbolTable;
+    /// # fn main() { example().unwrap(); }
+    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut table = SymbolTable::new();
+    /// let sym = table.intern("abc".to_string())?;
+    /// table.intern("xyz".to_string())?;
+    /// table.intern("123")?;
+    /// table.intern("789")?;
+    ///
+    /// assert_eq!(4, table.len());
+    /// assert_eq!(Some("abc"), table.get(sym));
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn intern<T>(&mut self, contents: T) -> Result<Symbol, SymbolOverflowError>
     where
         T: Into<Cow<'static, str>>,


### PR DESCRIPTION
This PR ensures that doctests are executed even when they are wrapped in a function to enable the question mark operator.

Executing the tests revealed some failing assertions. These failures were from errors in the examples, which have been fixed.

This PR adds a note on allocation behavior to `SymbolTable::intern` and `bytes::SymbolTable::intern`.

This PR adds an example that illustrates how to intern static and owned strings to `SymbolTable::intern` and `bytes::SymbolTable::intern`.

This PR adds an example to `Symbol::new` docs.

This PR unifies all "Examples" headers to be pluralized.