### PR TITLE
Fix clippy lint violations in new stable 1.65.0

### DIFF
--- a/src/internal.rs
+++ b/src/internal.rs
@@ -262,7 +262,7 @@ where
     const fn as_slice(&self) -> &T {
         match self {
             Self::Static(slice) => slice,
-            Self::Owned(owned) => &**owned,
+            Self::Owned(owned) => owned,
         }
     }
 


### PR DESCRIPTION
- `clippy::explicit_auto_deref`