### PR TITLE
Remove dependency on actions-rs organization GitHub Actions

### DIFF
--- a/.github/workflows/miri.yaml
+++ b/.github/workflows/miri.yaml
@@ -22,12 +22,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: artichoke/setup-rust/miri@v1
         with:
           toolchain: nightly
-          profile: minimal
-          override: true
-          components: miri, rust-src
 
       - name: Miri setup
         run: cargo miri setup


### PR DESCRIPTION
These actions are unmaintained and use deprecated GitHub Actions technologies.

See: https://github.com/artichoke/project-infrastructure/issues/265