### PR TITLE
Remove a redundant 'of' from 'Symbol::new' docs, fix some typos

### DIFF
--- a/src/internal.rs
+++ b/src/internal.rs
@@ -218,7 +218,7 @@ where
 ///
 /// # Safety
 ///
-/// Even though `Box` is a "unique owner" of the data in the `Owned` varint, it
+/// Even though `Box` is a "unique owner" of the data in the `Owned` variant, it
 /// should not be mutably dereferenced, because `as_static_slice` promises the
 /// slice to be valid as long as the `Slice` is not dropped.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,8 +173,8 @@ pub struct Symbol(u32);
 impl Symbol {
     /// Construct a new `Symbol` from the given `u32`.
     ///
-    /// `Symbol`s constructed outside of a [`SymbolTable`] may fail to
-    /// resolve to an underlying string using [`SymbolTable::get`].
+    /// `Symbol`s constructed outside a [`SymbolTable`] may fail to resolve to
+    /// an underlying string using [`SymbolTable::get`].
     ///
     /// `Symbol`s are not constrained to the `SymbolTable` which created them.
     /// No runtime checks ensure that [`SymbolTable::get`] is called with a


### PR DESCRIPTION
Caught by `cargo-spellcheck`.