### PR TITLE
Release v1.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "intaglio"
-version = "1.1.0"
+version = "1.1.1"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2018"
 description = "UTF-8 string and bytestring interner and symbol table"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@
 //! - **bytes** - Enables an additional symbol table implementation for
 //!   interning bytestrings (`Vec<u8>` and `&'static [u8]`).
 
-#![doc(html_root_url = "https://docs.rs/intaglio/1.1.0")]
+#![doc(html_root_url = "https://docs.rs/intaglio/1.1.1")]
 
 // Ensure code blocks in README.md compile
 #[cfg(doctest)]


### PR DESCRIPTION
Release 1.1.1 of intaglio.

[`intaglio` is available on crates.io](https://crates.io/crates/intaglio).

## Improvements

- Remove dependency on [`bstr`]. `intaglio` now has zero runtime dependencies outside of `std. (GH-29).
- Reduce `unsafe` usage in crate internals. (GH-28, GH-31)
- More aggressive inlining. (GH-30)
- Optional UTF-8 formatting of `bytes::SymbolTable` when supplying the alternate format specifier `{:#}`. (GH-32)

This release contains improvements to documentation and build process.

[`bstr`]: https://crates.io/crates/bstr