### PR TITLE
Clarify documentation around the default symbol table capacity

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "intaglio"
-version = "1.4.0" # remember to set `html_root_url` in `src/lib.rs`.
+version = "1.4.1" # remember to set `html_root_url` in `src/lib.rs`.
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "MIT"
 edition = "2021"

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -340,8 +340,10 @@ impl<S> Drop for SymbolTable<S> {
 }
 
 impl SymbolTable<RandomState> {
-    /// Constructs a new, empty `SymbolTable` with
-    /// [default capacity](DEFAULT_SYMBOL_TABLE_CAPACITY).
+    /// Constructs a new, empty `SymbolTable` with [default capacity].
+    ///
+    /// This function will always allocate. To construct a symbol table without
+    /// allocating, call [`SymbolTable::with_capacity(0)`]
     ///
     /// # Examples
     ///
@@ -351,6 +353,9 @@ impl SymbolTable<RandomState> {
     /// assert_eq!(0, table.len());
     /// assert!(table.capacity() >= 4096);
     /// ```
+    ///
+    /// [default capacity]: DEFAULT_SYMBOL_TABLE_CAPACITY
+    /// [`SymbolTable::with_capacity(0)`]: Self::with_capacity
     #[must_use]
     pub fn new() -> Self {
         Self::with_capacity(DEFAULT_SYMBOL_TABLE_CAPACITY)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@
 //! - **bytes** - Enables an additional symbol table implementation for
 //!   interning byte strings (`Vec<u8>` and `&'static [u8]`).
 
-#![doc(html_root_url = "https://docs.rs/intaglio/1.4.0")]
+#![doc(html_root_url = "https://docs.rs/intaglio/1.4.1")]
 
 // Ensure code blocks in README.md compile
 #[cfg(doctest)]
@@ -107,7 +107,8 @@ pub use crate::str::*;
 // not hold.
 const _: () = [()][!(size_of::<usize>() >= size_of::<u32>()) as usize];
 
-/// Default capacity for new a [`SymbolTable`].
+/// Default capacity for a new [`SymbolTable`] created with
+/// [`SymbolTable::new`].
 pub const DEFAULT_SYMBOL_TABLE_CAPACITY: usize = 4096;
 
 /// Error returned when a [`SymbolTable`] or symbol identifier overflows.

--- a/src/str.rs
+++ b/src/str.rs
@@ -285,8 +285,10 @@ impl<S> Drop for SymbolTable<S> {
 }
 
 impl SymbolTable<RandomState> {
-    /// Constructs a new, empty `SymbolTable` with
-    /// [default capacity](DEFAULT_SYMBOL_TABLE_CAPACITY).
+    /// Constructs a new, empty `SymbolTable` with [default capacity].
+    ///
+    /// This function will always allocate. To construct a symbol table without
+    /// allocating, call [`SymbolTable::with_capacity(0)`]
     ///
     /// # Examples
     ///
@@ -296,6 +298,9 @@ impl SymbolTable<RandomState> {
     /// assert_eq!(0, table.len());
     /// assert!(table.capacity() >= 4096);
     /// ```
+    ///
+    /// [default capacity]: DEFAULT_SYMBOL_TABLE_CAPACITY
+    /// [`SymbolTable::with_capacity(0)`]: Self::with_capacity
     #[must_use]
     pub fn new() -> Self {
         Self::with_capacity(DEFAULT_SYMBOL_TABLE_CAPACITY)


### PR DESCRIPTION
- Fix some typos in the documentation for `DEFAULT_SYMBOL_TABLE_CAPACITY`.
- Link to `SymbolTable::new` from the docs for `DEFAULT_SYMBOL_TABLE_CAPACITY`.
- Note in `SymbolTable::new` and `bytes::SymbolTable::new` that these functions always allocate.
- Note in `SymbolTable::new` and `bytes::SymbolTable::new` to call `with_capacity(0)` to avoid allocations.

Bump crate version to 1.4.1.