### PR TITLE
Release v1.8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "intaglio"
-version = "1.7.0" # remember to set `html_root_url` in `src/lib.rs`.
+version = "1.8.0" # remember to set `html_root_url` in `src/lib.rs`.
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "MIT"
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-intaglio = "1.7.0"
+intaglio = "1.8.0"
 ```
 
 Then intern UTF-8 strings like:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,7 @@
 //! [`&Path`]: std::path::Path
 //! [`&'static Path`]: std::path::Path
 
-#![doc(html_root_url = "https://docs.rs/intaglio/1.7.0")]
+#![doc(html_root_url = "https://docs.rs/intaglio/1.8.0")]
 
 use core::fmt;
 use core::num::TryFromIntError;


### PR DESCRIPTION
Release 1.8.0 of intaglio.

[`intaglio` is available on crates.io](https://crates.io/crates/intaglio/1.8.0).

## Testing improvements

- Ensure MSRV CI job overrides the active Rust version. https://github.com/artichoke/intaglio/pull/176
- Add code coverage CI job. https://github.com/artichoke/intaglio/pull/177, https://github.com/artichoke/intaglio/pull/178, https://github.com/artichoke/intaglio/pull/179, https://github.com/artichoke/intaglio/pull/185.
- Add coverage for `SymbolOverflowError` derives and trait impls. https://github.com/artichoke/intaglio/pull/180
- Add tests for `From` impls on `Symbol`. https://github.com/artichoke/intaglio/pull/181
- Add tests for converting `Symbol` into primitive integer values. https://github.com/artichoke/intaglio/pull/182
- Disable LeakSanitizer tests on macOS. https://github.com/artichoke/intaglio/pull/201

## Quality improvements

- Remove dead code from internal module. https://github.com/artichoke/intaglio/pull/183
- Warn on `clippy::undocumented_unsafe_blocks`. https://github.com/artichoke/intaglio/pull/184
- Fix clippy lint violations in new stable 1.65.0. https://github.com/artichoke/intaglio/pull/196