### PR TITLE
Address lint spam from `clippy::let_underscore_untyped` in Rust 1.69.0

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,8 +194,7 @@ impl SymbolOverflowError {
 
 impl From<TryFromIntError> for SymbolOverflowError {
     #[inline]
-    fn from(err: TryFromIntError) -> Self {
-        let _ = err;
+    fn from(_err: TryFromIntError) -> Self {
         Self::new()
     }
 }


### PR DESCRIPTION
See:

- https://github.com/artichoke/artichoke/pull/2511

Caused by:

- https://github.com/rust-lang/rust-clippy/pull/10442