### PR TITLE
Make `Symbol` repr(transparent)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "intaglio"
-version = "1.2.2" # remember to set `html_root_url` in `src/lib.rs`.
+version = "1.3.0" # remember to set `html_root_url` in `src/lib.rs`.
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "MIT"
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-intaglio = "1.2"
+intaglio = "1.3"
 ```
 
 Then intern UTF-8 strings like:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,7 @@
 //! - **bytes** - Enables an additional symbol table implementation for
 //!   interning bytestrings (`Vec<u8>` and `&'static [u8]`).
 
-#![doc(html_root_url = "https://docs.rs/intaglio/1.2.2")]
+#![doc(html_root_url = "https://docs.rs/intaglio/1.3.0")]
 
 // Ensure code blocks in README.md compile
 #[cfg(doctest)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,6 +165,7 @@ impl error::Error for SymbolOverflowError {}
 /// `Symbol`s are not constrained to the `SymbolTable` which created them.  No
 /// runtime checks ensure that [`SymbolTable::get`] is called with a `Symbol`
 /// that the table itself issued.
+#[repr(transparent)]
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Symbol(u32);
 


### PR DESCRIPTION
bump crate version to 1.3.0 and prepare for release.