### PR TITLE
Fix off-by-one error in `SymbolOverflowError::max_capacity`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -241,3 +241,16 @@ impl Symbol {
         self.0
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::SymbolOverflowError;
+
+    #[test]
+    #[cfg(not(miri))]
+    fn max_capacity_is_length_of_symbol_range() {
+        let symbol_range = 0_u32..=u32::MAX;
+        let len = symbol_range.size_hint().0;
+        assert_eq!(SymbolOverflowError::new().max_capacity(), len);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -259,5 +259,7 @@ mod tests {
         let symbol_range = 0_u32..=u32::MAX;
         let len = symbol_range.size_hint().0;
         assert_eq!(SymbolOverflowError::new().max_capacity(), len);
+        let len = symbol_range.size_hint().1.unwrap();
+        assert_eq!(SymbolOverflowError::new().max_capacity(), len);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,7 +162,14 @@ impl SymbolOverflowError {
     #[must_use]
     #[allow(clippy::unused_self)]
     pub const fn max_capacity(self) -> usize {
-        u32::MAX as usize
+        // The valid representation of `Symbol` is:
+        //
+        // ```
+        // Symbol(0_u32)..=Symbol(u32::MAX)
+        // ```
+        //
+        // The length of a range from `0..uX::MAX` is `uX::MAX + 1`.
+        u32::MAX as usize + 1
     }
 }
 


### PR DESCRIPTION
This bug was discovered in:

- https://github.com/artichoke/intaglio/pull/141