### PR TITLE
Ensure code in .config directory is tracked

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,11 @@ tags
 [._]*.un~
 
 # End of https://www.toptal.com/developers/gitignore/api/vim,rust,ruby
+
+# Overrides
+
+# Cargo and other Rust tool configuration lives in a top-level `.config/` directory.
+!/.config/
+# https://github.com/sourcefrog/cargo-mutants/blob/main/.gitignore
+mutants.out
+mutants.out.old


### PR DESCRIPTION
This location is used by cargo and tools like cargo-spellcheck.