### PR TITLE
Incrementally improve crate quality

### DIFF
--- a/src/convert.rs
+++ b/src/convert.rs
@@ -1,4 +1,5 @@
 use core::convert::TryFrom;
+use core::mem::size_of;
 use core::num::{NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize};
 
 use crate::{Symbol, SymbolOverflowError};
@@ -185,7 +186,9 @@ impl From<Symbol> for usize {
     #[inline]
     fn from(sym: Symbol) -> Self {
         // This conversion relies on size_of::<usize>() >= size_of::<u32>(),
-        // which is ensured with a const assertion in `lib.rs`.
+        // which is ensured with a const assertion.
+        const _: () = [()][!(size_of::<usize>() >= size_of::<u32>()) as usize];
+
         sym.id() as usize
     }
 }
@@ -214,6 +217,10 @@ impl From<&Symbol> for u64 {
 impl From<&Symbol> for usize {
     #[inline]
     fn from(sym: &Symbol) -> Self {
+        // This conversion relies on size_of::<usize>() >= size_of::<u32>(),
+        // which is ensured with a const assertion.
+        const _: () = [()][!(size_of::<usize>() >= size_of::<u32>()) as usize];
+
         sym.id() as usize
     }
 }

--- a/src/str.rs
+++ b/src/str.rs
@@ -1,10 +1,10 @@
 //! Intaglio interner for UTF-8 [`String`]s.
 
-use core::cmp;
 use core::convert::TryInto;
 use core::hash::BuildHasher;
-use core::iter::{self, FusedIterator};
+use core::iter::{FromIterator, FusedIterator, Zip};
 use core::marker::PhantomData;
+use core::mem::ManuallyDrop;
 use core::ops::{Range, RangeInclusive};
 use core::slice;
 use std::borrow::Cow;
@@ -78,7 +78,7 @@ impl<'a> Iterator for AllSymbols<'a> {
         }
     }
 
-    fn collect<B: iter::FromIterator<Self::Item>>(self) -> B {
+    fn collect<B: FromIterator<Self::Item>>(self) -> B {
         match self.range {
             Ok(range) => range.map(Symbol::from).collect(),
             Err(range) => range.map(Symbol::from).collect(),
@@ -147,7 +147,7 @@ impl<'a> Iterator for Strings<'a> {
         self.0.nth(n).map(Interned::as_slice)
     }
 
-    fn collect<B: iter::FromIterator<Self::Item>>(self) -> B {
+    fn collect<B: FromIterator<Self::Item>>(self) -> B {
         self.0.map(Interned::as_slice).collect()
     }
 }
@@ -198,7 +198,7 @@ impl<'a> FusedIterator for Strings<'a> {}
 /// # example().unwrap();
 /// ```
 #[derive(Debug, Clone)]
-pub struct Iter<'a>(iter::Zip<AllSymbols<'a>, Strings<'a>>);
+pub struct Iter<'a>(Zip<AllSymbols<'a>, Strings<'a>>);
 
 impl<'a> Iterator for Iter<'a> {
     type Item = (Symbol, &'a str);
@@ -223,7 +223,7 @@ impl<'a> Iterator for Iter<'a> {
         self.0.nth(n)
     }
 
-    fn collect<B: iter::FromIterator<Self::Item>>(self) -> B {
+    fn collect<B: FromIterator<Self::Item>>(self) -> B {
         self.0.collect()
     }
 }
@@ -262,8 +262,26 @@ impl<'a> IntoIterator for &'a SymbolTable {
 /// ```
 #[derive(Default, Debug)]
 pub struct SymbolTable<S = RandomState> {
-    map: HashMap<&'static str, Symbol, S>,
-    vec: Vec<Interned<str>>,
+    map: ManuallyDrop<HashMap<&'static str, Symbol, S>>,
+    vec: ManuallyDrop<Vec<Interned<str>>>,
+}
+
+impl<S> Drop for SymbolTable<S> {
+    fn drop(&mut self) {
+        // Safety:
+        //
+        // `Interned` requires that the `'static` references it gives out are
+        // dropped before the owning buffer stored in the `Interned`.
+        //
+        // `ManuallyDrop::drop` is only invoked in this `Drop::drop` impl;
+        // because mutable references to `map` and `vec` fields are not given
+        // out by `SymbolTable`, `map` and `vec` are guaranteed to be
+        // initialized.
+        unsafe {
+            ManuallyDrop::drop(&mut self.map);
+            ManuallyDrop::drop(&mut self.vec);
+        }
+    }
 }
 
 impl SymbolTable<RandomState> {
@@ -301,8 +319,8 @@ impl SymbolTable<RandomState> {
     pub fn with_capacity(capacity: usize) -> Self {
         let capacity = capacity.next_power_of_two();
         Self {
-            map: HashMap::with_capacity(capacity),
-            vec: Vec::with_capacity(capacity),
+            map: ManuallyDrop::new(HashMap::with_capacity(capacity)),
+            vec: ManuallyDrop::new(Vec::with_capacity(capacity)),
         }
     }
 }
@@ -341,8 +359,8 @@ impl<S> SymbolTable<S> {
     /// ```
     pub fn with_capacity_and_hasher(capacity: usize, hash_builder: S) -> Self {
         Self {
-            vec: Vec::with_capacity(capacity),
-            map: HashMap::with_capacity_and_hasher(capacity, hash_builder),
+            map: ManuallyDrop::new(HashMap::with_capacity_and_hasher(capacity, hash_builder)),
+            vec: ManuallyDrop::new(Vec::with_capacity(capacity)),
         }
     }
 
@@ -357,7 +375,7 @@ impl<S> SymbolTable<S> {
     /// assert!(table.capacity() >= 10);
     /// ```
     pub fn capacity(&self) -> usize {
-        cmp::min(self.vec.capacity(), self.map.capacity())
+        usize::min(self.vec.capacity(), self.map.capacity())
     }
 
     /// Returns the number of interned bytestrings in the table.
@@ -639,6 +657,19 @@ where
         }
         let name = Interned::from(contents);
         let id = self.map.len().try_into()?;
+        // Safety:
+        //
+        // This expression creates a reference with a `'static` lifetime
+        // from an owned and interned buffer. This is permissible because:
+        //
+        // - `Interned` is an internal implementation detail of `SymbolTable`.
+        // - `SymbolTable` never give out `'static` references to underlying
+        //   byte contents.
+        // - All slice references given out by the `SymbolTable` have the same
+        //   lifetime as the `SymbolTable`.
+        // - The `map` field of `SymbolTable`, which contains the `'static`
+        //   references, is dropped before the owned buffers stored in this
+        //   `Interned`.
         let slice = unsafe { name.as_static_slice() };
 
         self.map.insert(slice, id);
@@ -725,8 +756,8 @@ where
     /// # example().unwrap();
     /// ```
     pub fn reserve(&mut self, additional: usize) {
-        self.vec.reserve(additional);
         self.map.reserve(additional);
+        self.vec.reserve(additional);
     }
 
     /// Shrinks the capacity of the symbol table as much as possible.
@@ -751,8 +782,8 @@ where
     /// # example().unwrap();
     /// ```
     pub fn shrink_to_fit(&mut self) {
-        self.vec.shrink_to_fit();
         self.map.shrink_to_fit();
+        self.vec.shrink_to_fit();
     }
 }
 


### PR DESCRIPTION
- Add safety comments for implementation and usage of `Interned::as_static_slice`.
- Import all traits and structs from `core::iter` to avoid prefixing items with the module name to improve readability.
- Reorder statements in `str::SymbolTable` and `bytes::SymbolTable` to always access or modify the `map` field first for consistency.
- Remove `core::cmp` import from `str::SymbolTable` and `bytes::SymbolTable` (use `usize::cmp` with associated function syntax for the same amount of clarity).
- Add inline anonymous const assertions for `size_of<usize> > size_of<u32>` in `From` impls that rely on it for local consistency instead of relying on an assertion in the crate root.
- Remove `allow(trivial_casts)` on the core unsafe code in `intaglio`. Expand the trival cast, document what the intended steps are by expanding into multiple lines, and add a big safety comment.
- Ensure the drop order of `SymbolTable`'s fields upholds `Interned`'s safety invariants.