### PR TITLE
Fixup typos, remove code variation

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -664,7 +664,7 @@ impl<S> SymbolTable<S> {
     /// table.intern(b"123".to_vec())?;
     /// table.intern(b"789".to_vec())?;
     ///
-    /// let  bytestrings = table.bytestrings();
+    /// let bytestrings = table.bytestrings();
     /// assert_eq!(table.len(), bytestrings.count());
     /// # Ok(())
     /// # }
@@ -884,7 +884,7 @@ where
 mod tests {
     use quickcheck_macros::quickcheck;
 
-    use crate::bytes::SymbolTable;
+    use super::SymbolTable;
 
     #[test]
     fn alloc_drop_new() {

--- a/src/cstr.rs
+++ b/src/cstr.rs
@@ -686,7 +686,7 @@ impl<S> SymbolTable<S> {
     /// table.intern(CString::new(*b"123")?)?;
     /// table.intern(CString::new(*b"789")?)?;
     ///
-    /// let  c_strings = table.c_strings();
+    /// let c_strings = table.c_strings();
     /// assert_eq!(table.len(), c_strings.count());
     /// # Ok(())
     /// # }
@@ -914,7 +914,7 @@ mod tests {
 
     use quickcheck_macros::quickcheck;
 
-    use crate::cstr::SymbolTable;
+    use super::SymbolTable;
 
     #[test]
     fn alloc_drop_new() {

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -32,8 +32,8 @@ impl From<String> for Interned<str> {
 
 impl From<Cow<'static, str>> for Interned<str> {
     #[inline]
-    fn from(string: Cow<'static, str>) -> Self {
-        Self(string.into())
+    fn from(cow: Cow<'static, str>) -> Self {
+        Self(cow.into())
     }
 }
 
@@ -48,8 +48,8 @@ impl From<Vec<u8>> for Interned<[u8]> {
 #[cfg(feature = "bytes")]
 impl From<Cow<'static, [u8]>> for Interned<[u8]> {
     #[inline]
-    fn from(bytes: Cow<'static, [u8]>) -> Self {
-        Self(bytes.into())
+    fn from(cow: Cow<'static, [u8]>) -> Self {
+        Self(cow.into())
     }
 }
 
@@ -64,8 +64,8 @@ impl From<CString> for Interned<CStr> {
 #[cfg(feature = "cstr")]
 impl From<Cow<'static, CStr>> for Interned<CStr> {
     #[inline]
-    fn from(cstr: Cow<'static, CStr>) -> Self {
-        Self(cstr.into())
+    fn from(cow: Cow<'static, CStr>) -> Self {
+        Self(cow.into())
     }
 }
 
@@ -295,8 +295,8 @@ impl From<String> for Slice<str> {
 
 impl From<Cow<'static, str>> for Slice<str> {
     #[inline]
-    fn from(string: Cow<'static, str>) -> Self {
-        match string {
+    fn from(cow: Cow<'static, str>) -> Self {
+        match cow {
             Cow::Borrowed(slice) => slice.into(),
             Cow::Owned(owned) => owned.into(),
         }
@@ -314,8 +314,8 @@ impl From<Vec<u8>> for Slice<[u8]> {
 #[cfg(feature = "bytes")]
 impl From<Cow<'static, [u8]>> for Slice<[u8]> {
     #[inline]
-    fn from(bytes: Cow<'static, [u8]>) -> Self {
-        match bytes {
+    fn from(cow: Cow<'static, [u8]>) -> Self {
+        match cow {
             Cow::Borrowed(slice) => slice.into(),
             Cow::Owned(owned) => owned.into(),
         }
@@ -333,8 +333,8 @@ impl From<CString> for Slice<CStr> {
 #[cfg(feature = "cstr")]
 impl From<Cow<'static, CStr>> for Slice<CStr> {
     #[inline]
-    fn from(bytes: Cow<'static, CStr>) -> Self {
-        match bytes {
+    fn from(cow: Cow<'static, CStr>) -> Self {
+        match cow {
             Cow::Borrowed(slice) => slice.into(),
             Cow::Owned(owned) => owned.into(),
         }

--- a/src/str.rs
+++ b/src/str.rs
@@ -604,7 +604,7 @@ impl<S> SymbolTable<S> {
     /// table.intern("123")?;
     /// table.intern("789")?;
     ///
-    /// let  strings = table.strings();
+    /// let strings = table.strings();
     /// assert_eq!(table.len(), strings.count());
     /// # Ok(())
     /// # }
@@ -822,7 +822,7 @@ where
 mod tests {
     use quickcheck_macros::quickcheck;
 
-    use crate::str::SymbolTable;
+    use super::SymbolTable;
 
     #[test]
     fn alloc_drop_new() {


### PR DESCRIPTION
Some variation in the code does not convey much meaning but makes it
difficult to use the source as a template for stamping out new
interners. Remove mentions of specific borrowed/owned contents when
possible to make porting to `Path` and `OsStr` interners easier.