### PR TITLE
Remove actions-rs GitHub Actions

### DIFF
--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -22,11 +22,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: artichoke/setup-rust/build-and-test@v1
         with:
           toolchain: stable
-          profile: minimal
-          override: true
 
       - name: Compile
         run: cargo build --verbose

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,10 +32,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: artichoke/setup-rust/build-and-test@v1
         with:
           toolchain: stable
-          profile: minimal
 
       - name: Compile
         run: cargo build --verbose
@@ -72,10 +71,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: artichoke/setup-rust/build-and-test@v1
         with:
           toolchain: stable
-          profile: minimal
           target: ${{ matrix.target }}
 
       - name: Install 32-bit platform support
@@ -109,11 +107,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: artichoke/setup-rust/build-and-test@v1
         with:
           toolchain: "1.56.0"
-          profile: minimal
-          override: true
 
       - name: Compile
         run: cargo build --verbose
@@ -149,13 +145,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Install nightly Rust toolchain
-        uses: actions-rs/toolchain@v1
+      - name: Install Rust toolchain
+        uses: artichoke/setup-rust/build-and-test@v1
         with:
           toolchain: nightly
-          profile: minimal
           target: ${{ matrix.target }}
-          override: true
 
       - name: Test with leak sanitizer and all features
         run: cargo test --all-features --target ${{ matrix.target }}
@@ -173,21 +167,20 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: artichoke/setup-rust/lint-and-format@v1
+        with:
+          toolchain: nightly
+
+      - name: Install Rust toolchain
+        uses: artichoke/setup-rust/lint-and-format@v1
         with:
           toolchain: stable
-          override: true
-          profile: minimal
-          components: rustfmt, clippy
 
       - name: Check formatting
-        run: cargo fmt -- --check --color=auto
+        run: cargo +nightly fmt --check
 
       - name: Lint with Clippy
-        uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features --all-targets
+        run: cargo clippy --workspace --all-features --all-targets
 
   ruby:
     name: Lint and format Ruby


### PR DESCRIPTION
GitHub is deprecating the node 12 runtime for GitHub Actions. actions-rs/toolchain and actions-rs/clippy are unmaintained and currently emit warnings due to the deprecation.

Replace these with actions from https://github.com/artichoke/setup-rust.

Audit and rustdoc workflows are not updated since these are managed by Terraform in artichoke/project-infrastructure.

Skip miri workflow, blocked on https://github.com/artichoke/setup-rust/issues/6.