### PR TITLE
Prepare for 1.7.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "intaglio"
-version = "1.6.1" # remember to set `html_root_url` in `src/lib.rs`.
+version = "1.7.0" # remember to set `html_root_url` in `src/lib.rs`.
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "MIT"
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-intaglio = "1.6.1"
+intaglio = "1.7.0"
 ```
 
 Then intern UTF-8 strings like:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,7 @@
 //! [`&Path`]: std::path::Path
 //! [`&'static Path`]: std::path::Path
 
-#![doc(html_root_url = "https://docs.rs/intaglio/1.6.1")]
+#![doc(html_root_url = "https://docs.rs/intaglio/1.7.0")]
 
 // Ensure code blocks in `README.md` compile
 //


### PR DESCRIPTION
Release 1.7.0 of intaglio.

[`intaglio` is available on crates.io](https://crates.io/crates/intaglio/1.7.0).

## Testing improvements

- Add test that impl Display for SymbolOverflowError is non-empty. https://github.com/artichoke/intaglio/pull/168
- Build docs with no default features in CI. https://github.com/artichoke/intaglio/pull/170

## Documentation improvements

- `intaglio` only includes documentation about other string interner types if their Cargo features are enabled. This fixes broken intradoc links when building with a subset of features. https://github.com/artichoke/intaglio/pull/170