### PR TITLE
Remove Zlib as an allowed license from cargo-deny config

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -9,7 +9,6 @@ unlicensed = "deny"
 allow = [
   "Apache-2.0",
   "MIT",
-  "Zlib",
 ]
 deny = []
 copyleft = "deny"


### PR DESCRIPTION
TinyVec relicensed to include an MIT option in Lokathor/tinyvec#81.