### PR TITLE
Suppress clippy::missing_panic_doc for debug_assert false positive in 1.51.0

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -683,6 +683,7 @@ where
     /// # }
     /// # example().unwrap();
     /// ```
+    #[allow(clippy::missing_panics_doc)] // clippy in 1.51.0 gives a false positive on `debug_assert!`.
     pub fn intern<T>(&mut self, contents: T) -> Result<Symbol, SymbolOverflowError>
     where
         T: Into<Cow<'static, [u8]>>,

--- a/src/str.rs
+++ b/src/str.rs
@@ -628,6 +628,7 @@ where
     /// # }
     /// # example().unwrap();
     /// ```
+    #[allow(clippy::missing_panics_doc)] // clippy in 1.51.0 gives a false positive on `debug_assert!`.
     pub fn intern<T>(&mut self, contents: T) -> Result<Symbol, SymbolOverflowError>
     where
         T: Into<Cow<'static, str>>,


### PR DESCRIPTION
- https://github.com/rust-lang/rust-clippy/issues/6970
- https://github.com/rust-lang/rust-clippy/issues/6739