### PR TITLE
Update docs to remove references to `Box::leak` and reimplement Debug for bytes interner

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,20 +20,10 @@ include = [
 # All features are enabled by default.
 default = ["bytes"]
 # `bytes` feature enables an additional symbol table implementation for
-# interning bytestrings (`Vec<u8>` and `&'static [u8]`). When this feature is
-# enabled, Intaglio will depend on [`bstr`].
-bytes = ["bstr"]
+# interning bytestrings (`Vec<u8>` and `&'static [u8]`).
+bytes = []
 
 [dependencies]
-# The dependency on bstr is not strictly necessary, but `intaglio` uses the
-# `fmt::Debug` impl on `BStr` to provide readable debug representations of the
-# bytestring interner variant.
-#
-# If keys are conventionally UTF-8, their UTF-8 portions will be rendered as
-# characters. The UTF-8 invalid parts will be shown as e.g. \xFF escape codes
-# which is also an improvement of how `std` implements `fmt::Debug` for byte
-# slices.
-bstr = { version = "0.2", default-features = false, optional = true }
 
 [dev-dependencies]
 # Property testing for interner getters and setters.

--- a/README.md
+++ b/README.md
@@ -69,8 +69,7 @@ fn intern_and_get() -> Result<(), Box<dyn std::error::Error>> {
 ## Implementation
 
 Intaglio interns owned and borrowed strings with no additional copying by
-leveraging `Cow` and `Box::leak`. This requires unsafe code in the `Drop`
-implementation of `SymbolTable`. CI runs `drop` tests under Miri.
+leveraging `Cow` and a bit of unsafe code. CI runs `drop` tests under Miri.
 
 ## Crate features
 

--- a/README.md
+++ b/README.md
@@ -76,8 +76,7 @@ leveraging `Cow` and a bit of unsafe code. CI runs `drop` tests under Miri.
 All features are enabled by default.
 
 - **bytes** - Enables an additional symbol table implementation for interning
-  bytestrings (`Vec<u8>` and `&'static [u8]`). Disabling this drops the [`bstr`]
-  dependency.
+  bytestrings (`Vec<u8>` and `&'static [u8]`).
 
 ## License
 
@@ -85,4 +84,3 @@ All features are enabled by default.
 
 [symbol]: https://ruby-doc.org/core-2.6.3/Symbol.html
 [artichoke]: https://github.com/artichoke/artichoke
-[`bstr`]: https://crates.io/crates/bstr

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -52,19 +52,20 @@
 
 use core::cmp;
 use core::convert::TryInto;
-use core::hash::{BuildHasher, Hash};
+use core::hash::BuildHasher;
 use core::iter::{self, FusedIterator};
 use core::marker::PhantomData;
-use core::ops::{Deref, Range, RangeInclusive};
+use core::ops::{Range, RangeInclusive};
 use core::slice;
 use std::borrow::Cow;
-use std::collections::hash_map::RandomState;
-use std::collections::HashMap;
+use std::collections::hash_map::{HashMap, RandomState};
 
 use crate::internal::Interned;
 use crate::{Symbol, SymbolOverflowError, DEFAULT_SYMBOL_TABLE_CAPACITY};
 
 /// An iterator over all [`Symbol`]s in a [`SymbolTable`].
+///
+/// See the [`all_symbols`](SymbolTable::all_symbols) method in [`SymbolTable`].
 ///
 /// # Usage
 ///
@@ -164,6 +165,8 @@ impl<'a> FusedIterator for AllSymbols<'a> {}
 
 /// An iterator over all interned bytestrings in a [`SymbolTable`].
 ///
+/// See the [`bytestrings`](SymbolTable::bytestrings) method in [`SymbolTable`].
+///
 /// # Usage
 ///
 /// ```
@@ -184,7 +187,7 @@ impl<'a> Iterator for Bytestrings<'a> {
     type Item = &'a [u8];
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.0.next().map(Deref::deref)
+        self.0.next().map(Interned::as_slice)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -202,28 +205,28 @@ impl<'a> Iterator for Bytestrings<'a> {
     where
         Self: Sized,
     {
-        self.0.last().map(Deref::deref)
+        self.0.last().map(Interned::as_slice)
     }
 
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
-        self.0.nth(n).map(Deref::deref)
+        self.0.nth(n).map(Interned::as_slice)
     }
 
     fn collect<B: iter::FromIterator<Self::Item>>(self) -> B
     where
         Self: Sized,
     {
-        self.0.map(Deref::deref).collect()
+        self.0.map(Interned::as_slice).collect()
     }
 }
 
 impl<'a> DoubleEndedIterator for Bytestrings<'a> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        self.0.next_back().map(Deref::deref)
+        self.0.next_back().map(Interned::as_slice)
     }
 
     fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
-        self.0.nth_back(n).map(Deref::deref)
+        self.0.nth_back(n).map(Interned::as_slice)
     }
 
     fn rfold<B, F>(self, accum: B, f: F) -> B
@@ -231,7 +234,7 @@ impl<'a> DoubleEndedIterator for Bytestrings<'a> {
         Self: Sized,
         F: FnMut(B, Self::Item) -> B,
     {
-        self.0.map(Deref::deref).rfold(accum, f)
+        self.0.map(Interned::as_slice).rfold(accum, f)
     }
 }
 
@@ -244,6 +247,8 @@ impl<'a> ExactSizeIterator for Bytestrings<'a> {
 impl<'a> FusedIterator for Bytestrings<'a> {}
 
 /// An iterator over all symbols and interned bytestrings in a [`SymbolTable`].
+///
+/// See the [`iter`](SymbolTable::iter) method in [`SymbolTable`].
 ///
 /// # Usage
 ///

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -55,6 +55,7 @@ use bstr::{BStr, ByteSlice};
 use core::borrow::Borrow;
 use core::cmp;
 use core::convert::TryInto;
+use core::fmt;
 use core::hash::{BuildHasher, Hash, Hasher};
 use core::iter::{self, FusedIterator};
 use core::marker::PhantomData;
@@ -72,7 +73,6 @@ use crate::{Symbol, SymbolOverflowError, DEFAULT_SYMBOL_TABLE_CAPACITY};
 ///
 /// Must not be `Clone` or `Copy` because the Drop logic assumes this enum is the
 /// unique owner of `&'static` references handed out with `as_static_slice`.
-#[derive(Debug)]
 enum Slice {
     /// True `'static` references.
     Static(&'static [u8]),
@@ -129,6 +129,15 @@ impl Slice {
 impl Default for Slice {
     fn default() -> Self {
         Self::Static(<_>::default())
+    }
+}
+
+impl fmt::Debug for Slice {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Static(_) => write!(f, "Static({:?})", self.as_bstr()),
+            Self::Owned(_) => write!(f, "Owned({:?})", self.as_bstr()),
+        }
     }
 }
 

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -1,0 +1,404 @@
+//! A Wrapper around interned strings that maintains the safety invariants of
+//! the `'static` slices handed out to the interner.
+
+use core::borrow::Borrow;
+use core::fmt;
+use core::hash::{Hash, Hasher};
+use core::ops::Deref;
+use std::borrow::Cow;
+
+/// Wrapper around `&'static [u8]` that does not allow mutable access to the
+/// slice.
+pub struct Interned<T: 'static + ?Sized>(Slice<T>);
+
+impl<T> From<&'static T> for Interned<T> {
+    #[inline]
+    fn from(slice: &'static T) -> Self {
+        Self(slice.into())
+    }
+}
+
+impl From<String> for Interned<str> {
+    #[inline]
+    fn from(owned: String) -> Self {
+        Self(owned.into())
+    }
+}
+
+impl From<Cow<'static, str>> for Interned<str> {
+    #[inline]
+    fn from(string: Cow<'static, str>) -> Self {
+        Self(string.into())
+    }
+}
+
+#[cfg(feature = "bytes")]
+impl From<Vec<u8>> for Interned<[u8]> {
+    #[inline]
+    fn from(owned: Vec<u8>) -> Self {
+        Self(owned.into())
+    }
+}
+
+#[cfg(feature = "bytes")]
+impl From<Cow<'static, [u8]>> for Interned<[u8]> {
+    #[inline]
+    fn from(bytes: Cow<'static, [u8]>) -> Self {
+        Self(bytes.into())
+    }
+}
+
+impl<T> Interned<T>
+where
+    T: ?Sized,
+{
+    /// Return a reference to the inner slice.
+    #[inline]
+    pub fn as_slice(&self) -> &T {
+        self.0.as_slice()
+    }
+
+    /// Return a `'static` reference to the inner slice.
+    ///
+    /// # Safety
+    ///
+    /// This returns a reference with an unbounded lifetime. It is the caller's
+    /// responsibility to make sure it is not used after this `Slice` is
+    /// dropped.
+    #[inline]
+    pub unsafe fn as_static_slice(&self) -> &'static T {
+        self.0.as_static_slice()
+    }
+}
+
+impl<T> Default for Interned<T>
+where
+    T: ?Sized,
+    &'static T: Default,
+{
+    #[inline]
+    fn default() -> Self {
+        Self(Slice::default())
+    }
+}
+
+impl fmt::Debug for Interned<str> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self.0)
+    }
+}
+
+#[cfg(feature = "bytes")]
+impl fmt::Debug for Interned<[u8]> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self.0)
+    }
+}
+
+impl<T> Deref for Interned<T>
+where
+    T: ?Sized,
+{
+    type Target = T;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        self.as_slice()
+    }
+}
+
+impl<T> PartialEq<Interned<T>> for Interned<T>
+where
+    T: ?Sized + PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.as_slice() == other.as_slice()
+    }
+}
+
+impl<T> PartialEq<T> for Interned<T>
+where
+    T: ?Sized + PartialEq,
+{
+    fn eq(&self, other: &T) -> bool {
+        self.as_slice() == other
+    }
+}
+
+impl PartialEq<String> for Interned<str> {
+    fn eq(&self, other: &String) -> bool {
+        self.as_slice() == other
+    }
+}
+
+impl PartialEq<Interned<str>> for String {
+    fn eq(&self, other: &Interned<str>) -> bool {
+        self == other.as_slice()
+    }
+}
+
+#[cfg(feature = "bytes")]
+impl PartialEq<Vec<u8>> for Interned<[u8]> {
+    fn eq(&self, other: &Vec<u8>) -> bool {
+        self.as_slice() == other.as_slice()
+    }
+}
+
+#[cfg(feature = "bytes")]
+impl PartialEq<Interned<[u8]>> for Vec<u8> {
+    fn eq(&self, other: &Interned<[u8]>) -> bool {
+        self.as_slice() == other.as_slice()
+    }
+}
+
+impl<T> Eq for Interned<T> where T: ?Sized + PartialEq {}
+
+impl<T> Hash for Interned<T>
+where
+    T: ?Sized + Hash,
+{
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.as_slice().hash(state);
+    }
+}
+
+impl<T> Borrow<T> for Interned<T>
+where
+    T: ?Sized,
+{
+    fn borrow(&self) -> &T {
+        self.as_slice()
+    }
+}
+
+impl<T> Borrow<T> for &Interned<T>
+where
+    T: ?Sized,
+{
+    fn borrow(&self) -> &T {
+        self.as_slice()
+    }
+}
+
+impl<T> AsRef<T> for Interned<T>
+where
+    T: ?Sized,
+{
+    fn as_ref(&self) -> &T {
+        self.as_slice()
+    }
+}
+
+/// Wrapper around `&'static [u8]`.
+///
+/// # Safety
+///
+/// Even though `Box` is a "unique owner" of the data in the `Owned` varint, it
+/// should not be mutably dereferenced, because `as_static_slice` promises the
+/// slice to be valid as long as the `Slice` is not dropped.
+///
+/// This is achieved by not exposing the `Slice` enum directly and only allowing
+/// shared access to its internals.
+enum Slice<T: 'static + ?Sized> {
+    /// True `'static` references.
+    Static(&'static T),
+    /// Owned `'static` references.
+    Owned(Box<T>),
+}
+
+impl<T> From<&'static T> for Slice<T> {
+    #[inline]
+    fn from(slice: &'static T) -> Self {
+        Self::Static(slice)
+    }
+}
+
+impl From<String> for Slice<str> {
+    #[inline]
+    fn from(owned: String) -> Self {
+        Self::Owned(owned.into_boxed_str())
+    }
+}
+
+impl From<Cow<'static, str>> for Slice<str> {
+    #[inline]
+    fn from(string: Cow<'static, str>) -> Self {
+        match string {
+            Cow::Borrowed(slice) => Self::Static(slice),
+            Cow::Owned(owned) => owned.into(),
+        }
+    }
+}
+
+#[cfg(feature = "bytes")]
+impl From<Vec<u8>> for Slice<[u8]> {
+    #[inline]
+    fn from(owned: Vec<u8>) -> Self {
+        Self::Owned(owned.into_boxed_slice())
+    }
+}
+
+#[cfg(feature = "bytes")]
+impl From<Cow<'static, [u8]>> for Slice<[u8]> {
+    #[inline]
+    fn from(bytes: Cow<'static, [u8]>) -> Self {
+        match bytes {
+            Cow::Borrowed(slice) => Self::Static(slice),
+            Cow::Owned(owned) => owned.into(),
+        }
+    }
+}
+
+impl<T> Slice<T>
+where
+    T: ?Sized,
+{
+    /// Return a reference to the inner slice.
+    #[inline]
+    fn as_slice(&self) -> &T {
+        match self {
+            Self::Static(slice) => slice,
+            Self::Owned(owned) => &**owned,
+        }
+    }
+
+    /// Return a `'static` reference to the inner slice.
+    ///
+    /// # Safety
+    ///
+    /// This returns a reference with an unbounded lifetime. It is the caller's
+    /// responsibility to make sure it is not used after this `Slice` is
+    /// dropped.
+    #[inline]
+    unsafe fn as_static_slice(&self) -> &'static T {
+        match self {
+            Self::Static(slice) => slice,
+            #[allow(trivial_casts)]
+            Self::Owned(owned) => &*(&**owned as *const T),
+        }
+    }
+}
+
+impl<T> Default for Slice<T>
+where
+    T: ?Sized,
+    &'static T: Default,
+{
+    #[inline]
+    fn default() -> Self {
+        Self::Static(<_>::default())
+    }
+}
+
+impl fmt::Debug for Slice<str> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Static(_) => write!(f, "Static({:?})", self),
+            Self::Owned(_) => write!(f, "Owned({:?})", self),
+        }
+    }
+}
+
+#[cfg(feature = "bytes")]
+impl fmt::Debug for Slice<[u8]> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Static(_) => write!(f, "Static({:?})", String::from_utf8_lossy(self.as_slice())),
+            Self::Owned(_) => write!(f, "Owned({:?})", String::from_utf8_lossy(self.as_slice())),
+        }
+    }
+}
+
+impl<T> Deref for Slice<T>
+where
+    T: ?Sized,
+{
+    type Target = T;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        self.as_slice()
+    }
+}
+
+impl<T> PartialEq<Slice<T>> for Slice<T>
+where
+    T: ?Sized + PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.as_slice() == other.as_slice()
+    }
+}
+
+impl<T> PartialEq<T> for Slice<T>
+where
+    T: ?Sized + PartialEq,
+{
+    fn eq(&self, other: &T) -> bool {
+        self.as_slice() == other
+    }
+}
+
+impl PartialEq<String> for Slice<str> {
+    fn eq(&self, other: &String) -> bool {
+        self.as_slice() == other
+    }
+}
+
+impl PartialEq<Slice<str>> for String {
+    fn eq(&self, other: &Slice<str>) -> bool {
+        self == other.as_slice()
+    }
+}
+
+#[cfg(feature = "bytes")]
+impl PartialEq<Vec<u8>> for Slice<[u8]> {
+    fn eq(&self, other: &Vec<u8>) -> bool {
+        self.as_slice() == other.as_slice()
+    }
+}
+
+#[cfg(feature = "bytes")]
+impl PartialEq<Slice<[u8]>> for Vec<u8> {
+    fn eq(&self, other: &Slice<[u8]>) -> bool {
+        self.as_slice() == other.as_slice()
+    }
+}
+
+impl<T> Eq for Slice<T> where T: ?Sized + PartialEq {}
+
+impl<T> Hash for Slice<T>
+where
+    T: ?Sized + Hash,
+{
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.as_slice().hash(state);
+    }
+}
+
+impl<T> Borrow<T> for Slice<T>
+where
+    T: ?Sized,
+{
+    fn borrow(&self) -> &T {
+        self.as_slice()
+    }
+}
+
+impl<T> Borrow<T> for &Slice<T>
+where
+    T: ?Sized,
+{
+    fn borrow(&self) -> &T {
+        self.as_slice()
+    }
+}
+
+impl<T> AsRef<T> for Slice<T>
+where
+    T: ?Sized,
+{
+    fn as_ref(&self) -> &T {
+        self.as_slice()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,8 +59,7 @@
 //! All features are enabled by default.
 //!
 //! - **bytes** - Enables an additional symbol table implementation for
-//!   interning bytestrings (`Vec<u8>` and `&'static [u8]`). Disabling this
-//!   drops the `bstr` dependency.
+//!   interning bytestrings (`Vec<u8>` and `&'static [u8]`).
 
 #![doc(html_root_url = "https://docs.rs/intaglio/1.1.0")]
 
@@ -86,6 +85,7 @@ use std::error;
 
 #[cfg(feature = "bytes")]
 pub mod bytes;
+mod internal;
 mod str;
 
 pub use crate::str::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,9 +52,7 @@
 //! [`SymbolTable::shrink_to_fit`].
 //!
 //! [`SymbolTable::intern`] does not clone or copy interned strings. It takes
-//! ownership of the string contents with no additional allocations. Owned
-//! strings are leaked with [`Box::leak`] and recovered and deallocated when the
-//! table is dropped.
+//! ownership of the string contents with no additional allocations.
 //!
 //! # Crate features
 //!

--- a/src/str.rs
+++ b/src/str.rs
@@ -14,20 +14,39 @@ use std::collections::HashMap;
 
 use crate::{Symbol, SymbolOverflowError, DEFAULT_SYMBOL_TABLE_CAPACITY};
 
-/// Wrapper around `&'static str` that supports deallocating references created
-/// via [`Box::leak`].
+/// Wrapper around `&'static str`.
 ///
 /// # Safety
 ///
 /// Must not be `Clone` or `Copy` because the Drop logic assumes this enum is the
-/// unique owner of a leaked boxed slice. The lack of `Clone` and `Copy` impls is
-/// necessary to prevent double frees.
+/// unique owner of `&'static` references handed out with `as_static_slice`.
 #[derive(Debug)]
 enum Slice {
     /// True `'static` references.
     Static(&'static str),
     /// Owned `'static` references.
     Owned(Box<str>),
+}
+
+impl From<&'static str> for Slice {
+    fn from(string: &'static str) -> Self {
+        Self::Static(string)
+    }
+}
+
+impl From<String> for Slice {
+    fn from(string: String) -> Self {
+        Self::Owned(string.into_boxed_str())
+    }
+}
+
+impl From<Cow<'static, str>> for Slice {
+    fn from(string: Cow<'static, str>) -> Self {
+        match string {
+            Cow::Borrowed(string) => string.into(),
+            Cow::Owned(string) => string.into(),
+        }
+    }
 }
 
 impl Slice {
@@ -39,13 +58,13 @@ impl Slice {
         }
     }
 
-    /// Return a reference to the inner slice.
+    /// Return a `'static` reference to the inner slice.
     ///
     /// # Safety
     ///
-    /// This returns a reference with an unbounded lifetime.
-    /// It is your responsibility to make sure it is not used
-    /// after this `Slice` is dropped.
+    /// This returns a reference with an unbounded lifetime. It is the caller's
+    /// responsibility to make sure it is not used after this `Slice` is
+    /// dropped.
     unsafe fn as_static_slice(&self) -> &'static str {
         match self {
             Self::Static(global) => global,
@@ -741,23 +760,6 @@ impl<S> SymbolTable<S> {
     pub fn strings(&self) -> Strings<'_> {
         Strings(self.vec.iter())
     }
-
-    /// Transform owned String into a leaked boxed slice and return the
-    /// resulting `'static` reference which is suitable for storing in the list
-    /// of symbols.
-    ///
-    /// The reference is wrapped in a `Slice::Owned` which will convert the
-    /// reference back into a `Box` to be deallocated on `drop`.
-    ///
-    /// # Safety
-    ///
-    /// This function is not marked unsafe because the only side effect is
-    /// leaking memory. Memory leaks are not unsafe.
-    #[must_use]
-    fn alloc(contents: String) -> Slice {
-        let boxed_slice = contents.into_boxed_str();
-        Slice::Owned(boxed_slice)
-    }
 }
 
 impl<S> SymbolTable<S>
@@ -803,10 +805,7 @@ where
         if let Some(&id) = self.map.get(contents.as_ref()) {
             return Ok(id);
         }
-        let name = match contents {
-            Cow::Borrowed(contents) => Slice::Static(contents),
-            Cow::Owned(contents) => Self::alloc(contents),
-        };
+        let name = Slice::from(contents);
         let id = self.map.len().try_into()?;
         let slice = unsafe { name.as_static_slice() };
 

--- a/src/str.rs
+++ b/src/str.rs
@@ -2,19 +2,20 @@
 
 use core::cmp;
 use core::convert::TryInto;
-use core::hash::{BuildHasher, Hash};
+use core::hash::BuildHasher;
 use core::iter::{self, FusedIterator};
 use core::marker::PhantomData;
-use core::ops::{Deref, Range, RangeInclusive};
+use core::ops::{Range, RangeInclusive};
 use core::slice;
 use std::borrow::Cow;
-use std::collections::hash_map::RandomState;
-use std::collections::HashMap;
+use std::collections::hash_map::{HashMap, RandomState};
 
 use crate::internal::Interned;
 use crate::{Symbol, SymbolOverflowError, DEFAULT_SYMBOL_TABLE_CAPACITY};
 
 /// An iterator over all [`Symbol`]s in a [`SymbolTable`].
+///
+/// See the [`all_symbols`](SymbolTable::all_symbols) method in [`SymbolTable`].
 ///
 /// # Usage
 ///
@@ -114,6 +115,8 @@ impl<'a> FusedIterator for AllSymbols<'a> {}
 
 /// An iterator over all interned strings in a [`SymbolTable`].
 ///
+/// See the [`strings`](SymbolTable::strings) method in [`SymbolTable`].
+///
 /// # Usage
 ///
 /// ```
@@ -134,7 +137,7 @@ impl<'a> Iterator for Strings<'a> {
     type Item = &'a str;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.0.next().map(Deref::deref)
+        self.0.next().map(Interned::as_slice)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -152,28 +155,28 @@ impl<'a> Iterator for Strings<'a> {
     where
         Self: Sized,
     {
-        self.0.last().map(Deref::deref)
+        self.0.last().map(Interned::as_slice)
     }
 
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
-        self.0.nth(n).map(Deref::deref)
+        self.0.nth(n).map(Interned::as_slice)
     }
 
     fn collect<B: iter::FromIterator<Self::Item>>(self) -> B
     where
         Self: Sized,
     {
-        self.0.map(Deref::deref).collect()
+        self.0.map(Interned::as_slice).collect()
     }
 }
 
 impl<'a> DoubleEndedIterator for Strings<'a> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        self.0.next_back().map(Deref::deref)
+        self.0.next_back().map(Interned::as_slice)
     }
 
     fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
-        self.0.nth_back(n).map(Deref::deref)
+        self.0.nth_back(n).map(Interned::as_slice)
     }
 
     fn rfold<B, F>(self, accum: B, f: F) -> B
@@ -181,7 +184,7 @@ impl<'a> DoubleEndedIterator for Strings<'a> {
         Self: Sized,
         F: FnMut(B, Self::Item) -> B,
     {
-        self.0.map(Deref::deref).rfold(accum, f)
+        self.0.map(Interned::as_slice).rfold(accum, f)
     }
 }
 
@@ -194,6 +197,8 @@ impl<'a> ExactSizeIterator for Strings<'a> {
 impl<'a> FusedIterator for Strings<'a> {}
 
 /// An iterator over all symbols and interned strings in a [`SymbolTable`].
+///
+/// See the [`iter`](SymbolTable::iter) method in [`SymbolTable`].
 ///
 /// # Usage
 ///


### PR DESCRIPTION
Followup to GH-28.

This decreases the scope of the `bstr` dependency quite a bit which makes it feasible to hide it behind another feature flag.

Thanks for your work on GH-28 @CAD97. I won't block on you taking a look at this, but I would appreciate it if you could leave a comment about whether you feel this followup is sufficient.