### PR TITLE
Update Cargo.toml manifest version and docs.rs metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,8 @@ cstr = []
 
 [dev-dependencies]
 # Property testing for interner getters and setters.
-quickcheck = { version = "1.0", default-features = false }
-quickcheck_macros = "1.0"
+quickcheck = { version = "1.0.3", default-features = false }
+quickcheck_macros = "1.0.0"
 
 # Check that crate versions are properly updated in documentation and code when
 # bumping the version.
@@ -41,5 +41,6 @@ features = ["markdown_deps_updated", "html_root_url_updated"]
 [package.metadata.docs.rs]
 # This sets the default target to `x86_64-unknown-linux-gnu` and only builds
 # that target. `intaglio` has the same API and code on all targets.
-targets = ["x86_64-unknown-linux-gnu"]
+default-target = "x86_64-unknown-linux-gnu"
+targets = []
 rustdoc-args = ["--cfg", "docsrs"]


### PR DESCRIPTION
- Use precise versions for dependencies. See: https://users.rust-lang.org/t/psa-please-specify-precise-dependency-versions-in-cargo-toml/71277
- Use the same style of docs.rs metadata as used in artichoke/raw-parts#24.