### PR TITLE
Prepare for v1.2.2 release on crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "intaglio"
-version = "1.2.1" # remember to set `html_root_url` in `src/lib.rs`.
+version = "1.2.2" # remember to set `html_root_url` in `src/lib.rs`.
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "MIT"
 edition = "2018"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,7 @@
 //! - **bytes** - Enables an additional symbol table implementation for
 //!   interning bytestrings (`Vec<u8>` and `&'static [u8]`).
 
-#![doc(html_root_url = "https://docs.rs/intaglio/1.2.1")]
+#![doc(html_root_url = "https://docs.rs/intaglio/1.2.2")]
 
 // Ensure code blocks in README.md compile
 #[cfg(doctest)]


### PR DESCRIPTION
Release 1.2.2 of intaglio.

[`intaglio` is available on crates.io](https://crates.io/crates/intaglio/1.2.2).

This release adds feature callouts to the generated documentation on docs.rs using `doc_cfg` #75.

No Rust logic changed in this release.