### PR TITLE
Update version-sync to 0.9.3 and trim some deps from Cargo.lock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,9 +27,13 @@ bytes = []
 # Property testing for interner getters and setters.
 quickcheck = { version = "1.0", default-features = false }
 quickcheck_macros = "1.0"
+
 # Check that crate versions are properly updated in documentation and code when
 # bumping the version.
-version-sync = "0.9, >= 0.9.2"
+[dev-dependencies.version-sync]
+version = "0.9.3"
+default-features = false
+features = ["markdown_deps_updated", "html_root_url_updated"]
 
 [package.metadata.docs.rs]
 # This sets the default target to `x86_64-unknown-linux-gnu` and only builds


### PR DESCRIPTION
Turning off the `assert_contains_regex!` macro removes deps on regex and regex-syntax.