### PR TITLE
Use `include_str!` in attribute position for README doctests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,18 +87,9 @@
 #![doc(html_root_url = "https://docs.rs/intaglio/1.4.2")]
 
 // Ensure code blocks in README.md compile
-#[cfg(doctest)]
-macro_rules! readme {
-    ($x:expr) => {
-        #[doc = $x]
-        mod readme {}
-    };
-    () => {
-        readme!(include_str!("../README.md"));
-    };
-}
-#[cfg(all(doctest, feature = "bytes"))]
-readme!();
+#[cfg(all(doctest, feature = "bytes", feature = "cstr"))]
+#[doc = include_str!("../README.md")]
+mod readme {}
 
 use core::fmt;
 use core::mem::size_of;


### PR DESCRIPTION
Leverage that high 1.56.0 MSRV to simplify a bit of the code.