### PR TITLE
Release v1.6.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "intaglio"
-version = "1.6.0" # remember to set `html_root_url` in `src/lib.rs`.
+version = "1.6.1" # remember to set `html_root_url` in `src/lib.rs`.
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "MIT"
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-intaglio = "1.6.0"
+intaglio = "1.6.1"
 ```
 
 Then intern UTF-8 strings like:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,7 @@
 //! [`&Path`]: std::path::Path
 //! [`&'static Path`]: std::path::Path
 
-#![doc(html_root_url = "https://docs.rs/intaglio/1.6.0")]
+#![doc(html_root_url = "https://docs.rs/intaglio/1.6.1")]
 
 // Ensure code blocks in `README.md` compile
 //


### PR DESCRIPTION
Release 1.6.1 of intaglio.

[`intaglio` is available on crates.io](https://crates.io/crates/intaglio/1.6.1).

## Testing improvements

- Parallelize leak sanitizer tests. https://github.com/artichoke/intaglio/pull/145
- Add missing drop tests to miri. https://github.com/artichoke/intaglio/pull/146
- Unify all miri tests into one integration test crate. https://github.com/artichoke/intaglio/pull/147
- Refactor u32 to usize cast assertions. https://github.com/artichoke/intaglio/pull/154
- Run Miri tests under strict provenance and randomize layout. https://github.com/artichoke/intaglio/pull/157