### PR TITLE
Warn on `clippy::undocumented_unsafe_blocks`

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -308,16 +308,13 @@ pub struct SymbolTable<S = RandomState> {
 
 impl<S> Drop for SymbolTable<S> {
     fn drop(&mut self) {
-        // Safety:
-        //
-        // `Interned` requires that the `'static` references it gives out are
-        // dropped before the owning buffer stored in the `Interned`.
-        //
-        // `ManuallyDrop::drop` is only invoked in this `Drop::drop` impl;
-        // because mutable references to `map` and `vec` fields are not given
-        // out by `SymbolTable`, `map` and `vec` are guaranteed to be
-        // initialized.
+        // SAFETY: No mutable references to `SymbolTable` internal fields are
+        // given out, which means `ManuallyDrop::drop` can only be invoked in
+        // this `Drop::drop` impl. Interal fields are guaranteed to be
+        // initialized by `SymbolTable` constructors.
         unsafe {
+            // `Interned` requires that the `'static` references it gives out
+            // are dropped before the owning buffer stored in the `Interned`.
             ManuallyDrop::drop(&mut self.map);
             ManuallyDrop::drop(&mut self.vec);
         }
@@ -697,14 +694,12 @@ where
         }
         let name = Interned::from(contents);
         let id = self.map.len().try_into()?;
-        // Safety:
-        //
-        // This expression creates a reference with a `'static` lifetime
-        // from an owned and interned buffer. This is permissible because:
+        // SAFETY: This expression creates a reference with a `'static` lifetime
+        // from an owned and interned buffer, which is permissible because:
         //
         // - `Interned` is an internal implementation detail of `SymbolTable`.
-        // - `SymbolTable` never give out `'static` references to underlying
-        //   byte contents.
+        // - `SymbolTable` never gives out `'static` references to underlying
+        //   byte string byte contents.
         // - All slice references given out by the `SymbolTable` have the same
         //   lifetime as the `SymbolTable`.
         // - The `map` field of `SymbolTable`, which contains the `'static`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
 #![warn(clippy::cargo)]
+#![warn(clippy::undocumented_unsafe_blocks)]
 #![allow(clippy::cast_possible_truncation)]
 #![allow(unknown_lints)]
 #![warn(missing_copy_implementations)]

--- a/src/osstr.rs
+++ b/src/osstr.rs
@@ -321,16 +321,13 @@ pub struct SymbolTable<S = RandomState> {
 
 impl<S> Drop for SymbolTable<S> {
     fn drop(&mut self) {
-        // Safety:
-        //
-        // `Interned` requires that the `'static` references it gives out are
-        // dropped before the owning buffer stored in the `Interned`.
-        //
-        // `ManuallyDrop::drop` is only invoked in this `Drop::drop` impl;
-        // because mutable references to `map` and `vec` fields are not given
-        // out by `SymbolTable`, `map` and `vec` are guaranteed to be
-        // initialized.
+        // SAFETY: No mutable references to `SymbolTable` internal fields are
+        // given out, which means `ManuallyDrop::drop` can only be invoked in
+        // this `Drop::drop` impl. Interal fields are guaranteed to be
+        // initialized by `SymbolTable` constructors.
         unsafe {
+            // `Interned` requires that the `'static` references it gives out
+            // are dropped before the owning buffer stored in the `Interned`.
             ManuallyDrop::drop(&mut self.map);
             ManuallyDrop::drop(&mut self.vec);
         }
@@ -720,13 +717,11 @@ where
         }
         let name = Interned::from(contents);
         let id = self.map.len().try_into()?;
-        // Safety:
-        //
-        // This expression creates a reference with a `'static` lifetime
-        // from an owned and interned buffer. This is permissible because:
+        // SAFETY: This expression creates a reference with a `'static` lifetime
+        // from an owned and interned buffer, which is permissible because:
         //
         // - `Interned` is an internal implementation detail of `SymbolTable`.
-        // - `SymbolTable` never give out `'static` references to underlying
+        // - `SymbolTable` never gives out `'static` references to underlying
         //   platform string byte contents.
         // - All slice references given out by the `SymbolTable` have the same
         //   lifetime as the `SymbolTable`.

--- a/src/path.rs
+++ b/src/path.rs
@@ -321,16 +321,13 @@ pub struct SymbolTable<S = RandomState> {
 
 impl<S> Drop for SymbolTable<S> {
     fn drop(&mut self) {
-        // Safety:
-        //
-        // `Interned` requires that the `'static` references it gives out are
-        // dropped before the owning buffer stored in the `Interned`.
-        //
-        // `ManuallyDrop::drop` is only invoked in this `Drop::drop` impl;
-        // because mutable references to `map` and `vec` fields are not given
-        // out by `SymbolTable`, `map` and `vec` are guaranteed to be
-        // initialized.
+        // SAFETY: No mutable references to `SymbolTable` internal fields are
+        // given out, which means `ManuallyDrop::drop` can only be invoked in
+        // this `Drop::drop` impl. Interal fields are guaranteed to be
+        // initialized by `SymbolTable` constructors.
         unsafe {
+            // `Interned` requires that the `'static` references it gives out
+            // are dropped before the owning buffer stored in the `Interned`.
             ManuallyDrop::drop(&mut self.map);
             ManuallyDrop::drop(&mut self.vec);
         }
@@ -720,13 +717,11 @@ where
         }
         let name = Interned::from(contents);
         let id = self.map.len().try_into()?;
-        // Safety:
-        //
-        // This expression creates a reference with a `'static` lifetime
-        // from an owned and interned buffer. This is permissible because:
+        // SAFETY: This expression creates a reference with a `'static` lifetime
+        // from an owned and interned buffer, which is permissible because:
         //
         // - `Interned` is an internal implementation detail of `SymbolTable`.
-        // - `SymbolTable` never give out `'static` references to underlying
+        // - `SymbolTable` never gives out `'static` references to underlying
         //   path string byte contents.
         // - All slice references given out by the `SymbolTable` have the same
         //   lifetime as the `SymbolTable`.

--- a/src/str.rs
+++ b/src/str.rs
@@ -253,16 +253,13 @@ pub struct SymbolTable<S = RandomState> {
 
 impl<S> Drop for SymbolTable<S> {
     fn drop(&mut self) {
-        // Safety:
-        //
-        // `Interned` requires that the `'static` references it gives out are
-        // dropped before the owning buffer stored in the `Interned`.
-        //
-        // `ManuallyDrop::drop` is only invoked in this `Drop::drop` impl;
-        // because mutable references to `map` and `vec` fields are not given
-        // out by `SymbolTable`, `map` and `vec` are guaranteed to be
-        // initialized.
+        // SAFETY: No mutable references to `SymbolTable` internal fields are
+        // given out, which means `ManuallyDrop::drop` can only be invoked in
+        // this `Drop::drop` impl. Interal fields are guaranteed to be
+        // initialized by `SymbolTable` constructors.
         unsafe {
+            // `Interned` requires that the `'static` references it gives out
+            // are dropped before the owning buffer stored in the `Interned`.
             ManuallyDrop::drop(&mut self.map);
             ManuallyDrop::drop(&mut self.vec);
         }
@@ -637,14 +634,12 @@ where
         }
         let name = Interned::from(contents);
         let id = self.map.len().try_into()?;
-        // Safety:
-        //
-        // This expression creates a reference with a `'static` lifetime
-        // from an owned and interned buffer. This is permissible because:
+        // SAFETY: This expression creates a reference with a `'static` lifetime
+        // from an owned and interned buffer, which is permissible because:
         //
         // - `Interned` is an internal implementation detail of `SymbolTable`.
-        // - `SymbolTable` never give out `'static` references to underlying
-        //   string contents.
+        // - `SymbolTable` never gives out `'static` references to underlying
+        //   string byte contents.
         // - All slice references given out by the `SymbolTable` have the same
         //   lifetime as the `SymbolTable`.
         // - The `map` field of `SymbolTable`, which contains the `'static`


### PR DESCRIPTION
This lint is from the `restriction` category and is not previously
warned on in `intaglio`.

Update SAFETY comments to use `rustc`'s style (all caps, justification
inline with the word "SAFETY:").