### PR TITLE
Speed up drop tests under miri

### DIFF
--- a/.github/workflows/miri.yaml
+++ b/.github/workflows/miri.yaml
@@ -32,4 +32,4 @@ jobs:
         run: cargo miri setup
 
       - name: Test unsafe code with Miri
-        run: cargo miri test drop
+        run: cargo miri test --test leak_drop_symbol_table --test leak_drop_symbol_table_bytes

--- a/tests/leak_drop_symbol_table.rs
+++ b/tests/leak_drop_symbol_table.rs
@@ -4,7 +4,10 @@
 use core::iter;
 use intaglio::SymbolTable;
 
+#[cfg(not(miri))]
 const ITERATIONS: usize = 100_000;
+#[cfg(miri)]
+const ITERATIONS: usize = 25;
 
 #[test]
 fn dealloc_owned_data_str() {

--- a/tests/leak_drop_symbol_table_bytes.rs
+++ b/tests/leak_drop_symbol_table_bytes.rs
@@ -5,7 +5,10 @@
 use core::iter;
 use intaglio::bytes::SymbolTable;
 
+#[cfg(not(miri))]
 const ITERATIONS: usize = 100_000;
+#[cfg(miri)]
+const ITERATIONS: usize = 25;
 
 #[test]
 fn dealloc_owned_data_bytes() {


### PR DESCRIPTION
Lots of allocations are expensive under miri, so drop the iteration count from 100k to 25.