### PR TITLE
Simplify and shrink `AllSymbols` iterators

### DIFF
--- a/src/cstr.rs
+++ b/src/cstr.rs
@@ -60,7 +60,7 @@ use core::hash::BuildHasher;
 use core::iter::{FromIterator, FusedIterator, Zip};
 use core::marker::PhantomData;
 use core::mem::ManuallyDrop;
-use core::ops::{Range, RangeInclusive};
+use core::ops::Range;
 use core::slice;
 use std::borrow::Cow;
 use std::collections::hash_map::{HashMap, RandomState};
@@ -90,8 +90,7 @@ use crate::{Symbol, SymbolOverflowError, DEFAULT_SYMBOL_TABLE_CAPACITY};
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 #[cfg_attr(docsrs, doc(cfg(feature = "cstr")))]
 pub struct AllSymbols<'a> {
-    // this Result is being used as an Either type.
-    range: Result<Range<u32>, RangeInclusive<u32>>,
+    range: Range<usize>,
     // Hold a shared reference to the underlying `SymbolTable` to ensure the
     // table is not modified while we are iterating which would make the results
     // not match the real state.
@@ -102,61 +101,47 @@ impl<'a> Iterator for AllSymbols<'a> {
     type Item = Symbol;
 
     fn next(&mut self) -> Option<Self::Item> {
-        match self.range {
-            Ok(ref mut range) => range.next().map(Symbol::from),
-            Err(ref mut range) => range.next().map(Symbol::from),
-        }
+        let next = self.range.next()?;
+        debug_assert!(u32::try_from(next).is_ok());
+        Some((next as u32).into())
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        match self.range {
-            Ok(ref range) => range.size_hint(),
-            Err(ref range) => range.size_hint(),
-        }
+        self.range.size_hint()
     }
 
     fn count(self) -> usize {
-        match self.range {
-            Ok(range) => range.count(),
-            Err(range) => range.count(),
-        }
+        self.range.count()
     }
 
     fn last(self) -> Option<Self::Item> {
-        match self.range {
-            Ok(range) => range.last().map(Symbol::from),
-            Err(range) => range.last().map(Symbol::from),
-        }
+        let last = self.range.last()?;
+        debug_assert!(u32::try_from(last).is_ok());
+        Some((last as u32).into())
     }
 
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
-        match self.range {
-            Ok(ref mut range) => range.nth(n).map(Symbol::from),
-            Err(ref mut range) => range.nth(n).map(Symbol::from),
-        }
+        let nth = self.range.nth(n)?;
+        debug_assert!(u32::try_from(nth).is_ok());
+        Some((nth as u32).into())
     }
 
     fn collect<B: FromIterator<Self::Item>>(self) -> B {
-        match self.range {
-            Ok(range) => range.map(Symbol::from).collect(),
-            Err(range) => range.map(Symbol::from).collect(),
-        }
+        self.range.map(|sym| Symbol::from(sym as u32)).collect()
     }
 }
 
 impl<'a> DoubleEndedIterator for AllSymbols<'a> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        match self.range {
-            Ok(ref mut range) => range.next_back().map(Symbol::from),
-            Err(ref mut range) => range.next_back().map(Symbol::from),
-        }
+        let next = self.range.next_back()?;
+        debug_assert!(u32::try_from(next).is_ok());
+        Some((next as u32).into())
     }
 
     fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
-        match self.range {
-            Ok(ref mut range) => range.nth_back(n).map(Symbol::from),
-            Err(ref mut range) => range.nth_back(n).map(Symbol::from),
-        }
+        let nth = self.range.nth_back(n)?;
+        debug_assert!(u32::try_from(nth).is_ok());
+        Some((nth as u32).into())
     }
 }
 
@@ -639,17 +624,9 @@ impl<S> SymbolTable<S> {
     /// # example().unwrap();
     /// ```
     pub fn all_symbols(&self) -> AllSymbols<'_> {
-        if self.len() == u32::MAX as usize {
-            AllSymbols {
-                range: Err(0..=u32::MAX),
-                phantom: PhantomData,
-            }
-        } else {
-            let upper_bound = self.len() as u32;
-            AllSymbols {
-                range: Ok(0..upper_bound),
-                phantom: PhantomData,
-            }
+        AllSymbols {
+            range: 0..self.len(),
+            phantom: PhantomData,
         }
     }
 

--- a/src/osstr.rs
+++ b/src/osstr.rs
@@ -60,7 +60,7 @@ use core::hash::BuildHasher;
 use core::iter::{FromIterator, FusedIterator, Zip};
 use core::marker::PhantomData;
 use core::mem::ManuallyDrop;
-use core::ops::{Range, RangeInclusive};
+use core::ops::Range;
 use core::slice;
 use std::borrow::Cow;
 use std::collections::hash_map::{HashMap, RandomState};
@@ -90,8 +90,7 @@ use crate::{Symbol, SymbolOverflowError, DEFAULT_SYMBOL_TABLE_CAPACITY};
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 #[cfg_attr(docsrs, doc(cfg(feature = "osstr")))]
 pub struct AllSymbols<'a> {
-    // this Result is being used as an Either type.
-    range: Result<Range<u32>, RangeInclusive<u32>>,
+    range: Range<usize>,
     // Hold a shared reference to the underlying `SymbolTable` to ensure the
     // table is not modified while we are iterating which would make the results
     // not match the real state.
@@ -102,61 +101,47 @@ impl<'a> Iterator for AllSymbols<'a> {
     type Item = Symbol;
 
     fn next(&mut self) -> Option<Self::Item> {
-        match self.range {
-            Ok(ref mut range) => range.next().map(Symbol::from),
-            Err(ref mut range) => range.next().map(Symbol::from),
-        }
+        let next = self.range.next()?;
+        debug_assert!(u32::try_from(next).is_ok());
+        Some((next as u32).into())
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        match self.range {
-            Ok(ref range) => range.size_hint(),
-            Err(ref range) => range.size_hint(),
-        }
+        self.range.size_hint()
     }
 
     fn count(self) -> usize {
-        match self.range {
-            Ok(range) => range.count(),
-            Err(range) => range.count(),
-        }
+        self.range.count()
     }
 
     fn last(self) -> Option<Self::Item> {
-        match self.range {
-            Ok(range) => range.last().map(Symbol::from),
-            Err(range) => range.last().map(Symbol::from),
-        }
+        let last = self.range.last()?;
+        debug_assert!(u32::try_from(last).is_ok());
+        Some((last as u32).into())
     }
 
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
-        match self.range {
-            Ok(ref mut range) => range.nth(n).map(Symbol::from),
-            Err(ref mut range) => range.nth(n).map(Symbol::from),
-        }
+        let nth = self.range.nth(n)?;
+        debug_assert!(u32::try_from(nth).is_ok());
+        Some((nth as u32).into())
     }
 
     fn collect<B: FromIterator<Self::Item>>(self) -> B {
-        match self.range {
-            Ok(range) => range.map(Symbol::from).collect(),
-            Err(range) => range.map(Symbol::from).collect(),
-        }
+        self.range.map(|sym| Symbol::from(sym as u32)).collect()
     }
 }
 
 impl<'a> DoubleEndedIterator for AllSymbols<'a> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        match self.range {
-            Ok(ref mut range) => range.next_back().map(Symbol::from),
-            Err(ref mut range) => range.next_back().map(Symbol::from),
-        }
+        let next = self.range.next_back()?;
+        debug_assert!(u32::try_from(next).is_ok());
+        Some((next as u32).into())
     }
 
     fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
-        match self.range {
-            Ok(ref mut range) => range.nth_back(n).map(Symbol::from),
-            Err(ref mut range) => range.nth_back(n).map(Symbol::from),
-        }
+        let nth = self.range.nth_back(n)?;
+        debug_assert!(u32::try_from(nth).is_ok());
+        Some((nth as u32).into())
     }
 }
 
@@ -639,17 +624,9 @@ impl<S> SymbolTable<S> {
     /// # example().unwrap();
     /// ```
     pub fn all_symbols(&self) -> AllSymbols<'_> {
-        if self.len() == u32::MAX as usize {
-            AllSymbols {
-                range: Err(0..=u32::MAX),
-                phantom: PhantomData,
-            }
-        } else {
-            let upper_bound = self.len() as u32;
-            AllSymbols {
-                range: Ok(0..upper_bound),
-                phantom: PhantomData,
-            }
+        AllSymbols {
+            range: 0..self.len(),
+            phantom: PhantomData,
         }
     }
 

--- a/src/path.rs
+++ b/src/path.rs
@@ -60,7 +60,7 @@ use core::hash::BuildHasher;
 use core::iter::{FromIterator, FusedIterator, Zip};
 use core::marker::PhantomData;
 use core::mem::ManuallyDrop;
-use core::ops::{Range, RangeInclusive};
+use core::ops::Range;
 use core::slice;
 use std::borrow::Cow;
 use std::collections::hash_map::{HashMap, RandomState};
@@ -90,8 +90,7 @@ use crate::{Symbol, SymbolOverflowError, DEFAULT_SYMBOL_TABLE_CAPACITY};
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 #[cfg_attr(docsrs, doc(cfg(feature = "path")))]
 pub struct AllSymbols<'a> {
-    // this Result is being used as an Either type.
-    range: Result<Range<u32>, RangeInclusive<u32>>,
+    range: Range<usize>,
     // Hold a shared reference to the underlying `SymbolTable` to ensure the
     // table is not modified while we are iterating which would make the results
     // not match the real state.
@@ -102,61 +101,47 @@ impl<'a> Iterator for AllSymbols<'a> {
     type Item = Symbol;
 
     fn next(&mut self) -> Option<Self::Item> {
-        match self.range {
-            Ok(ref mut range) => range.next().map(Symbol::from),
-            Err(ref mut range) => range.next().map(Symbol::from),
-        }
+        let next = self.range.next()?;
+        debug_assert!(u32::try_from(next).is_ok());
+        Some((next as u32).into())
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        match self.range {
-            Ok(ref range) => range.size_hint(),
-            Err(ref range) => range.size_hint(),
-        }
+        self.range.size_hint()
     }
 
     fn count(self) -> usize {
-        match self.range {
-            Ok(range) => range.count(),
-            Err(range) => range.count(),
-        }
+        self.range.count()
     }
 
     fn last(self) -> Option<Self::Item> {
-        match self.range {
-            Ok(range) => range.last().map(Symbol::from),
-            Err(range) => range.last().map(Symbol::from),
-        }
+        let last = self.range.last()?;
+        debug_assert!(u32::try_from(last).is_ok());
+        Some((last as u32).into())
     }
 
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
-        match self.range {
-            Ok(ref mut range) => range.nth(n).map(Symbol::from),
-            Err(ref mut range) => range.nth(n).map(Symbol::from),
-        }
+        let nth = self.range.nth(n)?;
+        debug_assert!(u32::try_from(nth).is_ok());
+        Some((nth as u32).into())
     }
 
     fn collect<B: FromIterator<Self::Item>>(self) -> B {
-        match self.range {
-            Ok(range) => range.map(Symbol::from).collect(),
-            Err(range) => range.map(Symbol::from).collect(),
-        }
+        self.range.map(|sym| Symbol::from(sym as u32)).collect()
     }
 }
 
 impl<'a> DoubleEndedIterator for AllSymbols<'a> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        match self.range {
-            Ok(ref mut range) => range.next_back().map(Symbol::from),
-            Err(ref mut range) => range.next_back().map(Symbol::from),
-        }
+        let next = self.range.next_back()?;
+        debug_assert!(u32::try_from(next).is_ok());
+        Some((next as u32).into())
     }
 
     fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
-        match self.range {
-            Ok(ref mut range) => range.nth_back(n).map(Symbol::from),
-            Err(ref mut range) => range.nth_back(n).map(Symbol::from),
-        }
+        let nth = self.range.nth_back(n)?;
+        debug_assert!(u32::try_from(nth).is_ok());
+        Some((nth as u32).into())
     }
 }
 
@@ -639,17 +624,9 @@ impl<S> SymbolTable<S> {
     /// # example().unwrap();
     /// ```
     pub fn all_symbols(&self) -> AllSymbols<'_> {
-        if self.len() == u32::MAX as usize {
-            AllSymbols {
-                range: Err(0..=u32::MAX),
-                phantom: PhantomData,
-            }
-        } else {
-            let upper_bound = self.len() as u32;
-            AllSymbols {
-                range: Ok(0..upper_bound),
-                phantom: PhantomData,
-            }
+        AllSymbols {
+            range: 0..self.len(),
+            phantom: PhantomData,
         }
     }
 

--- a/src/str.rs
+++ b/src/str.rs
@@ -5,7 +5,7 @@ use core::hash::BuildHasher;
 use core::iter::{FromIterator, FusedIterator, Zip};
 use core::marker::PhantomData;
 use core::mem::ManuallyDrop;
-use core::ops::{Range, RangeInclusive};
+use core::ops::Range;
 use core::slice;
 use std::borrow::Cow;
 use std::collections::hash_map::{HashMap, RandomState};
@@ -32,8 +32,7 @@ use crate::{Symbol, SymbolOverflowError, DEFAULT_SYMBOL_TABLE_CAPACITY};
 /// ```
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub struct AllSymbols<'a> {
-    // this Result is being used as an Either type.
-    range: Result<Range<u32>, RangeInclusive<u32>>,
+    range: Range<usize>,
     // Hold a shared reference to the underlying `SymbolTable` to ensure the
     // table is not modified while we are iterating which would make the results
     // not match the real state.
@@ -44,61 +43,47 @@ impl<'a> Iterator for AllSymbols<'a> {
     type Item = Symbol;
 
     fn next(&mut self) -> Option<Self::Item> {
-        match self.range {
-            Ok(ref mut range) => range.next().map(Symbol::from),
-            Err(ref mut range) => range.next().map(Symbol::from),
-        }
+        let next = self.range.next()?;
+        debug_assert!(u32::try_from(next).is_ok());
+        Some((next as u32).into())
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        match self.range {
-            Ok(ref range) => range.size_hint(),
-            Err(ref range) => range.size_hint(),
-        }
+        self.range.size_hint()
     }
 
     fn count(self) -> usize {
-        match self.range {
-            Ok(range) => range.count(),
-            Err(range) => range.count(),
-        }
+        self.range.count()
     }
 
     fn last(self) -> Option<Self::Item> {
-        match self.range {
-            Ok(range) => range.last().map(Symbol::from),
-            Err(range) => range.last().map(Symbol::from),
-        }
+        let last = self.range.last()?;
+        debug_assert!(u32::try_from(last).is_ok());
+        Some((last as u32).into())
     }
 
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
-        match self.range {
-            Ok(ref mut range) => range.nth(n).map(Symbol::from),
-            Err(ref mut range) => range.nth(n).map(Symbol::from),
-        }
+        let nth = self.range.nth(n)?;
+        debug_assert!(u32::try_from(nth).is_ok());
+        Some((nth as u32).into())
     }
 
     fn collect<B: FromIterator<Self::Item>>(self) -> B {
-        match self.range {
-            Ok(range) => range.map(Symbol::from).collect(),
-            Err(range) => range.map(Symbol::from).collect(),
-        }
+        self.range.map(|sym| Symbol::from(sym as u32)).collect()
     }
 }
 
 impl<'a> DoubleEndedIterator for AllSymbols<'a> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        match self.range {
-            Ok(ref mut range) => range.next_back().map(Symbol::from),
-            Err(ref mut range) => range.next_back().map(Symbol::from),
-        }
+        let next = self.range.next_back()?;
+        debug_assert!(u32::try_from(next).is_ok());
+        Some((next as u32).into())
     }
 
     fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
-        match self.range {
-            Ok(ref mut range) => range.nth_back(n).map(Symbol::from),
-            Err(ref mut range) => range.nth_back(n).map(Symbol::from),
-        }
+        let nth = self.range.nth_back(n)?;
+        debug_assert!(u32::try_from(nth).is_ok());
+        Some((nth as u32).into())
     }
 }
 
@@ -559,17 +544,9 @@ impl<S> SymbolTable<S> {
     /// # example().unwrap();
     /// ```
     pub fn all_symbols(&self) -> AllSymbols<'_> {
-        if self.len() == u32::MAX as usize {
-            AllSymbols {
-                range: Err(0..=u32::MAX),
-                phantom: PhantomData,
-            }
-        } else {
-            let upper_bound = self.len() as u32;
-            AllSymbols {
-                range: Ok(0..upper_bound),
-                phantom: PhantomData,
-            }
+        AllSymbols {
+            range: 0..self.len(),
+            phantom: PhantomData,
         }
     }
 


### PR DESCRIPTION
Remove the "either" branching of the inner range in the `AllSymbols`
iterators.

Use a `Range<usize>` rather than converting to either a `Range<u32>` or
`RangeInclusive<u32>`. Do the case to u32 -> Symbol when advancing the
iterator.

This removes a bunch of branching and reduces the size of the struct.