### PR TITLE
Refactor u32 to usize cast assertions

### DIFF
--- a/src/convert.rs
+++ b/src/convert.rs
@@ -1,5 +1,4 @@
 use core::convert::TryFrom;
-use core::mem::size_of;
 use core::num::{NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize};
 
 use crate::{Symbol, SymbolOverflowError};
@@ -185,9 +184,8 @@ impl From<Symbol> for u64 {
 impl From<Symbol> for usize {
     #[inline]
     fn from(sym: Symbol) -> Self {
-        // This conversion relies on `size_of::<usize>() >= size_of::<u32>()`,
-        // which is ensured with a const assertion.
-        const _: () = [()][!(size_of::<usize>() >= size_of::<u32>()) as usize];
+        // Ensure this cast is lossless.
+        const_assert!(usize::BITS >= u32::BITS);
 
         sym.id() as usize
     }
@@ -217,11 +215,7 @@ impl From<&Symbol> for u64 {
 impl From<&Symbol> for usize {
     #[inline]
     fn from(sym: &Symbol) -> Self {
-        // This conversion relies on `size_of::<usize>() >= size_of::<u32>()`,
-        // which is ensured with a const assertion.
-        const _: () = [()][!(size_of::<usize>() >= size_of::<u32>()) as usize];
-
-        sym.id() as usize
+        (*sym).into()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,9 +107,18 @@
 mod readme {}
 
 use core::fmt;
-use core::mem::size_of;
 use core::num::TryFromIntError;
 use std::error;
+
+macro_rules! const_assert {
+    ($x:expr $(,)?) => {
+        #[allow(unknown_lints, clippy::eq_op)]
+        const _: [(); 0 - !{
+            const ASSERT: bool = $x;
+            ASSERT
+        } as usize] = [];
+    };
+}
 
 #[cfg(feature = "bytes")]
 #[cfg_attr(docsrs, doc(cfg(feature = "bytes")))]
@@ -132,10 +141,7 @@ pub use crate::str::*;
 
 // To prevent overflows when indexing into the backing `Vec`, `intaglio`
 // requires `usize` to be at least as big as `u32`.
-//
-// This const-evaluated expression will fail to compile if this invariant does
-// not hold.
-const _: () = [()][!(size_of::<usize>() >= size_of::<u32>()) as usize];
+const_assert!(usize::BITS >= u32::BITS);
 
 /// Default capacity for a new [`SymbolTable`] created with
 /// [`SymbolTable::new`].


### PR DESCRIPTION
Use a const assert macro to make the assertions easier to read.
Use ::BITS constants rather than size_of operator.