### PR TITLE
[WIP] Ensure max length of `SymbolTable` does not exceed `u32::MAX`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "intaglio"
-version = "1.5.0" # remember to set `html_root_url` in `src/lib.rs`.
+version = "2.0.0" # remember to set `html_root_url` in `src/lib.rs`.
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "MIT"
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-intaglio = "1.5.0"
+intaglio = "2.0.0"
 ```
 
 Then intern UTF-8 strings like:

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -911,6 +911,7 @@ mod tests {
     use quickcheck_macros::quickcheck;
 
     use super::SymbolTable;
+    use crate::Symbol;
 
     #[test]
     fn alloc_drop_new() {
@@ -997,8 +998,12 @@ mod tests {
 
     #[quickcheck]
     fn table_does_not_contain_missing_symbol_ids(sym: u32) -> bool {
-        let table = SymbolTable::new();
-        !table.contains(sym.into())
+        if let Some(sym) = Symbol::new(sym) {
+            let table = SymbolTable::new();
+            !table.contains(sym)
+        } else {
+            true
+        }
     }
 
     #[quickcheck]

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -273,6 +273,9 @@ impl<'a> IntoIterator for &'a SymbolTable {
 /// This symbol table is implemented by storing byte strings with a fast path for
 /// `&[u8]` that are already `'static`.
 ///
+/// `SymbolTable`s store at most `u32::MAX` symbols. The maximum symbol id is
+/// `u32::MAX - 1`.
+///
 /// See module documentation for more.
 ///
 /// # Usage

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -83,7 +83,7 @@ use crate::{Symbol, SymbolOverflowError, DEFAULT_SYMBOL_TABLE_CAPACITY};
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 #[cfg_attr(docsrs, doc(cfg(feature = "bytes")))]
 pub struct AllSymbols<'a> {
-    range: Range<usize>,
+    range: Range<u32>,
     // Hold a shared reference to the underlying `SymbolTable` to ensure the
     // table is not modified while we are iterating which would make the results
     // not match the real state.
@@ -94,9 +94,7 @@ impl<'a> Iterator for AllSymbols<'a> {
     type Item = Symbol;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let next = self.range.next()?;
-        debug_assert!(u32::try_from(next).is_ok());
-        Some((next as u32).into())
+        self.range.next().map(Symbol::from)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -108,33 +106,25 @@ impl<'a> Iterator for AllSymbols<'a> {
     }
 
     fn last(self) -> Option<Self::Item> {
-        let last = self.range.last()?;
-        debug_assert!(u32::try_from(last).is_ok());
-        Some((last as u32).into())
+        self.range.last().map(Symbol::from)
     }
 
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
-        let nth = self.range.nth(n)?;
-        debug_assert!(u32::try_from(nth).is_ok());
-        Some((nth as u32).into())
+        self.range.nth(n).map(Symbol::from)
     }
 
     fn collect<B: FromIterator<Self::Item>>(self) -> B {
-        self.range.map(|sym| Symbol::from(sym as u32)).collect()
+        self.range.map(Symbol::from).collect()
     }
 }
 
 impl<'a> DoubleEndedIterator for AllSymbols<'a> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        let next = self.range.next_back()?;
-        debug_assert!(u32::try_from(next).is_ok());
-        Some((next as u32).into())
+        self.range.next_back().map(Symbol::from)
     }
 
     fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
-        let nth = self.range.nth_back(n)?;
-        debug_assert!(u32::try_from(nth).is_ok());
-        Some((nth as u32).into())
+        self.range.nth_back(n).map(Symbol::from)
     }
 }
 
@@ -604,8 +594,14 @@ impl<S> SymbolTable<S> {
     /// # example().unwrap();
     /// ```
     pub fn all_symbols(&self) -> AllSymbols<'_> {
+        let len = self.len();
+        debug_assert!(
+            u32::try_from(len).is_ok(),
+            "Interner can hold at most u32::MAX symbols"
+        );
+        let len = len as u32;
         AllSymbols {
-            range: 0..self.len(),
+            range: 0_u32..len,
             phantom: PhantomData,
         }
     }

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -94,7 +94,13 @@ impl<'a> Iterator for AllSymbols<'a> {
     type Item = Symbol;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.range.next().map(Symbol::from)
+        self.range.next().map(|sym| {
+            // Safety:
+            //
+            // `self.range` is a `Range<u32>` which can never yield
+            // `u32::MAX`.
+            unsafe { Symbol::new_unchecked(sym) }
+        })
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -106,25 +112,57 @@ impl<'a> Iterator for AllSymbols<'a> {
     }
 
     fn last(self) -> Option<Self::Item> {
-        self.range.last().map(Symbol::from)
+        self.range.last().map(|sym| {
+            // Safety:
+            //
+            // `self.range` is a `Range<u32>` which can never yield
+            // `u32::MAX`.
+            unsafe { Symbol::new_unchecked(sym) }
+        })
     }
 
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
-        self.range.nth(n).map(Symbol::from)
+        self.range.nth(n).map(|sym| {
+            // Safety:
+            //
+            // `self.range` is a `Range<u32>` which can never yield
+            // `u32::MAX`.
+            unsafe { Symbol::new_unchecked(sym) }
+        })
     }
 
     fn collect<B: FromIterator<Self::Item>>(self) -> B {
-        self.range.map(Symbol::from).collect()
+        self.range
+            .map(|sym| {
+                // Safety:
+                //
+                // `self.range` is a `Range<u32>` which can never yield
+                // `u32::MAX`.
+                unsafe { Symbol::new_unchecked(sym) }
+            })
+            .collect()
     }
 }
 
 impl<'a> DoubleEndedIterator for AllSymbols<'a> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        self.range.next_back().map(Symbol::from)
+        self.range.next_back().map(|sym| {
+            // Safety:
+            //
+            // `self.range` is a `Range<u32>` which can never yield
+            // `u32::MAX`.
+            unsafe { Symbol::new_unchecked(sym) }
+        })
     }
 
     fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
-        self.range.nth_back(n).map(Symbol::from)
+        self.range.nth_back(n).map(|sym| {
+            // Safety:
+            //
+            // `self.range` is a `Range<u32>` which can never yield
+            // `u32::MAX`.
+            unsafe { Symbol::new_unchecked(sym) }
+        })
     }
 }
 
@@ -695,7 +733,6 @@ where
             return Ok(id);
         }
 
-        let id = self.map.len().try_into()?;
         // If the number of symbols stored in the table is `u32::MAX`, then the
         // last issued symbol was `u32::MAX - 1` because `(0..u32::MAX).count() == u32::MAX`.
         //
@@ -703,9 +740,7 @@ where
         // table would be `0..=u32::MAX`, which means the table would store
         // `u32::MAX + 1` symbols, which is beyond `SymbolTable`'s documented
         // capacity.
-        if id == u32::MAX {
-            return Err(SymbolOverflowError::new());
-        }
+        let id = self.map.len().try_into()?;
 
         // If given `Cow::Owned(_)` this operation will potentially perform a
         // copy when converting the owned string into a boxed owned string.

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -691,7 +691,6 @@ where
         if let Some(&id) = self.map.get(&*contents) {
             return Ok(id);
         }
-        let name = Interned::from(contents);
 
         let id = self.map.len().try_into()?;
         // If the number of symbols stored in the table is `u32::MAX`, then the
@@ -704,6 +703,10 @@ where
         if id == u32::MAX {
             return Err(SymbolOverflowError::new());
         }
+
+        // If given `Cow::Owned(_)` this operation will potentially perform a
+        // copy when converting the owned string into a boxed owned string.
+        let name = Interned::from(contents);
 
         // Safety:
         //

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -35,8 +35,8 @@
 //!
 //! table.intern(&b"xyz"[..])?;
 //! let mut map = HashMap::new();
-//! map.insert(Symbol::new(0), &b"abc"[..]);
-//! map.insert(Symbol::new(1), &b"xyz"[..]);
+//! map.insert(Symbol::try_from(0_u32)?, &b"abc"[..]);
+//! map.insert(Symbol::try_from(1_u32)?, &b"xyz"[..]);
 //! // Retrieve symbol to byte content mappings.
 //! let iter = table.iter();
 //! assert_eq!(map, iter.collect::<HashMap<_, _>>());
@@ -257,7 +257,7 @@ impl<'a> FusedIterator for Bytestrings<'a> {}
 /// let sym = table.intern(b"abc".to_vec())?;
 /// let iter = table.iter();
 /// let mut map = HashMap::new();
-/// map.insert(Symbol::new(0), &b"abc"[..]);
+/// map.insert(Symbol::try_from(0_u32)?, &b"abc"[..]);
 /// assert_eq!(map, iter.collect::<HashMap<_, _>>());
 /// # Ok(())
 /// # }
@@ -506,10 +506,10 @@ impl<S> SymbolTable<S> {
     /// # use intaglio::Symbol;
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
-    /// assert!(!table.contains(Symbol::new(0)));
+    /// assert!(!table.contains(Symbol::try_from(0_u32)?));
     ///
     /// let sym = table.intern(b"abc".to_vec())?;
-    /// assert!(table.contains(Symbol::new(0)));
+    /// assert!(table.contains(Symbol::try_from(0_u32)?));
     /// assert!(table.contains(sym));
     /// # Ok(())
     /// # }
@@ -534,10 +534,10 @@ impl<S> SymbolTable<S> {
     /// # use intaglio::Symbol;
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
-    /// assert!(table.get(Symbol::new(0)).is_none());
+    /// assert!(table.get(Symbol::try_from(0_u32)?).is_none());
     ///
     /// let sym = table.intern(b"abc".to_vec())?;
-    /// assert_eq!(Some(&b"abc"[..]), table.get(Symbol::new(0)));
+    /// assert_eq!(Some(&b"abc"[..]), table.get(Symbol::try_from(0_u32)?));
     /// assert_eq!(Some(&b"abc"[..]), table.get(sym));
     /// # Ok(())
     /// # }
@@ -567,10 +567,10 @@ impl<S> SymbolTable<S> {
     ///
     /// let iter = table.iter();
     /// let mut map = HashMap::new();
-    /// map.insert(Symbol::new(0), &b"abc"[..]);
-    /// map.insert(Symbol::new(1), &b"xyz"[..]);
-    /// map.insert(Symbol::new(2), &b"123"[..]);
-    /// map.insert(Symbol::new(3), &b"789"[..]);
+    /// map.insert(Symbol::try_from(0_u32)?, &b"abc"[..]);
+    /// map.insert(Symbol::try_from(1_u32)?, &b"xyz"[..]);
+    /// map.insert(Symbol::try_from(2_u32)?, &b"123"[..]);
+    /// map.insert(Symbol::try_from(3_u32)?, &b"789"[..]);
     /// assert_eq!(map, iter.collect::<HashMap<_, _>>());
     /// # Ok(())
     /// # }
@@ -611,8 +611,8 @@ impl<S> SymbolTable<S> {
     /// table.intern(b"789".to_vec())?;
     ///
     /// let mut all_symbols = table.all_symbols();
-    /// assert_eq!(Some(Symbol::new(0)), all_symbols.next());
-    /// assert_eq!(Some(Symbol::new(1)), all_symbols.nth_back(2));
+    /// assert_eq!(Some(Symbol::try_from(0_u32)?), all_symbols.next());
+    /// assert_eq!(Some(Symbol::try_from(1_u32)?), all_symbols.nth_back(2));
     /// assert_eq!(None, all_symbols.next());
     /// # Ok(())
     /// # }
@@ -787,7 +787,7 @@ where
     ///
     /// table.intern(b"abc".to_vec())?;
     /// assert!(table.is_interned(b"abc"));
-    /// assert_eq!(Some(Symbol::new(0)), table.check_interned(b"abc"));
+    /// assert_eq!(Some(Symbol::try_from(0_u32)?), table.check_interned(b"abc"));
     /// # Ok(())
     /// # }
     /// # example().unwrap();
@@ -813,7 +813,7 @@ where
     ///
     /// table.intern(b"abc".to_vec())?;
     /// assert!(table.is_interned(b"abc"));
-    /// assert_eq!(Some(Symbol::new(0)), table.check_interned(b"abc"));
+    /// assert_eq!(Some(Symbol::try_from(0_u32)?), table.check_interned(b"abc"));
     /// # Ok(())
     /// # }
     /// # example().unwrap();

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -6,43 +6,61 @@ use crate::{Symbol, SymbolOverflowError};
 
 impl From<u8> for Symbol {
     #[inline]
-    fn from(id: u8) -> Self {
-        Self(id.into())
+    fn from(sym: u8) -> Self {
+        // Safety:
+        //
+        // `u8::MAX` is less than `u32::MAX`
+        unsafe { Self::new_unchecked(sym.into()) }
     }
 }
 
 impl From<NonZeroU8> for Symbol {
     #[inline]
     fn from(sym: NonZeroU8) -> Self {
-        Self(sym.get().into())
+        // Safety:
+        //
+        // `u8::MAX` is less than `u32::MAX`
+        unsafe { Self::new_unchecked(sym.get().into()) }
     }
 }
 
 impl From<u16> for Symbol {
     #[inline]
-    fn from(id: u16) -> Self {
-        Self(id.into())
+    fn from(sym: u16) -> Self {
+        // Safety:
+        //
+        // `u16::MAX` is less than `u32::MAX`
+        unsafe { Self::new_unchecked(sym.into()) }
     }
 }
 
 impl From<NonZeroU16> for Symbol {
     #[inline]
     fn from(sym: NonZeroU16) -> Self {
-        Self(sym.get().into())
+        // Safety:
+        //
+        // `u16::MAX` is less than `u32::MAX`
+        unsafe { Self::new_unchecked(sym.get().into()) }
     }
 }
 
-impl From<u32> for Symbol {
+impl TryFrom<u32> for Symbol {
+    type Error = SymbolOverflowError;
+
     #[inline]
-    fn from(id: u32) -> Self {
-        Self(id)
+    fn try_from(sym: u32) -> Result<Self, Self::Error> {
+        let sym = Self::new(sym).ok_or_else(SymbolOverflowError::new)?;
+        Ok(sym)
     }
 }
 
-impl From<NonZeroU32> for Symbol {
+impl TryFrom<NonZeroU32> for Symbol {
+    type Error = SymbolOverflowError;
+
     #[inline]
-    fn from(sym: NonZeroU32) -> Self {
-        Self(sym.get())
+    fn try_from(sym: NonZeroU32) -> Result<Self, Self::Error> {
+        let sym = Self::new(sym.get()).ok_or_else(SymbolOverflowError::new)?;
+        Ok(sym)
     }
 }
 
@@ -50,9 +68,10 @@ impl TryFrom<u64> for Symbol {
     type Error = SymbolOverflowError;
 
     #[inline]
-    fn try_from(value: u64) -> Result<Self, Self::Error> {
-        let id = u32::try_from(value)?;
-        Ok(id.into())
+    fn try_from(sym: u64) -> Result<Self, Self::Error> {
+        let sym = u32::try_from(sym)?;
+        let sym = Self::new(sym).ok_or_else(SymbolOverflowError::new)?;
+        Ok(sym)
     }
 }
 
@@ -60,9 +79,10 @@ impl TryFrom<NonZeroU64> for Symbol {
     type Error = SymbolOverflowError;
 
     #[inline]
-    fn try_from(value: NonZeroU64) -> Result<Self, Self::Error> {
-        let id = u32::try_from(value.get())?;
-        Ok(id.into())
+    fn try_from(sym: NonZeroU64) -> Result<Self, Self::Error> {
+        let sym = u32::try_from(sym.get())?;
+        let sym = Self::new(sym).ok_or_else(SymbolOverflowError::new)?;
+        Ok(sym)
     }
 }
 
@@ -70,9 +90,10 @@ impl TryFrom<usize> for Symbol {
     type Error = SymbolOverflowError;
 
     #[inline]
-    fn try_from(value: usize) -> Result<Self, Self::Error> {
-        let id = u32::try_from(value)?;
-        Ok(id.into())
+    fn try_from(sym: usize) -> Result<Self, Self::Error> {
+        let sym = u32::try_from(sym)?;
+        let sym = Self::new(sym).ok_or_else(SymbolOverflowError::new)?;
+        Ok(sym)
     }
 }
 
@@ -80,51 +101,56 @@ impl TryFrom<NonZeroUsize> for Symbol {
     type Error = SymbolOverflowError;
 
     #[inline]
-    fn try_from(value: NonZeroUsize) -> Result<Self, Self::Error> {
-        let id = u32::try_from(value.get())?;
-        Ok(id.into())
+    fn try_from(sym: NonZeroUsize) -> Result<Self, Self::Error> {
+        let sym = u32::try_from(sym.get())?;
+        let sym = Self::new(sym).ok_or_else(SymbolOverflowError::new)?;
+        Ok(sym)
     }
 }
 
 impl From<&u8> for Symbol {
     #[inline]
-    fn from(id: &u8) -> Self {
-        Self((*id).into())
+    fn from(sym: &u8) -> Self {
+        (*sym).into()
     }
 }
 
 impl From<&NonZeroU8> for Symbol {
     #[inline]
     fn from(sym: &NonZeroU8) -> Self {
-        Self(sym.get().into())
+        sym.get().into()
     }
 }
 
 impl From<&u16> for Symbol {
     #[inline]
-    fn from(id: &u16) -> Self {
-        Self((*id).into())
+    fn from(sym: &u16) -> Self {
+        (*sym).into()
     }
 }
 
 impl From<&NonZeroU16> for Symbol {
     #[inline]
     fn from(sym: &NonZeroU16) -> Self {
-        Self(sym.get().into())
+        sym.get().into()
     }
 }
 
-impl From<&u32> for Symbol {
+impl TryFrom<&u32> for Symbol {
+    type Error = SymbolOverflowError;
+
     #[inline]
-    fn from(id: &u32) -> Self {
-        Self(*id)
+    fn try_from(sym: &u32) -> Result<Self, Self::Error> {
+        (*sym).try_into()
     }
 }
 
-impl From<&NonZeroU32> for Symbol {
+impl TryFrom<&NonZeroU32> for Symbol {
+    type Error = SymbolOverflowError;
+
     #[inline]
-    fn from(sym: &NonZeroU32) -> Self {
-        Self(sym.get())
+    fn try_from(sym: &NonZeroU32) -> Result<Self, Self::Error> {
+        sym.try_into()
     }
 }
 
@@ -132,9 +158,8 @@ impl TryFrom<&u64> for Symbol {
     type Error = SymbolOverflowError;
 
     #[inline]
-    fn try_from(value: &u64) -> Result<Self, Self::Error> {
-        let id = u32::try_from(*value)?;
-        Ok(id.into())
+    fn try_from(sym: &u64) -> Result<Self, Self::Error> {
+        (*sym).try_into()
     }
 }
 
@@ -142,9 +167,8 @@ impl TryFrom<&NonZeroU64> for Symbol {
     type Error = SymbolOverflowError;
 
     #[inline]
-    fn try_from(value: &NonZeroU64) -> Result<Self, Self::Error> {
-        let id = u32::try_from(value.get())?;
-        Ok(id.into())
+    fn try_from(sym: &NonZeroU64) -> Result<Self, Self::Error> {
+        sym.get().try_into()
     }
 }
 
@@ -152,9 +176,8 @@ impl TryFrom<&usize> for Symbol {
     type Error = SymbolOverflowError;
 
     #[inline]
-    fn try_from(value: &usize) -> Result<Self, Self::Error> {
-        let id = u32::try_from(*value)?;
-        Ok(id.into())
+    fn try_from(sym: &usize) -> Result<Self, Self::Error> {
+        (*sym).try_into()
     }
 }
 
@@ -162,9 +185,8 @@ impl TryFrom<&NonZeroUsize> for Symbol {
     type Error = SymbolOverflowError;
 
     #[inline]
-    fn try_from(value: &NonZeroUsize) -> Result<Self, Self::Error> {
-        let id = u32::try_from(value.get())?;
-        Ok(id.into())
+    fn try_from(sym: &NonZeroUsize) -> Result<Self, Self::Error> {
+        sym.get().try_into()
     }
 }
 

--- a/src/cstr.rs
+++ b/src/cstr.rs
@@ -941,6 +941,7 @@ mod tests {
     use quickcheck_macros::quickcheck;
 
     use super::SymbolTable;
+    use crate::Symbol;
 
     #[test]
     fn alloc_drop_new() {
@@ -1049,8 +1050,12 @@ mod tests {
 
     #[quickcheck]
     fn table_does_not_contain_missing_symbol_ids(sym: u32) -> bool {
-        let table = SymbolTable::new();
-        !table.contains(sym.into())
+        if let Some(sym) = Symbol::new(sym) {
+            let table = SymbolTable::new();
+            !table.contains(sym)
+        } else {
+            true
+        }
     }
 
     #[quickcheck]

--- a/src/cstr.rs
+++ b/src/cstr.rs
@@ -90,7 +90,7 @@ use crate::{Symbol, SymbolOverflowError, DEFAULT_SYMBOL_TABLE_CAPACITY};
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 #[cfg_attr(docsrs, doc(cfg(feature = "cstr")))]
 pub struct AllSymbols<'a> {
-    range: Range<usize>,
+    range: Range<u32>,
     // Hold a shared reference to the underlying `SymbolTable` to ensure the
     // table is not modified while we are iterating which would make the results
     // not match the real state.
@@ -101,9 +101,7 @@ impl<'a> Iterator for AllSymbols<'a> {
     type Item = Symbol;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let next = self.range.next()?;
-        debug_assert!(u32::try_from(next).is_ok());
-        Some((next as u32).into())
+        self.range.next().map(Symbol::from)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -115,33 +113,25 @@ impl<'a> Iterator for AllSymbols<'a> {
     }
 
     fn last(self) -> Option<Self::Item> {
-        let last = self.range.last()?;
-        debug_assert!(u32::try_from(last).is_ok());
-        Some((last as u32).into())
+        self.range.last().map(Symbol::from)
     }
 
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
-        let nth = self.range.nth(n)?;
-        debug_assert!(u32::try_from(nth).is_ok());
-        Some((nth as u32).into())
+        self.range.nth(n).map(Symbol::from)
     }
 
     fn collect<B: FromIterator<Self::Item>>(self) -> B {
-        self.range.map(|sym| Symbol::from(sym as u32)).collect()
+        self.range.map(Symbol::from).collect()
     }
 }
 
 impl<'a> DoubleEndedIterator for AllSymbols<'a> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        let next = self.range.next_back()?;
-        debug_assert!(u32::try_from(next).is_ok());
-        Some((next as u32).into())
+        self.range.next_back().map(Symbol::from)
     }
 
     fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
-        let nth = self.range.nth_back(n)?;
-        debug_assert!(u32::try_from(nth).is_ok());
-        Some((nth as u32).into())
+        self.range.nth_back(n).map(Symbol::from)
     }
 }
 
@@ -624,8 +614,14 @@ impl<S> SymbolTable<S> {
     /// # example().unwrap();
     /// ```
     pub fn all_symbols(&self) -> AllSymbols<'_> {
+        let len = self.len();
+        debug_assert!(
+            u32::try_from(len).is_ok(),
+            "Interner can hold at most u32::MAX symbols"
+        );
+        let len = len as u32;
         AllSymbols {
-            range: 0..self.len(),
+            range: 0_u32..len,
             phantom: PhantomData,
         }
     }

--- a/src/cstr.rs
+++ b/src/cstr.rs
@@ -715,7 +715,19 @@ where
             return Ok(id);
         }
         let name = Interned::from(contents);
+
         let id = self.map.len().try_into()?;
+        // If the number of symbols stored in the table is `u32::MAX`, then the
+        // last issued symbol was `u32::MAX - 1` because `(0..u32::MAX).count() == u32::MAX`.
+        //
+        // Creating a symbol with id `u32::MAX` means the range of ids in the
+        // table would be `0..=u32::MAX`, which means the table would store
+        // `u32::MAX + 1` symbols, which is beyond `SymbolTable`'s documented
+        // capacity.
+        if id == u32::MAX {
+            return Err(SymbolOverflowError::new());
+        }
+
         // Safety:
         //
         // This expression creates a reference with a `'static` lifetime

--- a/src/cstr.rs
+++ b/src/cstr.rs
@@ -101,7 +101,13 @@ impl<'a> Iterator for AllSymbols<'a> {
     type Item = Symbol;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.range.next().map(Symbol::from)
+        self.range.next().map(|sym| {
+            // Safety:
+            //
+            // `self.range` is a `Range<u32>` which can never yield
+            // `u32::MAX`.
+            unsafe { Symbol::new_unchecked(sym) }
+        })
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -113,25 +119,57 @@ impl<'a> Iterator for AllSymbols<'a> {
     }
 
     fn last(self) -> Option<Self::Item> {
-        self.range.last().map(Symbol::from)
+        self.range.last().map(|sym| {
+            // Safety:
+            //
+            // `self.range` is a `Range<u32>` which can never yield
+            // `u32::MAX`.
+            unsafe { Symbol::new_unchecked(sym) }
+        })
     }
 
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
-        self.range.nth(n).map(Symbol::from)
+        self.range.nth(n).map(|sym| {
+            // Safety:
+            //
+            // `self.range` is a `Range<u32>` which can never yield
+            // `u32::MAX`.
+            unsafe { Symbol::new_unchecked(sym) }
+        })
     }
 
     fn collect<B: FromIterator<Self::Item>>(self) -> B {
-        self.range.map(Symbol::from).collect()
+        self.range
+            .map(|sym| {
+                // Safety:
+                //
+                // `self.range` is a `Range<u32>` which can never yield
+                // `u32::MAX`.
+                unsafe { Symbol::new_unchecked(sym) }
+            })
+            .collect()
     }
 }
 
 impl<'a> DoubleEndedIterator for AllSymbols<'a> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        self.range.next_back().map(Symbol::from)
+        self.range.next_back().map(|sym| {
+            // Safety:
+            //
+            // `self.range` is a `Range<u32>` which can never yield
+            // `u32::MAX`.
+            unsafe { Symbol::new_unchecked(sym) }
+        })
     }
 
     fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
-        self.range.nth_back(n).map(Symbol::from)
+        self.range.nth_back(n).map(|sym| {
+            // Safety:
+            //
+            // `self.range` is a `Range<u32>` which can never yield
+            // `u32::MAX`.
+            unsafe { Symbol::new_unchecked(sym) }
+        })
     }
 }
 
@@ -718,7 +756,6 @@ where
             return Ok(id);
         }
 
-        let id = self.map.len().try_into()?;
         // If the number of symbols stored in the table is `u32::MAX`, then the
         // last issued symbol was `u32::MAX - 1` because `(0..u32::MAX).count() == u32::MAX`.
         //
@@ -726,9 +763,7 @@ where
         // table would be `0..=u32::MAX`, which means the table would store
         // `u32::MAX + 1` symbols, which is beyond `SymbolTable`'s documented
         // capacity.
-        if id == u32::MAX {
-            return Err(SymbolOverflowError::new());
-        }
+        let id = self.map.len().try_into()?;
 
         // If given `Cow::Owned(_)` this operation will potentially perform a
         // copy when converting the owned string into a boxed owned string.

--- a/src/cstr.rs
+++ b/src/cstr.rs
@@ -282,6 +282,9 @@ impl<'a> IntoIterator for &'a SymbolTable {
 /// This symbol table is implemented by storing [`CString`]s with a fast path
 /// for [`&CStr`] that are already `'static`.
 ///
+/// `SymbolTable`s store at most `u32::MAX` symbols. The maximum symbol id is
+/// `u32::MAX - 1`.
+///
 /// See module documentation for more.
 ///
 /// # Usage

--- a/src/cstr.rs
+++ b/src/cstr.rs
@@ -714,7 +714,6 @@ where
         if let Some(&id) = self.map.get(&*contents) {
             return Ok(id);
         }
-        let name = Interned::from(contents);
 
         let id = self.map.len().try_into()?;
         // If the number of symbols stored in the table is `u32::MAX`, then the
@@ -727,6 +726,10 @@ where
         if id == u32::MAX {
             return Err(SymbolOverflowError::new());
         }
+
+        // If given `Cow::Owned(_)` this operation will potentially perform a
+        // copy when converting the owned string into a boxed owned string.
+        let name = Interned::from(contents);
 
         // Safety:
         //

--- a/src/cstr.rs
+++ b/src/cstr.rs
@@ -37,8 +37,8 @@
 //!
 //! table.intern(CStr::from_bytes_with_nul(b"xyz\0")?)?;
 //! let mut map = HashMap::new();
-//! map.insert(Symbol::new(0), CStr::from_bytes_with_nul(b"abc\0")?);
-//! map.insert(Symbol::new(1), CStr::from_bytes_with_nul(b"xyz\0")?);
+//! map.insert(Symbol::try_from(0_u32)?, CStr::from_bytes_with_nul(b"abc\0")?);
+//! map.insert(Symbol::try_from(1_u32)?, CStr::from_bytes_with_nul(b"xyz\0")?);
 //! // Retrieve symbol to C string content mappings.
 //! let iter = table.iter();
 //! assert_eq!(map, iter.collect::<HashMap<_, _>>());
@@ -266,7 +266,7 @@ impl<'a> FusedIterator for CStrings<'a> {}
 /// let sym = table.intern(CStr::from_bytes_with_nul(b"abc\0")?)?;
 /// let iter = table.iter();
 /// let mut map = HashMap::new();
-/// map.insert(Symbol::new(0), CStr::from_bytes_with_nul(b"abc\0")?);
+/// map.insert(Symbol::try_from(0_u32)?, CStr::from_bytes_with_nul(b"abc\0")?);
 /// assert_eq!(map, iter.collect::<HashMap<_, _>>());
 /// # Ok(())
 /// # }
@@ -521,10 +521,10 @@ impl<S> SymbolTable<S> {
     /// # use intaglio::Symbol;
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
-    /// assert!(!table.contains(Symbol::new(0)));
+    /// assert!(!table.contains(Symbol::try_from(0_u32)?));
     ///
     /// let sym = table.intern(CString::new(*b"abc")?)?;
-    /// assert!(table.contains(Symbol::new(0)));
+    /// assert!(table.contains(Symbol::try_from(0_u32)?));
     /// assert!(table.contains(sym));
     /// # Ok(())
     /// # }
@@ -550,10 +550,10 @@ impl<S> SymbolTable<S> {
     /// # use intaglio::Symbol;
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
-    /// assert!(table.get(Symbol::new(0)).is_none());
+    /// assert!(table.get(Symbol::try_from(0_u32)?).is_none());
     ///
     /// let sym = table.intern(CString::new(*b"abc")?)?;
-    /// assert_eq!(Some(CStr::from_bytes_with_nul(b"abc\0")?), table.get(Symbol::new(0)));
+    /// assert_eq!(Some(CStr::from_bytes_with_nul(b"abc\0")?), table.get(Symbol::try_from(0_u32)?));
     /// assert_eq!(Some(CStr::from_bytes_with_nul(b"abc\0")?), table.get(sym));
     /// # Ok(())
     /// # }
@@ -584,10 +584,10 @@ impl<S> SymbolTable<S> {
     ///
     /// let iter = table.iter();
     /// let mut map = HashMap::new();
-    /// map.insert(Symbol::new(0), CStr::from_bytes_with_nul(b"abc\0")?);
-    /// map.insert(Symbol::new(1), CStr::from_bytes_with_nul(b"xyz\0")?);
-    /// map.insert(Symbol::new(2), CStr::from_bytes_with_nul(b"123\0")?);
-    /// map.insert(Symbol::new(3), CStr::from_bytes_with_nul(b"789\0")?);
+    /// map.insert(Symbol::try_from(0_u32)?, CStr::from_bytes_with_nul(b"abc\0")?);
+    /// map.insert(Symbol::try_from(1_u32)?, CStr::from_bytes_with_nul(b"xyz\0")?);
+    /// map.insert(Symbol::try_from(2_u32)?, CStr::from_bytes_with_nul(b"123\0")?);
+    /// map.insert(Symbol::try_from(3_u32)?, CStr::from_bytes_with_nul(b"789\0")?);
     /// assert_eq!(map, iter.collect::<HashMap<_, _>>());
     /// # Ok(())
     /// # }
@@ -630,8 +630,8 @@ impl<S> SymbolTable<S> {
     /// table.intern(CString::new(*b"789")?)?;
     ///
     /// let mut all_symbols = table.all_symbols();
-    /// assert_eq!(Some(Symbol::new(0)), all_symbols.next());
-    /// assert_eq!(Some(Symbol::new(1)), all_symbols.nth_back(2));
+    /// assert_eq!(Some(Symbol::try_from(0_u32)?), all_symbols.next());
+    /// assert_eq!(Some(Symbol::try_from(1_u32)?), all_symbols.nth_back(2));
     /// assert_eq!(None, all_symbols.next());
     /// # Ok(())
     /// # }
@@ -811,7 +811,7 @@ where
     ///
     /// table.intern(CString::new(*b"abc")?)?;
     /// assert!(table.is_interned(CStr::from_bytes_with_nul(b"abc\0")?));
-    /// assert_eq!(Some(Symbol::new(0)), table.check_interned(CStr::from_bytes_with_nul(b"abc\0")?));
+    /// assert_eq!(Some(Symbol::try_from(0_u32)?), table.check_interned(CStr::from_bytes_with_nul(b"abc\0")?));
     /// # Ok(())
     /// # }
     /// # example().unwrap();
@@ -838,7 +838,7 @@ where
     ///
     /// table.intern(CString::new(*b"abc")?)?;
     /// assert!(table.is_interned(CStr::from_bytes_with_nul(b"abc\0")?));
-    /// assert_eq!(Some(Symbol::new(0)), table.check_interned(CStr::from_bytes_with_nul(b"abc\0")?));
+    /// assert_eq!(Some(Symbol::try_from(0_u32)?), table.check_interned(CStr::from_bytes_with_nul(b"abc\0")?));
     /// # Ok(())
     /// # }
     /// # example().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,7 @@
 //! [`&Path`]: std::path::Path
 //! [`&'static Path`]: std::path::Path
 
-#![doc(html_root_url = "https://docs.rs/intaglio/1.5.0")]
+#![doc(html_root_url = "https://docs.rs/intaglio/2.0.0")]
 
 // Ensure code blocks in README.md compile
 #[cfg(all(doctest, feature = "bytes", feature = "cstr", feature = "path"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,9 @@
 //! [`Symbol`]s are `u32` indexes into a `SymbolTable` that are cheap to
 //! compare, copy, store, and send.
 //!
+//! `SymbolTable`s store at most `u32::MAX` symbols. The maximum symbol id is
+//! `u32::MAX - 1`.
+//!
 //! # Allocations
 //!
 //! `SymbolTable` exposes several constructors for tuning the initial allocated

--- a/src/osstr.rs
+++ b/src/osstr.rs
@@ -941,6 +941,7 @@ mod tests {
     use quickcheck_macros::quickcheck;
 
     use super::SymbolTable;
+    use crate::Symbol;
 
     #[test]
     fn alloc_drop_new() {
@@ -1027,8 +1028,12 @@ mod tests {
 
     #[quickcheck]
     fn table_does_not_contain_missing_symbol_ids(sym: u32) -> bool {
-        let table = SymbolTable::new();
-        !table.contains(sym.into())
+        if let Some(sym) = Symbol::new(sym) {
+            let table = SymbolTable::new();
+            !table.contains(sym)
+        } else {
+            true
+        }
     }
 
     #[quickcheck]

--- a/src/osstr.rs
+++ b/src/osstr.rs
@@ -37,8 +37,8 @@
 //!
 //! table.intern(OsStr::new("xyz"))?;
 //! let mut map = HashMap::new();
-//! map.insert(Symbol::new(0), OsStr::new("abc"));
-//! map.insert(Symbol::new(1), OsStr::new("xyz"));
+//! map.insert(Symbol::try_from(0_u32)?, OsStr::new("abc"));
+//! map.insert(Symbol::try_from(1_u32)?, OsStr::new("xyz"));
 //! // Retrieve symbol to platform string content mappings.
 //! let iter = table.iter();
 //! assert_eq!(map, iter.collect::<HashMap<_, _>>());
@@ -266,7 +266,7 @@ impl<'a> FusedIterator for OsStrings<'a> {}
 /// let sym = table.intern(OsStr::new("abc"))?;
 /// let iter = table.iter();
 /// let mut map = HashMap::new();
-/// map.insert(Symbol::new(0), OsStr::new("abc"));
+/// map.insert(Symbol::try_from(0_u32)?, OsStr::new("abc"));
 /// assert_eq!(map, iter.collect::<HashMap<_, _>>());
 /// # Ok(())
 /// # }
@@ -521,10 +521,10 @@ impl<S> SymbolTable<S> {
     /// # use intaglio::Symbol;
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
-    /// assert!(!table.contains(Symbol::new(0)));
+    /// assert!(!table.contains(Symbol::try_from(0_u32)?));
     ///
     /// let sym = table.intern(OsString::from("abc"))?;
-    /// assert!(table.contains(Symbol::new(0)));
+    /// assert!(table.contains(Symbol::try_from(0_u32)?));
     /// assert!(table.contains(sym));
     /// # Ok(())
     /// # }
@@ -550,10 +550,10 @@ impl<S> SymbolTable<S> {
     /// # use intaglio::Symbol;
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
-    /// assert!(table.get(Symbol::new(0)).is_none());
+    /// assert!(table.get(Symbol::try_from(0_u32)?).is_none());
     ///
     /// let sym = table.intern(OsString::from("abc"))?;
-    /// assert_eq!(Some(OsStr::new("abc")), table.get(Symbol::new(0)));
+    /// assert_eq!(Some(OsStr::new("abc")), table.get(Symbol::try_from(0_u32)?));
     /// assert_eq!(Some(OsStr::new("abc")), table.get(sym));
     /// # Ok(())
     /// # }
@@ -584,10 +584,10 @@ impl<S> SymbolTable<S> {
     ///
     /// let iter = table.iter();
     /// let mut map = HashMap::new();
-    /// map.insert(Symbol::new(0), OsStr::new("abc"));
-    /// map.insert(Symbol::new(1), OsStr::new("xyz"));
-    /// map.insert(Symbol::new(2), OsStr::new("123"));
-    /// map.insert(Symbol::new(3), OsStr::new("789"));
+    /// map.insert(Symbol::try_from(0_u32)?, OsStr::new("abc"));
+    /// map.insert(Symbol::try_from(1_u32)?, OsStr::new("xyz"));
+    /// map.insert(Symbol::try_from(2_u32)?, OsStr::new("123"));
+    /// map.insert(Symbol::try_from(3_u32)?, OsStr::new("789"));
     /// assert_eq!(map, iter.collect::<HashMap<_, _>>());
     /// # Ok(())
     /// # }
@@ -630,8 +630,8 @@ impl<S> SymbolTable<S> {
     /// table.intern(OsString::from("789"))?;
     ///
     /// let mut all_symbols = table.all_symbols();
-    /// assert_eq!(Some(Symbol::new(0)), all_symbols.next());
-    /// assert_eq!(Some(Symbol::new(1)), all_symbols.nth_back(2));
+    /// assert_eq!(Some(Symbol::try_from(0_u32)?), all_symbols.next());
+    /// assert_eq!(Some(Symbol::try_from(1_u32)?), all_symbols.nth_back(2));
     /// assert_eq!(None, all_symbols.next());
     /// # Ok(())
     /// # }
@@ -811,7 +811,7 @@ where
     ///
     /// table.intern(OsString::from("abc"))?;
     /// assert!(table.is_interned(OsStr::new("abc")));
-    /// assert_eq!(Some(Symbol::new(0)), table.check_interned(OsStr::new("abc")));
+    /// assert_eq!(Some(Symbol::try_from(0_u32)?), table.check_interned(OsStr::new("abc")));
     /// # Ok(())
     /// # }
     /// # example().unwrap();
@@ -838,7 +838,7 @@ where
     ///
     /// table.intern(OsString::from("abc"))?;
     /// assert!(table.is_interned(OsStr::new("abc")));
-    /// assert_eq!(Some(Symbol::new(0)), table.check_interned(OsStr::new("abc")));
+    /// assert_eq!(Some(Symbol::try_from(0_u32)?), table.check_interned(OsStr::new("abc")));
     /// # Ok(())
     /// # }
     /// # example().unwrap();

--- a/src/osstr.rs
+++ b/src/osstr.rs
@@ -715,7 +715,19 @@ where
             return Ok(id);
         }
         let name = Interned::from(contents);
+
         let id = self.map.len().try_into()?;
+        // If the number of symbols stored in the table is `u32::MAX`, then the
+        // last issued symbol was `u32::MAX - 1` because `(0..u32::MAX).count() == u32::MAX`.
+        //
+        // Creating a symbol with id `u32::MAX` means the range of ids in the
+        // table would be `0..=u32::MAX`, which means the table would store
+        // `u32::MAX + 1` symbols, which is beyond `SymbolTable`'s documented
+        // capacity.
+        if id == u32::MAX {
+            return Err(SymbolOverflowError::new());
+        }
+
         // Safety:
         //
         // This expression creates a reference with a `'static` lifetime

--- a/src/osstr.rs
+++ b/src/osstr.rs
@@ -101,7 +101,13 @@ impl<'a> Iterator for AllSymbols<'a> {
     type Item = Symbol;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.range.next().map(Symbol::from)
+        self.range.next().map(|sym| {
+            // Safety:
+            //
+            // `self.range` is a `Range<u32>` which can never yield
+            // `u32::MAX`.
+            unsafe { Symbol::new_unchecked(sym) }
+        })
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -113,25 +119,57 @@ impl<'a> Iterator for AllSymbols<'a> {
     }
 
     fn last(self) -> Option<Self::Item> {
-        self.range.last().map(Symbol::from)
+        self.range.last().map(|sym| {
+            // Safety:
+            //
+            // `self.range` is a `Range<u32>` which can never yield
+            // `u32::MAX`.
+            unsafe { Symbol::new_unchecked(sym) }
+        })
     }
 
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
-        self.range.nth(n).map(Symbol::from)
+        self.range.nth(n).map(|sym| {
+            // Safety:
+            //
+            // `self.range` is a `Range<u32>` which can never yield
+            // `u32::MAX`.
+            unsafe { Symbol::new_unchecked(sym) }
+        })
     }
 
     fn collect<B: FromIterator<Self::Item>>(self) -> B {
-        self.range.map(Symbol::from).collect()
+        self.range
+            .map(|sym| {
+                // Safety:
+                //
+                // `self.range` is a `Range<u32>` which can never yield
+                // `u32::MAX`.
+                unsafe { Symbol::new_unchecked(sym) }
+            })
+            .collect()
     }
 }
 
 impl<'a> DoubleEndedIterator for AllSymbols<'a> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        self.range.next_back().map(Symbol::from)
+        self.range.next_back().map(|sym| {
+            // Safety:
+            //
+            // `self.range` is a `Range<u32>` which can never yield
+            // `u32::MAX`.
+            unsafe { Symbol::new_unchecked(sym) }
+        })
     }
 
     fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
-        self.range.nth_back(n).map(Symbol::from)
+        self.range.nth_back(n).map(|sym| {
+            // Safety:
+            //
+            // `self.range` is a `Range<u32>` which can never yield
+            // `u32::MAX`.
+            unsafe { Symbol::new_unchecked(sym) }
+        })
     }
 }
 
@@ -718,7 +756,6 @@ where
             return Ok(id);
         }
 
-        let id = self.map.len().try_into()?;
         // If the number of symbols stored in the table is `u32::MAX`, then the
         // last issued symbol was `u32::MAX - 1` because `(0..u32::MAX).count() == u32::MAX`.
         //
@@ -726,9 +763,7 @@ where
         // table would be `0..=u32::MAX`, which means the table would store
         // `u32::MAX + 1` symbols, which is beyond `SymbolTable`'s documented
         // capacity.
-        if id == u32::MAX {
-            return Err(SymbolOverflowError::new());
-        }
+        let id = self.map.len().try_into()?;
 
         // If given `Cow::Owned(_)` this operation will potentially perform a
         // copy when converting the owned string into a boxed owned string.

--- a/src/osstr.rs
+++ b/src/osstr.rs
@@ -714,7 +714,6 @@ where
         if let Some(&id) = self.map.get(&*contents) {
             return Ok(id);
         }
-        let name = Interned::from(contents);
 
         let id = self.map.len().try_into()?;
         // If the number of symbols stored in the table is `u32::MAX`, then the
@@ -727,6 +726,10 @@ where
         if id == u32::MAX {
             return Err(SymbolOverflowError::new());
         }
+
+        // If given `Cow::Owned(_)` this operation will potentially perform a
+        // copy when converting the owned string into a boxed owned string.
+        let name = Interned::from(contents);
 
         // Safety:
         //

--- a/src/osstr.rs
+++ b/src/osstr.rs
@@ -282,6 +282,9 @@ impl<'a> IntoIterator for &'a SymbolTable {
 /// This symbol table is implemented by storing [`OsString`]s with a fast path
 /// for [`&OsStr`] that are already `'static`.
 ///
+/// `SymbolTable`s store at most `u32::MAX` symbols. The maximum symbol id is
+/// `u32::MAX - 1`.
+///
 /// See module documentation for more.
 ///
 /// # Usage

--- a/src/osstr.rs
+++ b/src/osstr.rs
@@ -90,7 +90,7 @@ use crate::{Symbol, SymbolOverflowError, DEFAULT_SYMBOL_TABLE_CAPACITY};
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 #[cfg_attr(docsrs, doc(cfg(feature = "osstr")))]
 pub struct AllSymbols<'a> {
-    range: Range<usize>,
+    range: Range<u32>,
     // Hold a shared reference to the underlying `SymbolTable` to ensure the
     // table is not modified while we are iterating which would make the results
     // not match the real state.
@@ -101,9 +101,7 @@ impl<'a> Iterator for AllSymbols<'a> {
     type Item = Symbol;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let next = self.range.next()?;
-        debug_assert!(u32::try_from(next).is_ok());
-        Some((next as u32).into())
+        self.range.next().map(Symbol::from)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -115,33 +113,25 @@ impl<'a> Iterator for AllSymbols<'a> {
     }
 
     fn last(self) -> Option<Self::Item> {
-        let last = self.range.last()?;
-        debug_assert!(u32::try_from(last).is_ok());
-        Some((last as u32).into())
+        self.range.last().map(Symbol::from)
     }
 
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
-        let nth = self.range.nth(n)?;
-        debug_assert!(u32::try_from(nth).is_ok());
-        Some((nth as u32).into())
+        self.range.nth(n).map(Symbol::from)
     }
 
     fn collect<B: FromIterator<Self::Item>>(self) -> B {
-        self.range.map(|sym| Symbol::from(sym as u32)).collect()
+        self.range.map(Symbol::from).collect()
     }
 }
 
 impl<'a> DoubleEndedIterator for AllSymbols<'a> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        let next = self.range.next_back()?;
-        debug_assert!(u32::try_from(next).is_ok());
-        Some((next as u32).into())
+        self.range.next_back().map(Symbol::from)
     }
 
     fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
-        let nth = self.range.nth_back(n)?;
-        debug_assert!(u32::try_from(nth).is_ok());
-        Some((nth as u32).into())
+        self.range.nth_back(n).map(Symbol::from)
     }
 }
 
@@ -624,8 +614,14 @@ impl<S> SymbolTable<S> {
     /// # example().unwrap();
     /// ```
     pub fn all_symbols(&self) -> AllSymbols<'_> {
+        let len = self.len();
+        debug_assert!(
+            u32::try_from(len).is_ok(),
+            "Interner can hold at most u32::MAX symbols"
+        );
+        let len = len as u32;
         AllSymbols {
-            range: 0..self.len(),
+            range: 0_u32..len,
             phantom: PhantomData,
         }
     }

--- a/src/path.rs
+++ b/src/path.rs
@@ -941,6 +941,7 @@ mod tests {
     use quickcheck_macros::quickcheck;
 
     use super::SymbolTable;
+    use crate::Symbol;
 
     #[test]
     fn alloc_drop_new() {
@@ -1027,8 +1028,12 @@ mod tests {
 
     #[quickcheck]
     fn table_does_not_contain_missing_symbol_ids(sym: u32) -> bool {
-        let table = SymbolTable::new();
-        !table.contains(sym.into())
+        if let Some(sym) = Symbol::new(sym) {
+            let table = SymbolTable::new();
+            !table.contains(sym)
+        } else {
+            true
+        }
     }
 
     #[quickcheck]

--- a/src/path.rs
+++ b/src/path.rs
@@ -37,8 +37,8 @@
 //!
 //! table.intern(Path::new("xyz"))?;
 //! let mut map = HashMap::new();
-//! map.insert(Symbol::new(0), Path::new("abc"));
-//! map.insert(Symbol::new(1), Path::new("xyz"));
+//! map.insert(Symbol::try_from(0_u32)?, Path::new("abc"));
+//! map.insert(Symbol::try_from(1_u32)?, Path::new("xyz"));
 //! // Retrieve symbol to path string content mappings.
 //! let iter = table.iter();
 //! assert_eq!(map, iter.collect::<HashMap<_, _>>());
@@ -266,7 +266,7 @@ impl<'a> FusedIterator for Paths<'a> {}
 /// let sym = table.intern(Path::new("abc"))?;
 /// let iter = table.iter();
 /// let mut map = HashMap::new();
-/// map.insert(Symbol::new(0), Path::new("abc"));
+/// map.insert(Symbol::try_from(0_u32)?, Path::new("abc"));
 /// assert_eq!(map, iter.collect::<HashMap<_, _>>());
 /// # Ok(())
 /// # }
@@ -521,10 +521,10 @@ impl<S> SymbolTable<S> {
     /// # use intaglio::Symbol;
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
-    /// assert!(!table.contains(Symbol::new(0)));
+    /// assert!(!table.contains(Symbol::try_from(0_u32)?));
     ///
     /// let sym = table.intern(PathBuf::from("abc"))?;
-    /// assert!(table.contains(Symbol::new(0)));
+    /// assert!(table.contains(Symbol::try_from(0_u32)?));
     /// assert!(table.contains(sym));
     /// # Ok(())
     /// # }
@@ -550,10 +550,10 @@ impl<S> SymbolTable<S> {
     /// # use intaglio::Symbol;
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
-    /// assert!(table.get(Symbol::new(0)).is_none());
+    /// assert!(table.get(Symbol::try_from(0_u32)?).is_none());
     ///
     /// let sym = table.intern(PathBuf::from("abc"))?;
-    /// assert_eq!(Some(Path::new("abc")), table.get(Symbol::new(0)));
+    /// assert_eq!(Some(Path::new("abc")), table.get(Symbol::try_from(0_u32)?));
     /// assert_eq!(Some(Path::new("abc")), table.get(sym));
     /// # Ok(())
     /// # }
@@ -584,10 +584,10 @@ impl<S> SymbolTable<S> {
     ///
     /// let iter = table.iter();
     /// let mut map = HashMap::new();
-    /// map.insert(Symbol::new(0), Path::new("abc"));
-    /// map.insert(Symbol::new(1), Path::new("xyz"));
-    /// map.insert(Symbol::new(2), Path::new("123"));
-    /// map.insert(Symbol::new(3), Path::new("789"));
+    /// map.insert(Symbol::try_from(0_u32)?, Path::new("abc"));
+    /// map.insert(Symbol::try_from(1_u32)?, Path::new("xyz"));
+    /// map.insert(Symbol::try_from(2_u32)?, Path::new("123"));
+    /// map.insert(Symbol::try_from(3_u32)?, Path::new("789"));
     /// assert_eq!(map, iter.collect::<HashMap<_, _>>());
     /// # Ok(())
     /// # }
@@ -630,8 +630,8 @@ impl<S> SymbolTable<S> {
     /// table.intern(PathBuf::from("789"))?;
     ///
     /// let mut all_symbols = table.all_symbols();
-    /// assert_eq!(Some(Symbol::new(0)), all_symbols.next());
-    /// assert_eq!(Some(Symbol::new(1)), all_symbols.nth_back(2));
+    /// assert_eq!(Some(Symbol::try_from(0_u32)?), all_symbols.next());
+    /// assert_eq!(Some(Symbol::try_from(1_u32)?), all_symbols.nth_back(2));
     /// assert_eq!(None, all_symbols.next());
     /// # Ok(())
     /// # }
@@ -811,7 +811,7 @@ where
     ///
     /// table.intern(PathBuf::from("abc"))?;
     /// assert!(table.is_interned(Path::new("abc")));
-    /// assert_eq!(Some(Symbol::new(0)), table.check_interned(Path::new("abc")));
+    /// assert_eq!(Some(Symbol::try_from(0_u32)?), table.check_interned(Path::new("abc")));
     /// # Ok(())
     /// # }
     /// # example().unwrap();
@@ -838,7 +838,7 @@ where
     ///
     /// table.intern(PathBuf::from("abc"))?;
     /// assert!(table.is_interned(Path::new("abc")));
-    /// assert_eq!(Some(Symbol::new(0)), table.check_interned(Path::new("abc")));
+    /// assert_eq!(Some(Symbol::try_from(0_u32)?), table.check_interned(Path::new("abc")));
     /// # Ok(())
     /// # }
     /// # example().unwrap();

--- a/src/path.rs
+++ b/src/path.rs
@@ -715,7 +715,19 @@ where
             return Ok(id);
         }
         let name = Interned::from(contents);
+
         let id = self.map.len().try_into()?;
+        // If the number of symbols stored in the table is `u32::MAX`, then the
+        // last issued symbol was `u32::MAX - 1` because `(0..u32::MAX).count() == u32::MAX`.
+        //
+        // Creating a symbol with id `u32::MAX` means the range of ids in the
+        // table would be `0..=u32::MAX`, which means the table would store
+        // `u32::MAX + 1` symbols, which is beyond `SymbolTable`'s documented
+        // capacity.
+        if id == u32::MAX {
+            return Err(SymbolOverflowError::new());
+        }
+
         // Safety:
         //
         // This expression creates a reference with a `'static` lifetime

--- a/src/path.rs
+++ b/src/path.rs
@@ -101,7 +101,13 @@ impl<'a> Iterator for AllSymbols<'a> {
     type Item = Symbol;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.range.next().map(Symbol::from)
+        self.range.next().map(|sym| {
+            // Safety:
+            //
+            // `self.range` is a `Range<u32>` which can never yield
+            // `u32::MAX`.
+            unsafe { Symbol::new_unchecked(sym) }
+        })
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -113,25 +119,57 @@ impl<'a> Iterator for AllSymbols<'a> {
     }
 
     fn last(self) -> Option<Self::Item> {
-        self.range.last().map(Symbol::from)
+        self.range.last().map(|sym| {
+            // Safety:
+            //
+            // `self.range` is a `Range<u32>` which can never yield
+            // `u32::MAX`.
+            unsafe { Symbol::new_unchecked(sym) }
+        })
     }
 
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
-        self.range.nth(n).map(Symbol::from)
+        self.range.nth(n).map(|sym| {
+            // Safety:
+            //
+            // `self.range` is a `Range<u32>` which can never yield
+            // `u32::MAX`.
+            unsafe { Symbol::new_unchecked(sym) }
+        })
     }
 
     fn collect<B: FromIterator<Self::Item>>(self) -> B {
-        self.range.map(Symbol::from).collect()
+        self.range
+            .map(|sym| {
+                // Safety:
+                //
+                // `self.range` is a `Range<u32>` which can never yield
+                // `u32::MAX`.
+                unsafe { Symbol::new_unchecked(sym) }
+            })
+            .collect()
     }
 }
 
 impl<'a> DoubleEndedIterator for AllSymbols<'a> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        self.range.next_back().map(Symbol::from)
+        self.range.next_back().map(|sym| {
+            // Safety:
+            //
+            // `self.range` is a `Range<u32>` which can never yield
+            // `u32::MAX`.
+            unsafe { Symbol::new_unchecked(sym) }
+        })
     }
 
     fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
-        self.range.nth_back(n).map(Symbol::from)
+        self.range.nth_back(n).map(|sym| {
+            // Safety:
+            //
+            // `self.range` is a `Range<u32>` which can never yield
+            // `u32::MAX`.
+            unsafe { Symbol::new_unchecked(sym) }
+        })
     }
 }
 
@@ -718,7 +756,6 @@ where
             return Ok(id);
         }
 
-        let id = self.map.len().try_into()?;
         // If the number of symbols stored in the table is `u32::MAX`, then the
         // last issued symbol was `u32::MAX - 1` because `(0..u32::MAX).count() == u32::MAX`.
         //
@@ -726,9 +763,7 @@ where
         // table would be `0..=u32::MAX`, which means the table would store
         // `u32::MAX + 1` symbols, which is beyond `SymbolTable`'s documented
         // capacity.
-        if id == u32::MAX {
-            return Err(SymbolOverflowError::new());
-        }
+        let id = self.map.len().try_into()?;
 
         // If given `Cow::Owned(_)` this operation will potentially perform a
         // copy when converting the owned string into a boxed owned string.

--- a/src/path.rs
+++ b/src/path.rs
@@ -714,7 +714,6 @@ where
         if let Some(&id) = self.map.get(&*contents) {
             return Ok(id);
         }
-        let name = Interned::from(contents);
 
         let id = self.map.len().try_into()?;
         // If the number of symbols stored in the table is `u32::MAX`, then the
@@ -727,6 +726,10 @@ where
         if id == u32::MAX {
             return Err(SymbolOverflowError::new());
         }
+
+        // If given `Cow::Owned(_)` this operation will potentially perform a
+        // copy when converting the owned string into a boxed owned string.
+        let name = Interned::from(contents);
 
         // Safety:
         //

--- a/src/path.rs
+++ b/src/path.rs
@@ -282,6 +282,9 @@ impl<'a> IntoIterator for &'a SymbolTable {
 /// This symbol table is implemented by storing [`PathBuf`]s with a fast path
 /// for [`&Path`] that are already `'static`.
 ///
+/// `SymbolTable`s store at most `u32::MAX` symbols. The maximum symbol id is
+/// `u32::MAX - 1`.
+///
 /// See module documentation for more.
 ///
 /// # Usage

--- a/src/str.rs
+++ b/src/str.rs
@@ -849,6 +849,7 @@ mod tests {
     use quickcheck_macros::quickcheck;
 
     use super::SymbolTable;
+    use crate::Symbol;
 
     #[test]
     fn alloc_drop_new() {
@@ -935,8 +936,12 @@ mod tests {
 
     #[quickcheck]
     fn table_does_not_contain_missing_symbol_ids(sym: u32) -> bool {
-        let table = SymbolTable::new();
-        !table.contains(sym.into())
+        if let Some(sym) = Symbol::new(sym) {
+            let table = SymbolTable::new();
+            !table.contains(sym)
+        } else {
+            true
+        }
     }
 
     #[quickcheck]

--- a/src/str.rs
+++ b/src/str.rs
@@ -204,7 +204,7 @@ impl<'a> FusedIterator for Strings<'a> {}
 /// let sym = table.intern("abc")?;
 /// let iter = table.iter();
 /// let mut map = HashMap::new();
-/// map.insert(Symbol::new(0), "abc");
+/// map.insert(Symbol::try_from(0_u32)?, "abc");
 /// assert_eq!(map, iter.collect::<HashMap<_, _>>());
 /// # Ok(())
 /// # }
@@ -449,10 +449,10 @@ impl<S> SymbolTable<S> {
     /// # use intaglio::{Symbol, SymbolTable};
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
-    /// assert!(!table.contains(Symbol::new(0)));
+    /// assert!(!table.contains(Symbol::try_from(0_u32)?));
     ///
     /// let sym = table.intern("abc")?;
-    /// assert!(table.contains(Symbol::new(0)));
+    /// assert!(table.contains(Symbol::try_from(0_u32)?));
     /// assert!(table.contains(sym));
     /// # Ok(())
     /// # }
@@ -476,10 +476,10 @@ impl<S> SymbolTable<S> {
     /// # use intaglio::{Symbol, SymbolTable};
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut table = SymbolTable::new();
-    /// assert!(table.get(Symbol::new(0)).is_none());
+    /// assert!(table.get(Symbol::try_from(0_u32)?).is_none());
     ///
     /// let sym = table.intern("abc".to_string())?;
-    /// assert_eq!(Some("abc"), table.get(Symbol::new(0)));
+    /// assert_eq!(Some("abc"), table.get(Symbol::try_from(0_u32)?));
     /// assert_eq!(Some("abc"), table.get(sym));
     /// # Ok(())
     /// # }
@@ -508,10 +508,10 @@ impl<S> SymbolTable<S> {
     ///
     /// let iter = table.iter();
     /// let mut map = HashMap::new();
-    /// map.insert(Symbol::new(0), "abc");
-    /// map.insert(Symbol::new(1), "xyz");
-    /// map.insert(Symbol::new(2), "123");
-    /// map.insert(Symbol::new(3), "789");
+    /// map.insert(Symbol::try_from(0_u32)?, "abc");
+    /// map.insert(Symbol::try_from(1_u32)?, "xyz");
+    /// map.insert(Symbol::try_from(2_u32)?, "123");
+    /// map.insert(Symbol::try_from(3_u32)?, "789");
     /// assert_eq!(map, iter.collect::<HashMap<_, _>>());
     /// # Ok(())
     /// # }
@@ -551,8 +551,8 @@ impl<S> SymbolTable<S> {
     /// table.intern("789")?;
     ///
     /// let mut all_symbols = table.all_symbols();
-    /// assert_eq!(Some(Symbol::new(0)), all_symbols.next());
-    /// assert_eq!(Some(Symbol::new(1)), all_symbols.nth_back(2));
+    /// assert_eq!(Some(Symbol::try_from(0_u32)?), all_symbols.next());
+    /// assert_eq!(Some(Symbol::try_from(1_u32)?), all_symbols.nth_back(2));
     /// assert_eq!(None, all_symbols.next());
     /// # Ok(())
     /// # }
@@ -726,7 +726,7 @@ where
     ///
     /// table.intern("abc".to_string())?;
     /// assert!(table.is_interned("abc"));
-    /// assert_eq!(Some(Symbol::new(0)), table.check_interned("abc"));
+    /// assert_eq!(Some(Symbol::try_from(0_u32)?), table.check_interned("abc"));
     /// # Ok(())
     /// # }
     /// # example().unwrap();
@@ -751,7 +751,7 @@ where
     ///
     /// table.intern("abc".to_string())?;
     /// assert!(table.is_interned("abc"));
-    /// assert_eq!(Some(Symbol::new(0)), table.check_interned("abc"));
+    /// assert_eq!(Some(Symbol::try_from(0_u32)?), table.check_interned("abc"));
     /// # Ok(())
     /// # }
     /// # example().unwrap();

--- a/src/str.rs
+++ b/src/str.rs
@@ -631,7 +631,6 @@ where
         if let Some(&id) = self.map.get(&*contents) {
             return Ok(id);
         }
-        let name = Interned::from(contents);
 
         let id = self.map.len().try_into()?;
         // If the number of symbols stored in the table is `u32::MAX`, then the
@@ -644,6 +643,10 @@ where
         if id == u32::MAX {
             return Err(SymbolOverflowError::new());
         }
+
+        // If given `Cow::Owned(_)` this operation will potentially perform a
+        // copy when converting the owned string into a boxed owned string.
+        let name = Interned::from(contents);
 
         // Safety:
         //

--- a/src/str.rs
+++ b/src/str.rs
@@ -219,6 +219,9 @@ impl<'a> IntoIterator for &'a SymbolTable {
 /// This symbol table is implemented by storing UTF-8 strings with a fast path
 /// for `&str` that are already `'static`.
 ///
+/// `SymbolTable`s store at most `u32::MAX` symbols. The maximum symbol id is
+/// `u32::MAX - 1`.
+///
 /// See crate documentation for more.
 ///
 /// # Usage

--- a/src/str.rs
+++ b/src/str.rs
@@ -32,7 +32,7 @@ use crate::{Symbol, SymbolOverflowError, DEFAULT_SYMBOL_TABLE_CAPACITY};
 /// ```
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub struct AllSymbols<'a> {
-    range: Range<usize>,
+    range: Range<u32>,
     // Hold a shared reference to the underlying `SymbolTable` to ensure the
     // table is not modified while we are iterating which would make the results
     // not match the real state.
@@ -43,9 +43,7 @@ impl<'a> Iterator for AllSymbols<'a> {
     type Item = Symbol;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let next = self.range.next()?;
-        debug_assert!(u32::try_from(next).is_ok());
-        Some((next as u32).into())
+        self.range.next().map(Symbol::from)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -57,33 +55,25 @@ impl<'a> Iterator for AllSymbols<'a> {
     }
 
     fn last(self) -> Option<Self::Item> {
-        let last = self.range.last()?;
-        debug_assert!(u32::try_from(last).is_ok());
-        Some((last as u32).into())
+        self.range.last().map(Symbol::from)
     }
 
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
-        let nth = self.range.nth(n)?;
-        debug_assert!(u32::try_from(nth).is_ok());
-        Some((nth as u32).into())
+        self.range.nth(n).map(Symbol::from)
     }
 
     fn collect<B: FromIterator<Self::Item>>(self) -> B {
-        self.range.map(|sym| Symbol::from(sym as u32)).collect()
+        self.range.map(Symbol::from).collect()
     }
 }
 
 impl<'a> DoubleEndedIterator for AllSymbols<'a> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        let next = self.range.next_back()?;
-        debug_assert!(u32::try_from(next).is_ok());
-        Some((next as u32).into())
+        self.range.next_back().map(Symbol::from)
     }
 
     fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
-        let nth = self.range.nth_back(n)?;
-        debug_assert!(u32::try_from(nth).is_ok());
-        Some((nth as u32).into())
+        self.range.nth_back(n).map(Symbol::from)
     }
 }
 
@@ -544,8 +534,14 @@ impl<S> SymbolTable<S> {
     /// # example().unwrap();
     /// ```
     pub fn all_symbols(&self) -> AllSymbols<'_> {
+        let len = self.len();
+        debug_assert!(
+            u32::try_from(len).is_ok(),
+            "Interner can hold at most u32::MAX symbols"
+        );
+        let len = len as u32;
         AllSymbols {
-            range: 0..self.len(),
+            range: 0_u32..len,
             phantom: PhantomData,
         }
     }

--- a/src/str.rs
+++ b/src/str.rs
@@ -632,7 +632,19 @@ where
             return Ok(id);
         }
         let name = Interned::from(contents);
+
         let id = self.map.len().try_into()?;
+        // If the number of symbols stored in the table is `u32::MAX`, then the
+        // last issued symbol was `u32::MAX - 1` because `(0..u32::MAX).count() == u32::MAX`.
+        //
+        // Creating a symbol with id `u32::MAX` means the range of ids in the
+        // table would be `0..=u32::MAX`, which means the table would store
+        // `u32::MAX + 1` symbols, which is beyond `SymbolTable`'s documented
+        // capacity.
+        if id == u32::MAX {
+            return Err(SymbolOverflowError::new());
+        }
+
         // Safety:
         //
         // This expression creates a reference with a `'static` lifetime


### PR DESCRIPTION
This PR explores restricting `AllSymbols` to use a `Range<u32>` representation, which restricts the number of `Symbol`s stored in a `SymbolTable` to `u32::MAX`. This implies the maximum valid `Symbol` is `Symbol(u32::MAX - 1)`.

The result is an API change to `Symbol::new` and some of `Symbol`'s `From` impls which has a fairly wide blast radius in the codebase.

I don't think I will go forward with this PR since it significantly complicates the API for not much gain over simply documenting the following:

> - `Symbol` ids can be any valid `u32` value.
> - `SymbolTable`s can contain at most `u32::MAX + 1` symbols.