### PR TITLE
Fix missing period at end of sentence in SymbolTable::new docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "intaglio"
-version = "1.4.1" # remember to set `html_root_url` in `src/lib.rs`.
+version = "1.4.2" # remember to set `html_root_url` in `src/lib.rs`.
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "MIT"
 edition = "2021"

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -343,7 +343,7 @@ impl SymbolTable<RandomState> {
     /// Constructs a new, empty `SymbolTable` with [default capacity].
     ///
     /// This function will always allocate. To construct a symbol table without
-    /// allocating, call [`SymbolTable::with_capacity(0)`]
+    /// allocating, call [`SymbolTable::with_capacity(0)`].
     ///
     /// # Examples
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@
 //! - **bytes** - Enables an additional symbol table implementation for
 //!   interning byte strings (`Vec<u8>` and `&'static [u8]`).
 
-#![doc(html_root_url = "https://docs.rs/intaglio/1.4.1")]
+#![doc(html_root_url = "https://docs.rs/intaglio/1.4.2")]
 
 // Ensure code blocks in README.md compile
 #[cfg(doctest)]

--- a/src/str.rs
+++ b/src/str.rs
@@ -288,7 +288,7 @@ impl SymbolTable<RandomState> {
     /// Constructs a new, empty `SymbolTable` with [default capacity].
     ///
     /// This function will always allocate. To construct a symbol table without
-    /// allocating, call [`SymbolTable::with_capacity(0)`]
+    /// allocating, call [`SymbolTable::with_capacity(0)`].
     ///
     /// # Examples
     ///


### PR DESCRIPTION
:(

followup to v1.4.1 release.

bump crate version to v1.4.2.