### PR TITLE
Remove allow pragmas for `clippy::missing_panics_docs`

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -705,7 +705,6 @@ where
     /// # }
     /// # example().unwrap();
     /// ```
-    #[allow(clippy::missing_panics_doc)] // clippy in 1.51.0 gives a false positive on `debug_assert!`.
     pub fn intern<T>(&mut self, contents: T) -> Result<Symbol, SymbolOverflowError>
     where
         T: Into<Cow<'static, [u8]>>,

--- a/src/str.rs
+++ b/src/str.rs
@@ -646,7 +646,6 @@ where
     /// # }
     /// # example().unwrap();
     /// ```
-    #[allow(clippy::missing_panics_doc)] // clippy in 1.51.0 gives a false positive on `debug_assert!`.
     pub fn intern<T>(&mut self, contents: T) -> Result<Symbol, SymbolOverflowError>
     where
         T: Into<Cow<'static, str>>,


### PR DESCRIPTION
This false positive was addressed in rust-lang/rust-clippy#6996.

This rolls back the `allow` introduced in https://github.com/artichoke/intaglio/pull/67.