### PR TITLE
Fix spelling mistakes in docs: s/bytestring/byte string/g

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 repository = "https://github.com/artichoke/intaglio"
 documentation = "https://docs.rs/intaglio"
 homepage = "https://github.com/artichoke/intaglio"
-description = "UTF-8 string and bytestring interner and symbol table"
+description = "UTF-8 string and byte string interner and symbol table"
 keywords = ["bytestring", "intern", "interner", "symbol", "utf8"]
 categories = ["caching", "data-structures"]
 include = ["src/**/*", "tests/**/*", "LICENSE", "README.md"]
@@ -18,7 +18,7 @@ include = ["src/**/*", "tests/**/*", "LICENSE", "README.md"]
 # All features are enabled by default.
 default = ["bytes"]
 # `bytes` feature enables an additional symbol table implementation for
-# interning bytestrings (`Vec<u8>` and `&'static [u8]`).
+# interning byte strings (`Vec<u8>` and `&'static [u8]`).
 bytes = []
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 [![API](https://docs.rs/intaglio/badge.svg)](https://docs.rs/intaglio)
 [![API trunk](https://img.shields.io/badge/docs-trunk-blue.svg)](https://artichoke.github.io/intaglio/intaglio/)
 
-UTF-8 string and bytestring interner and symbol table. Used to implement storage
-for the [Ruby `Symbol`][symbol] table and the constant name table in [Artichoke
-Ruby][artichoke].
+UTF-8 string and byte string interner and symbol table. Used to implement
+storage for the [Ruby `Symbol`][symbol] table and the constant name table in
+[Artichoke Ruby][artichoke].
 
 > Symbol objects represent names and some strings inside the Ruby interpreter.
 > They are generated using the `:name` and `:"string"` literals syntax, and by
@@ -18,11 +18,11 @@ Ruby][artichoke].
 > given name or string for the duration of a program's execution, regardless of
 > the context or meaning of that name.
 
-Intaglio is a UTF-8 and bytestring interner, which means it stores a single copy
-of an immutable `&str` or `&[u8]` that can be referred to by a stable `u32`
+Intaglio is a UTF-8 and byte string interner, which means it stores a single
+copy of an immutable `&str` or `&[u8]` that can be referred to by a stable `u32`
 token.
 
-Interned strings and bytestrings are cheap to compare and copy because they are
+Interned strings and byte strings are cheap to compare and copy because they are
 represented as a `u32` integer.
 
 _Intaglio_ is an alternate name for an _engraved gem_, a gemstone that has been
@@ -52,7 +52,7 @@ fn intern_and_get() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
-Or intern bytestrings like:
+Or intern byte strings like:
 
 ```rust
 fn intern_and_get() -> Result<(), Box<dyn std::error::Error>> {
@@ -77,7 +77,7 @@ LeakSanitizer.
 All features are enabled by default.
 
 - **bytes** - Enables an additional symbol table implementation for interning
-  bytestrings (`Vec<u8>` and `&'static [u8]`).
+  byte strings (`Vec<u8>` and `&'static [u8]`).
 
 ### Minimum Supported Rust Version
 

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -6,7 +6,7 @@
 //! 1. Interned contents are `&[u8]` instead of `&str`. Additionally, `Vec<u8>`
 //!    is used where `String` would have been used.
 //!
-//! # Example: intern bytestring
+//! # Example: intern byte string
 //!
 //! ```
 //! # use intaglio::bytes::SymbolTable;
@@ -155,7 +155,7 @@ impl<'a> DoubleEndedIterator for AllSymbols<'a> {
 
 impl<'a> FusedIterator for AllSymbols<'a> {}
 
-/// An iterator over all interned bytestrings in a [`SymbolTable`].
+/// An iterator over all interned byte strings in a [`SymbolTable`].
 ///
 /// See the [`bytestrings`](SymbolTable::bytestrings) method in [`SymbolTable`].
 ///
@@ -229,7 +229,7 @@ impl<'a> ExactSizeIterator for Bytestrings<'a> {
 
 impl<'a> FusedIterator for Bytestrings<'a> {}
 
-/// An iterator over all symbols and interned bytestrings in a [`SymbolTable`].
+/// An iterator over all symbols and interned byte strings in a [`SymbolTable`].
 ///
 /// See the [`iter`](SymbolTable::iter) method in [`SymbolTable`].
 ///
@@ -295,7 +295,7 @@ impl<'a> IntoIterator for &'a SymbolTable {
 
 /// Byte string interner.
 ///
-/// This symbol table is implemented by storing bytestrings with a fast path for
+/// This symbol table is implemented by storing byte strings with a fast path for
 /// `&[u8]` that are already `'static`.
 ///
 /// See module documentation for more.
@@ -358,7 +358,7 @@ impl SymbolTable<RandomState> {
 
     /// Constructs a new, empty `SymbolTable` with the specified capacity.
     ///
-    /// The symbol table will be able to hold at least `capacity` bytestrings
+    /// The symbol table will be able to hold at least `capacity` byte strings
     /// without reallocating. If `capacity` is 0, the symbol table will not
     /// allocate.
     ///
@@ -419,7 +419,7 @@ impl<S> SymbolTable<S> {
         }
     }
 
-    /// Returns the number of bytestrings the table can hold without
+    /// Returns the number of byte strings the table can hold without
     /// reallocating.
     ///
     /// # Examples
@@ -433,7 +433,7 @@ impl<S> SymbolTable<S> {
         usize::min(self.vec.capacity(), self.map.capacity())
     }
 
-    /// Returns the number of interned bytestrings in the table.
+    /// Returns the number of interned byte strings in the table.
     ///
     /// # Examples
     ///
@@ -444,7 +444,7 @@ impl<S> SymbolTable<S> {
     /// assert_eq!(0, table.len());
     ///
     /// table.intern(b"abc".to_vec())?;
-    /// // only uniquely interned bytestrings grow the symbol table.
+    /// // only uniquely interned byte strings grow the symbol table.
     /// table.intern(b"abc".to_vec())?;
     /// table.intern(b"xyz".to_vec())?;
     /// assert_eq!(2, table.len());
@@ -456,7 +456,7 @@ impl<S> SymbolTable<S> {
         self.vec.len()
     }
 
-    /// Returns `true` if the symbol table contains no interned bytestrings.
+    /// Returns `true` if the symbol table contains no interned byte strings.
     ///
     /// # Examples
     ///
@@ -528,7 +528,7 @@ impl<S> SymbolTable<S> {
         Some(bytes.as_slice())
     }
 
-    /// Returns an iterator over all [`Symbol`]s and bytestrings in the
+    /// Returns an iterator over all [`Symbol`]s and byte strings in the
     /// [`SymbolTable`].
     ///
     /// # Examples
@@ -628,7 +628,7 @@ impl<S> SymbolTable<S> {
         }
     }
 
-    /// Returns an iterator over all bytestrings in the [`SymbolTable`].
+    /// Returns an iterator over all byte strings in the [`SymbolTable`].
     ///
     /// # Examples
     ///
@@ -674,10 +674,10 @@ impl<S> SymbolTable<S>
 where
     S: BuildHasher,
 {
-    /// Intern a bytestring for the lifetime of the symbol table.
+    /// Intern a byte string for the lifetime of the symbol table.
     ///
     /// The returned `Symbol` allows retrieving of the underlying bytes.
-    /// Equal bytestrings will be inserted into the symbol table exactly once.
+    /// Equal byte strings will be inserted into the symbol table exactly once.
     ///
     /// This function only allocates if the underlying symbol table has no
     /// remaining capacity.
@@ -685,7 +685,7 @@ where
     /// # Errors
     ///
     /// If the symbol table would grow larger than `u32::MAX` interned
-    /// bytestrings, the [`Symbol`] counter would overflow and a
+    /// byte strings, the [`Symbol`] counter would overflow and a
     /// [`SymbolOverflowError`] is returned.
     ///
     /// # Examples
@@ -971,13 +971,13 @@ mod tests {
     }
 
     #[quickcheck]
-    fn empty_table_does_not_report_any_interned_bytestrings(bytes: Vec<u8>) -> bool {
+    fn empty_table_does_not_report_any_interned_byte_strings(bytes: Vec<u8>) -> bool {
         let table = SymbolTable::new();
         !table.is_interned(bytes.as_slice())
     }
 
     #[quickcheck]
-    fn table_reports_interned_bytestrings_as_interned(bytes: Vec<u8>) -> bool {
+    fn table_reports_interned_byte_strings_as_interned(bytes: Vec<u8>) -> bool {
         let mut table = SymbolTable::new();
         table.intern(bytes.clone()).unwrap();
         table.is_interned(bytes.as_slice())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@
 //! All features are enabled by default.
 //!
 //! - **bytes** - Enables an additional symbol table implementation for
-//!   interning bytestrings (`Vec<u8>` and `&'static [u8]`).
+//!   interning byte strings (`Vec<u8>` and `&'static [u8]`).
 
 #![doc(html_root_url = "https://docs.rs/intaglio/1.4.0")]
 

--- a/src/str.rs
+++ b/src/str.rs
@@ -303,7 +303,7 @@ impl SymbolTable<RandomState> {
 
     /// Constructs a new, empty `SymbolTable` with the specified capacity.
     ///
-    /// The symbol table will be able to hold at least `capacity` bytestrings
+    /// The symbol table will be able to hold at least `capacity` strings
     /// without reallocating. If `capacity` is 0, the symbol table will not
     /// allocate.
     ///
@@ -364,8 +364,7 @@ impl<S> SymbolTable<S> {
         }
     }
 
-    /// Returns the number of bytestrings the table can hold without
-    /// reallocating.
+    /// Returns the number of strings the table can hold without reallocating.
     ///
     /// # Examples
     ///
@@ -378,7 +377,7 @@ impl<S> SymbolTable<S> {
         usize::min(self.vec.capacity(), self.map.capacity())
     }
 
-    /// Returns the number of interned bytestrings in the table.
+    /// Returns the number of interned strings in the table.
     ///
     /// # Examples
     ///
@@ -389,7 +388,7 @@ impl<S> SymbolTable<S> {
     /// assert_eq!(0, table.len());
     ///
     /// table.intern("abc")?;
-    /// // only uniquely interned bytestrings grow the symbol table.
+    /// // only uniquely interned strings grow the symbol table.
     /// table.intern("abc")?;
     /// table.intern("xyz")?;
     /// assert_eq!(2, table.len());
@@ -401,7 +400,7 @@ impl<S> SymbolTable<S> {
         self.vec.len()
     }
 
-    /// Returns `true` if the symbol table contains no interned bytestrings.
+    /// Returns `true` if the symbol table contains no interned strings.
     ///
     /// # Examples
     ///
@@ -443,7 +442,7 @@ impl<S> SymbolTable<S> {
         self.get(id).is_some()
     }
 
-    /// Returns a reference to the byte string associated with the given symbol.
+    /// Returns a reference to the string associated with the given symbol.
     ///
     /// If the given symbol does not exist in the underlying symbol table,
     /// `None` is returned.
@@ -471,7 +470,7 @@ impl<S> SymbolTable<S> {
         Some(bytes.as_slice())
     }
 
-    /// Returns an iterator over all [`Symbol`]s and bytestrings in the
+    /// Returns an iterator over all [`Symbol`]s and strings in the
     /// [`SymbolTable`].
     ///
     /// # Examples
@@ -615,10 +614,10 @@ impl<S> SymbolTable<S>
 where
     S: BuildHasher,
 {
-    /// Intern a bytestring for the lifetime of the symbol table.
+    /// Intern a string for the lifetime of the symbol table.
     ///
-    /// The returned `Symbol` allows retrieving of the underlying bytes.
-    /// Equal bytestrings will be inserted into the symbol table exactly once.
+    /// The returned `Symbol` allows retrieving of the underlying string.
+    /// Equal strings will be inserted into the symbol table exactly once.
     ///
     /// This function only allocates if the underlying symbol table has no
     /// remaining capacity.
@@ -626,7 +625,7 @@ where
     /// # Errors
     ///
     /// If the symbol table would grow larger than `u32::MAX` interned
-    /// bytestrings, the [`Symbol`] counter would overflow and a
+    /// strings, the [`Symbol`] counter would overflow and a
     /// [`SymbolOverflowError`] is returned.
     ///
     /// # Examples
@@ -663,7 +662,7 @@ where
         //
         // - `Interned` is an internal implementation detail of `SymbolTable`.
         // - `SymbolTable` never give out `'static` references to underlying
-        //   byte contents.
+        //   string contents.
         // - All slice references given out by the `SymbolTable` have the same
         //   lifetime as the `SymbolTable`.
         // - The `map` field of `SymbolTable`, which contains the `'static`
@@ -706,7 +705,7 @@ where
         self.map.get(contents).copied()
     }
 
-    /// Returns `true` if the given byte string has been interned before.
+    /// Returns `true` if the given string has been interned before.
     ///
     /// This method does not modify the symbol table.
     ///
@@ -859,7 +858,7 @@ mod tests {
         let mut table = SymbolTable::new();
         // intern an owned value
         let sym = table.intern("abc".to_string()).unwrap();
-        // retrieve bytes
+        // retrieve string
         assert_eq!("abc", table.get(sym).unwrap());
         // intern owned value again
         assert_eq!(sym, table.intern("abc".to_string()).unwrap());
@@ -872,7 +871,7 @@ mod tests {
         let mut table = SymbolTable::new();
         // intern a borrowed value
         let sym = table.intern("abc").unwrap();
-        // retrieve bytes
+        // retrieve string
         assert_eq!("abc", table.get(sym).unwrap());
         // intern owned value
         assert_eq!(sym, table.intern("abc".to_string()).unwrap());
@@ -892,8 +891,8 @@ mod tests {
     fn intern_get_roundtrip(string: String) -> bool {
         let mut table = SymbolTable::new();
         let sym = table.intern(string.clone()).unwrap();
-        let retrieved_bytes = table.get(sym).unwrap();
-        string == retrieved_bytes
+        let retrieved_str = table.get(sym).unwrap();
+        string == retrieved_str
     }
 
     #[quickcheck]
@@ -910,13 +909,13 @@ mod tests {
     }
 
     #[quickcheck]
-    fn empty_table_does_not_report_any_interned_bytestrings(string: String) -> bool {
+    fn empty_table_does_not_report_any_interned_strings(string: String) -> bool {
         let table = SymbolTable::new();
         !table.is_interned(string.as_str())
     }
 
     #[quickcheck]
-    fn table_reports_interned_bytestrings_as_interned(string: String) -> bool {
+    fn table_reports_interned_strings_as_interned(string: String) -> bool {
         let mut table = SymbolTable::new();
         table.intern(string.clone()).unwrap();
         table.is_interned(string.as_str())


### PR DESCRIPTION
Replace all prose instances of "bytestring" and "bytestrings" with "byte string" and "byte strings".

Doing the search and replace revealed that the `str` variant of `SymbolTable` was documented as returning byte strings all over the place when in reality it returns UTF-8 str content. These mistakes are fixed up.