### PR TITLE
Prepare for v1.2.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "intaglio"
-version = "1.1.1"
+version = "1.2.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2018"
 description = "UTF-8 string and bytestring interner and symbol table"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-intaglio = "1.1"
+intaglio = "1.2"
 ```
 
 Then intern UTF-8 strings like:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@
 //! - **bytes** - Enables an additional symbol table implementation for
 //!   interning bytestrings (`Vec<u8>` and `&'static [u8]`).
 
-#![doc(html_root_url = "https://docs.rs/intaglio/1.1.1")]
+#![doc(html_root_url = "https://docs.rs/intaglio/1.2.0")]
 
 // Ensure code blocks in README.md compile
 #[cfg(doctest)]


### PR DESCRIPTION
Release 1.2.0 of intaglio.

[`intaglio` is available on crates.io](https://crates.io/crates/intaglio/1.2.0).

## Minimum Rust Version

`intaglio` requires Rust 1.46.0 to build because the crate makes use of [`match` in const fn](https://blog.rust-lang.org/2020/08/27/Rust-1.46.0.html#const-fn-improvements).

## Improvements

- Add more `From` and `PartialEq` implementations for `Symbol`. (GH-38)
- Modify `SymbolOverflowError` so it is a zero-sized type. (GH-39)
- Make `SymbolOverflowError::new` const. (GH-39)
- Make `SymbolOverflowError::max_capacity` const. (GH-39)
- Make `Symbol::new` const. (GH-40)
- Make `Symbol::id` const. (GH-40)
- Make internal `Slice::as_slice` and `Interned::as_slice` const. (GH-40)
- Remove `libc` dev-dependency. (GH-49)

This release contains improvements to documentation and build process:

- Miri tests are updated for latest nightly `cargo-miri`. (GH-46)
- The test suite is run with LeakSanitizer. (GH-47, GH-49)

`intaglio` < 1.1.1 improperly declared the minimal versions of its dependencies. `intaglio` 1.2.0 has no dependencies. Using `1.2` as a minimal version is safe and is recommended in the README.