### PR TITLE
Rename clippy::identity_conversion lint allow

### DIFF
--- a/tests/leak/mod.rs
+++ b/tests/leak/mod.rs
@@ -61,7 +61,7 @@ impl<'a, T> Looper<'a, T> {
 }
 
 #[cfg(target_os = "linux")]
-#[allow(clippy::identity_conversion)]
+#[allow(clippy::useless_conversion)]
 fn resident_memsize() -> i64 {
     let mut out = MaybeUninit::<libc::rusage>::uninit();
     assert!(unsafe { libc::getrusage(libc::RUSAGE_SELF, out.as_mut_ptr()) } == 0);


### PR DESCRIPTION
`clippy::identity_conversion` has been renamed in Rust 1.45.0 to
`clippy::useless_conversion`.

Fixes this warning (which is upgraded to an error in CI):

```
warning: lint `clippy::identity_conversion` has been renamed to `clippy::useless_conversion`
  --> tests/leak/mod.rs:64:9
   |
64 | #[allow(clippy::identity_conversion)]
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `clippy::useless_conversion`
```

This was caught by the scheduled CI run.