### PR TITLE
Bump version to v1.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "intaglio"
-version = "1.0.1"
+version = "1.1.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2018"
 description = "UTF-8 string and bytestring interner and symbol table"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-intaglio = "1.0"
+intaglio = "1.1"
 ```
 
 Then intern UTF-8 strings like:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@
 //!   interning bytestrings (`Vec<u8>` and `&'static [u8]`). Disabling this
 //!   drops the `bstr` dependency.
 
-#![doc(html_root_url = "https://docs.rs/intaglio/1.0.1")]
+#![doc(html_root_url = "https://docs.rs/intaglio/1.1.0")]
 
 // Ensure code blocks in README.md compile
 #[cfg(doctest)]


### PR DESCRIPTION
## New APIs

- Add `Symbol::id` which returns the inner `u32` (GH-25)
- Add `impl From<&Symbol> for {u32,u64,usize}` (GH-25)

## Improvements

- Remove some dev-dependencies (GH-22)
- Improve crate documentation and examples (GH26)
- Optimize layout of `SymbolOverflowError` (GH-25)