### PR TITLE
Add callouts to generated documentation for the `bytes` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,9 @@ quickcheck_macros = "1.0"
 # Check that crate versions are properly updated in documentation and code when
 # bumping the version.
 version-sync = "0.9, >= 0.9.2"
+
+[package.metadata.docs.rs]
+# This sets the default target to `x86_64-unknown-linux-gnu` and only builds
+# that target. `intaglio` has the same API and code on all targets.
+targets = ["x86_64-unknown-linux-gnu"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -81,6 +81,7 @@ use crate::{Symbol, SymbolOverflowError, DEFAULT_SYMBOL_TABLE_CAPACITY};
 /// # example().unwrap();
 /// ```
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
+#[cfg_attr(docsrs, doc(cfg(feature = "bytes")))]
 pub struct AllSymbols<'a> {
     // this Result is being used as an Either type.
     range: Result<Range<u32>, RangeInclusive<u32>>,
@@ -172,6 +173,7 @@ impl<'a> FusedIterator for AllSymbols<'a> {}
 /// # example().unwrap();
 /// ```
 #[derive(Debug, Clone)]
+#[cfg_attr(docsrs, doc(cfg(feature = "bytes")))]
 pub struct Bytestrings<'a>(slice::Iter<'a, Interned<[u8]>>);
 
 impl<'a> Iterator for Bytestrings<'a> {
@@ -249,6 +251,7 @@ impl<'a> FusedIterator for Bytestrings<'a> {}
 /// # example().unwrap();
 /// ```
 #[derive(Debug, Clone)]
+#[cfg_attr(docsrs, doc(cfg(feature = "bytes")))]
 pub struct Iter<'a>(iter::Zip<AllSymbols<'a>, Bytestrings<'a>>);
 
 impl<'a> Iterator for Iter<'a> {
@@ -312,6 +315,7 @@ impl<'a> IntoIterator for &'a SymbolTable {
 /// # example().unwrap();
 /// ```
 #[derive(Default, Debug)]
+#[cfg_attr(docsrs, doc(cfg(feature = "bytes")))]
 pub struct SymbolTable<S = RandomState> {
     map: HashMap<&'static [u8], Symbol, S>,
     vec: Vec<Interned<[u8]>>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,12 @@
 #![warn(trivial_casts, trivial_numeric_casts)]
 #![warn(unused_qualifications)]
 #![warn(variant_size_differences)]
+// Enable feature callouts in generated documentation:
+// https://doc.rust-lang.org/beta/unstable-book/language-features/doc-cfg.html
+//
+// This approach is borrowed from tokio.
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_alias))]
 
 //! This crate provides a library for interning strings.
 //!
@@ -84,6 +90,7 @@ use core::num::TryFromIntError;
 use std::error;
 
 #[cfg(feature = "bytes")]
+#[cfg_attr(docsrs, doc(cfg(feature = "bytes")))]
 pub mod bytes;
 mod convert;
 mod eq;


### PR DESCRIPTION
The `bytes` module, its `SymbolTable`, and iterators are only available
when `intaglio`'s `bytes` Cargo feature is activated. Add callouts to
generated rustdoc documentation about this feature using the `doc_cfg`
attribute.

This commit also sets configuration for docs.rs to build Intaglio
rustdoc with the `docsrs` cfg flag set.

This approach is widely used in the spinoso family of crates.