### PR TITLE
Warn on unsafe_op_in_unsafe_fn

### DIFF
--- a/src/internal.rs
+++ b/src/internal.rs
@@ -70,7 +70,11 @@ where
     /// inner `Slice` is dropped.
     #[inline]
     pub unsafe fn as_static_slice(&self) -> &'static T {
-        self.0.as_static_slice()
+        // Safety:
+        //
+        // `Interned::as_static_slice`'s caller upheld safety invariants are the
+        // same as `Slice::as_static_slice`'s caller upheld safety invariants.
+        unsafe { self.0.as_static_slice() }
     }
 }
 
@@ -314,7 +318,7 @@ where
                 // - The `map` field of `SymbolTable` and `bytes::SymbolTable`,
                 //   which contains the `'static` references, is dropped before
                 //   the owned buffers stored in this `Slice`.
-                &*ptr
+                unsafe { &*ptr }
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 #![warn(missing_docs)]
 #![warn(rust_2018_idioms)]
 #![warn(trivial_casts, trivial_numeric_casts)]
+#![warn(unsafe_op_in_unsafe_fn)]
 #![warn(unused_qualifications)]
 #![warn(variant_size_differences)]
 // Enable feature callouts in generated documentation:


### PR DESCRIPTION
Add a pragma to the crate root to require unsafe operations inside
`unsafe fn` to be wrapped in an unsafe block.

This adds one additional safety comment where one was missing.