### PR TITLE
Disable LeakSanitizer tests on macOS

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -132,12 +132,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os:
+          - ubuntu-latest
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-          - os: macos-latest
-            target: x86_64-apple-darwin
     env:
       RUSTFLAGS: -D warnings
       RUST_BACKTRACE: 1


### PR DESCRIPTION
See:

- https://github.com/rust-lang/rust/issues/103404

These tests have been red since October and don't add anything above the Linux tests.