### PR TITLE
Address stacked borrows violation in `SymbolTable::intern`

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -705,10 +705,9 @@ where
         // get created after the `Box` is done being moved.
         self.vec.push(name);
 
-        // SAFETY: `self.map` and `self.vec` always have the same length, which
-        // means the derived `id` is the next index in `self.vec`. The preceding
-        // line of code pushes an entry into the vec at this position.
-        let name = unsafe { self.vec.get_unchecked(usize::from(id)) };
+        // SAFETY: `self.vec` is non-empty because the preceding line of code
+        // pushed an entry into it.
+        let name = unsafe { self.vec.last().unwrap_unchecked() };
 
         // SAFETY: This expression creates a reference with a `'static` lifetime
         // from an owned and interned buffer, which is permissible because:

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -50,7 +50,6 @@
 //! In general, one should expect this crate's performance on `&[u8]` to be
 //! roughly similar to performance on `&str`.
 
-use core::convert::TryInto;
 use core::hash::BuildHasher;
 use core::iter::{FromIterator, FusedIterator, Zip};
 use core::marker::PhantomData;
@@ -693,7 +692,24 @@ where
             return Ok(id);
         }
         let name = Interned::from(contents);
-        let id = self.map.len().try_into()?;
+        let id = Symbol::try_from(self.map.len())?;
+
+        // The `Interned::Owned` variant contains a `Box`. When such a structure
+        // is assigned (as it is with the call to `self.vec.push`), the alloc
+        // is "retagged" in Miri/stacked borrows. Retagging an allocation pops
+        // all of the borrows derived from it off of the stack.
+        //
+        // Previously this function derived the `&'static [u8]` from the given
+        // contents before pushing it into the vec. The code was restructured in
+        // the fix for #235 to ensure borrows on the underlying `Box<[u8]>` only
+        // get created after the `Box` is done being moved.
+        self.vec.push(name);
+
+        // SAFETY: `self.map` and `self.vec` always have the same length, which
+        // means the derived `id` is the next index in `self.vec`. The preceding
+        // line of code pushes an entry into the vec at this position.
+        let name = unsafe { self.vec.get_unchecked(usize::from(id)) };
+
         // SAFETY: This expression creates a reference with a `'static` lifetime
         // from an owned and interned buffer, which is permissible because:
         //
@@ -705,10 +721,11 @@ where
         // - The `map` field of `SymbolTable`, which contains the `'static`
         //   references, is dropped before the owned buffers stored in this
         //   `Interned`.
+        // - The shared reference may be derived from a `Box` and that `Box`
+        //   will never be retagged/reassigned for the life of the symbol table.
         let slice = unsafe { name.as_static_slice() };
 
         self.map.insert(slice, id);
-        self.vec.push(name);
 
         debug_assert_eq!(self.get(id), Some(slice));
         debug_assert_eq!(self.intern(slice), Ok(id));

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -691,19 +691,43 @@ where
         if let Some(&id) = self.map.get(&*contents) {
             return Ok(id);
         }
+
+        // The `Interned::Owned` variant is derived from a `Box<T>`. When such
+        // a structure is moved or assigned, as it is below in the call to
+        // `self.vec.push`, the allocation is "retagged" in Miri/stacked borrows.
+        //
+        // Retagging an allocation pops all of the borrows derived from it off
+        // of the stack. This means we need to move the `Interned` into the
+        // `Vec` before calling `Interned::as_static_slice` to ensure the
+        // reference does not get invalidated by retagging.
+        //
+        // However, that alone may be insufficient as the `Interened` may be
+        // moved when the symbol table grows.
+        //
+        // The `SymbolTable` API prevents shared references to the `Interned`
+        // being invalidated by a retag by tying resolved symbol contents,
+        // `&'a T`, to `&'a SymbolTable`, which means the `SymbolTable` cannot
+        // grow, shrink, or otherwise reallocate/move contents while a reference
+        // to the `Interned`'s inner `T` is alive.
+        //
+        // To protect against future updates to stacked borrows or the unsafe
+        // code operational semantics, we can address this additional invariant
+        // with updated `Interned` internals which store the `Box<T>` in a raw
+        // pointer form, which allows moves to be treated as untyped copies.
+        //
+        // See:
+        //
+        // - <https://github.com/artichoke/intaglio/issues/235>
+        // - <https://github.com/artichoke/intaglio/pull/236>
         let name = Interned::from(contents);
         let id = Symbol::try_from(self.map.len())?;
 
-        // The `Interned::Owned` variant contains a `Box`. When such a structure
-        // is assigned (as it is with the call to `self.vec.push`), the alloc
-        // is "retagged" in Miri/stacked borrows. Retagging an allocation pops
-        // all of the borrows derived from it off of the stack.
-        //
-        // Previously this function derived the `&'static [u8]` from the given
-        // contents before pushing it into the vec. The code was restructured in
-        // the fix for #235 to ensure borrows on the underlying `Box<[u8]>` only
-        // get created after the `Box` is done being moved.
+        // Move the `Interned` into the `Vec`, causing it to be retagged under
+        // stacked borrows, before taking any references to its inner `T`.
         self.vec.push(name);
+        // Ensure we grow the map before we take any shared references to the
+        // inner `T`.
+        self.map.reserve(1);
 
         // SAFETY: `self.vec` is non-empty because the preceding line of code
         // pushed an entry into it.
@@ -714,14 +738,16 @@ where
         //
         // - `Interned` is an internal implementation detail of `SymbolTable`.
         // - `SymbolTable` never gives out `'static` references to underlying
-        //   byte string byte contents.
+        //   contents.
         // - All slice references given out by the `SymbolTable` have the same
         //   lifetime as the `SymbolTable`.
         // - The `map` field of `SymbolTable`, which contains the `'static`
         //   references, is dropped before the owned buffers stored in this
         //   `Interned`.
-        // - The shared reference may be derived from a `Box` and that `Box`
-        //   will never be retagged/reassigned for the life of the symbol table.
+        // - The shared reference may be derived from a `PinBox` which prevents
+        //   moves from retagging the underlying boxed `T` under stacked borrows.
+        // - The symbol table cannot grow, shrink, or otherwise move its contents
+        //   while this reference is alive.
         let slice = unsafe { name.as_static_slice() };
 
         self.map.insert(slice, id);

--- a/src/cstr.rs
+++ b/src/cstr.rs
@@ -55,7 +55,6 @@
 //! [`CString`]: std::ffi::CString
 //! [`&CStr`]: std::ffi::CStr
 
-use core::convert::TryInto;
 use core::hash::BuildHasher;
 use core::iter::{FromIterator, FusedIterator, Zip};
 use core::marker::PhantomData;
@@ -716,7 +715,24 @@ where
             return Ok(id);
         }
         let name = Interned::from(contents);
-        let id = self.map.len().try_into()?;
+        let id = Symbol::try_from(self.map.len())?;
+
+        // The `Interned::Owned` variant contains a `Box`. When such a structure
+        // is assigned (as it is with the call to `self.vec.push`), the alloc
+        // is "retagged" in Miri/stacked borrows. Retagging an allocation pops
+        // all of the borrows derived from it off of the stack.
+        //
+        // Previously this function derived the `&'static CStr` from the given
+        // contents before pushing it into the vec. The code was restructured in
+        // the fix for #235 to ensure borrows on the underlying `Box<CStr>` only
+        // get created after the `Box` is done being moved.
+        self.vec.push(name);
+
+        // SAFETY: `self.map` and `self.vec` always have the same length, which
+        // means the derived `id` is the next index in `self.vec`. The preceding
+        // line of code pushes an entry into the vec at this position.
+        let name = unsafe { self.vec.get_unchecked(usize::from(id)) };
+
         // SAFETY: This expression creates a reference with a `'static` lifetime
         // from an owned and interned buffer, which is permissible because:
         //
@@ -728,10 +744,11 @@ where
         // - The `map` field of `SymbolTable`, which contains the `'static`
         //   references, is dropped before the owned buffers stored in this
         //   `Interned`.
+        // - The shared reference may be derived from a `Box` and that `Box`
+        //   will never be retagged/reassigned for the life of the symbol table.
         let slice = unsafe { name.as_static_slice() };
 
         self.map.insert(slice, id);
-        self.vec.push(name);
 
         debug_assert_eq!(self.get(id), Some(slice));
         debug_assert_eq!(self.intern(slice), Ok(id));

--- a/src/cstr.rs
+++ b/src/cstr.rs
@@ -714,19 +714,43 @@ where
         if let Some(&id) = self.map.get(&*contents) {
             return Ok(id);
         }
+
+        // The `Interned::Owned` variant is derived from a `Box<T>`. When such
+        // a structure is moved or assigned, as it is below in the call to
+        // `self.vec.push`, the allocation is "retagged" in Miri/stacked borrows.
+        //
+        // Retagging an allocation pops all of the borrows derived from it off
+        // of the stack. This means we need to move the `Interned` into the
+        // `Vec` before calling `Interned::as_static_slice` to ensure the
+        // reference does not get invalidated by retagging.
+        //
+        // However, that alone may be insufficient as the `Interened` may be
+        // moved when the symbol table grows.
+        //
+        // The `SymbolTable` API prevents shared references to the `Interned`
+        // being invalidated by a retag by tying resolved symbol contents,
+        // `&'a T`, to `&'a SymbolTable`, which means the `SymbolTable` cannot
+        // grow, shrink, or otherwise reallocate/move contents while a reference
+        // to the `Interned`'s inner `T` is alive.
+        //
+        // To protect against future updates to stacked borrows or the unsafe
+        // code operational semantics, we can address this additional invariant
+        // with updated `Interned` internals which store the `Box<T>` in a raw
+        // pointer form, which allows moves to be treated as untyped copies.
+        //
+        // See:
+        //
+        // - <https://github.com/artichoke/intaglio/issues/235>
+        // - <https://github.com/artichoke/intaglio/pull/236>
         let name = Interned::from(contents);
         let id = Symbol::try_from(self.map.len())?;
 
-        // The `Interned::Owned` variant contains a `Box`. When such a structure
-        // is assigned (as it is with the call to `self.vec.push`), the alloc
-        // is "retagged" in Miri/stacked borrows. Retagging an allocation pops
-        // all of the borrows derived from it off of the stack.
-        //
-        // Previously this function derived the `&'static CStr` from the given
-        // contents before pushing it into the vec. The code was restructured in
-        // the fix for #235 to ensure borrows on the underlying `Box<CStr>` only
-        // get created after the `Box` is done being moved.
+        // Move the `Interned` into the `Vec`, causing it to be retagged under
+        // stacked borrows, before taking any references to its inner `T`.
         self.vec.push(name);
+        // Ensure we grow the map before we take any shared references to the
+        // inner `T`.
+        self.map.reserve(1);
 
         // SAFETY: `self.vec` is non-empty because the preceding line of code
         // pushed an entry into it.
@@ -737,14 +761,16 @@ where
         //
         // - `Interned` is an internal implementation detail of `SymbolTable`.
         // - `SymbolTable` never gives out `'static` references to underlying
-        //   C string byte contents.
+        //   contents.
         // - All slice references given out by the `SymbolTable` have the same
         //   lifetime as the `SymbolTable`.
         // - The `map` field of `SymbolTable`, which contains the `'static`
         //   references, is dropped before the owned buffers stored in this
         //   `Interned`.
-        // - The shared reference may be derived from a `Box` and that `Box`
-        //   will never be retagged/reassigned for the life of the symbol table.
+        // - The shared reference may be derived from a `PinBox` which prevents
+        //   moves from retagging the underlying boxed `T` under stacked borrows.
+        // - The symbol table cannot grow, shrink, or otherwise move its contents
+        //   while this reference is alive.
         let slice = unsafe { name.as_static_slice() };
 
         self.map.insert(slice, id);

--- a/src/cstr.rs
+++ b/src/cstr.rs
@@ -728,10 +728,9 @@ where
         // get created after the `Box` is done being moved.
         self.vec.push(name);
 
-        // SAFETY: `self.map` and `self.vec` always have the same length, which
-        // means the derived `id` is the next index in `self.vec`. The preceding
-        // line of code pushes an entry into the vec at this position.
-        let name = unsafe { self.vec.get_unchecked(usize::from(id)) };
+        // SAFETY: `self.vec` is non-empty because the preceding line of code
+        // pushed an entry into it.
+        let name = unsafe { self.vec.last().unwrap_unchecked() };
 
         // SAFETY: This expression creates a reference with a `'static` lifetime
         // from an owned and interned buffer, which is permissible because:

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -367,6 +367,10 @@ impl fmt::Debug for Slice<Path> {
 /// - <https://github.com/CAD97/simple-interner/blob/24a836e9f8a0173faf48438d711442c2a86659c1/src/interner.rs#L26-L56>
 /// - <https://github.com/artichoke/intaglio/pull/236#issuecomment-1651058752>
 /// - <https://github.com/artichoke/intaglio/pull/236#issuecomment-1652003240>
+///
+/// This code is placed into the public domain by @CAD97:
+///
+/// - <https://github.com/artichoke/intaglio/pull/236#issuecomment-1652393974>
 mod boxed {
     use core::fmt;
     use core::marker::PhantomData;

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -10,6 +10,8 @@ use std::ffi::{OsStr, OsString};
 #[cfg(feature = "path")]
 use std::path::{Path, PathBuf};
 
+use self::boxed::PinBox;
+
 /// Wrapper around `&'static` slices that does not allow mutable access to the
 /// inner slice.
 pub struct Interned<T: 'static + ?Sized>(Slice<T>);
@@ -59,7 +61,7 @@ where
 {
     /// Return a reference to the inner slice.
     #[inline]
-    pub const fn as_slice(&self) -> &T {
+    pub fn as_slice(&self) -> &T {
         self.0.as_slice()
     }
 
@@ -127,7 +129,7 @@ enum Slice<T: 'static + ?Sized> {
     /// True `'static` references.
     Static(&'static T),
     /// Owned `'static` references.
-    Owned(Box<T>),
+    Owned(PinBox<T>),
 }
 
 impl<T> From<&'static T> for Slice<T>
@@ -143,7 +145,7 @@ where
 impl From<String> for Slice<str> {
     #[inline]
     fn from(owned: String) -> Self {
-        Self::Owned(owned.into_boxed_str())
+        Self::Owned(PinBox::new(owned.into_boxed_str()))
     }
 }
 
@@ -161,7 +163,7 @@ impl From<Cow<'static, str>> for Slice<str> {
 impl From<Vec<u8>> for Slice<[u8]> {
     #[inline]
     fn from(owned: Vec<u8>) -> Self {
-        Self::Owned(owned.into_boxed_slice())
+        Self::Owned(PinBox::new(owned.into_boxed_slice()))
     }
 }
 
@@ -180,7 +182,7 @@ impl From<Cow<'static, [u8]>> for Slice<[u8]> {
 impl From<CString> for Slice<CStr> {
     #[inline]
     fn from(owned: CString) -> Self {
-        Self::Owned(owned.into_boxed_c_str())
+        Self::Owned(PinBox::new(owned.into_boxed_c_str()))
     }
 }
 
@@ -199,7 +201,7 @@ impl From<Cow<'static, CStr>> for Slice<CStr> {
 impl From<OsString> for Slice<OsStr> {
     #[inline]
     fn from(owned: OsString) -> Self {
-        Self::Owned(owned.into_boxed_os_str())
+        Self::Owned(PinBox::new(owned.into_boxed_os_str()))
     }
 }
 
@@ -218,7 +220,7 @@ impl From<Cow<'static, OsStr>> for Slice<OsStr> {
 impl From<PathBuf> for Slice<Path> {
     #[inline]
     fn from(owned: PathBuf) -> Self {
-        Self::Owned(owned.into_boxed_path())
+        Self::Owned(PinBox::new(owned.into_boxed_path()))
     }
 }
 
@@ -239,10 +241,13 @@ where
 {
     /// Return a reference to the inner slice.
     #[inline]
-    const fn as_slice(&self) -> &T {
+    fn as_slice(&self) -> &T {
         match self {
             Self::Static(slice) => slice,
-            Self::Owned(owned) => owned,
+            Self::Owned(owned) => {
+                // SAFETY: `PinBox` acts like `Box`.
+                unsafe { owned.as_ref() }
+            }
         }
     }
 
@@ -258,8 +263,6 @@ where
         match self {
             Self::Static(slice) => slice,
             Self::Owned(owned) => {
-                // Coerce the `Box<T>` to a pointer.
-                let ptr: *const T = &**owned;
                 // SAFETY: This expression creates a reference with a `'static`
                 // lifetime from an owned buffer, which is permissible because:
                 //
@@ -270,9 +273,10 @@ where
                 // - The `map` field of the various symbol tables which contains
                 //   the `'static` references, is dropped before the owned buffers
                 //   stored in this `Slice`.
+                // - `PinBox` acts like `Box`.
                 unsafe {
                     // Coerce the pointer to a `&'static T`.
-                    &*ptr
+                    owned.as_ref()
                 }
             }
         }
@@ -350,6 +354,103 @@ impl fmt::Debug for Slice<Path> {
             write!(f, "{:?}", self.as_slice().to_string_lossy())
         } else {
             write!(f, "{:?}", self.as_slice())
+        }
+    }
+}
+
+/// An abstraction over a `Box<T>` where T is an unsized slice type which moves
+/// the box by raw pointer. This type is required to satisfy Miri with
+/// `-Zmiri-retag-fields`. See #235, #236.
+///
+/// The `PinBox` type is derived from:
+///
+/// - <https://github.com/CAD97/simple-interner/blob/24a836e9f8a0173faf48438d711442c2a86659c1/src/interner.rs#L26-L56>
+/// - <https://github.com/artichoke/intaglio/pull/236#issuecomment-1651058752>
+/// - <https://github.com/artichoke/intaglio/pull/236#issuecomment-1652003240>
+mod boxed {
+    use core::fmt;
+    use core::marker::PhantomData;
+    use core::ptr::NonNull;
+
+    /// A wrapper around box that does not provide &mut access to the pointee and
+    /// uses raw-pointer borrowing rules to avoid invalidating extant references.
+    ///
+    /// The resolved reference is guaranteed valid until the `PinBox` is dropped.
+    ///
+    /// This type is meant to allow the owned data in the given `Box<T>` to be moved
+    /// without being retagged by Miri. See #235, #236.
+    pub(crate) struct PinBox<T: ?Sized> {
+        ptr: NonNull<T>,
+        _marker: PhantomData<Box<T>>,
+    }
+
+    impl<T: ?Sized> PinBox<T> {
+        #[inline]
+        pub(crate) fn new(x: Box<T>) -> Self {
+            let ptr = Box::into_raw(x);
+            // SAFETY: `ptr` is derived from `Box::into_raw` and can never be null.
+            let ptr = unsafe { NonNull::new_unchecked(ptr) };
+            Self {
+                ptr,
+                _marker: PhantomData,
+            }
+        }
+
+        #[inline]
+        pub(crate) unsafe fn as_ref<'a>(&self) -> &'a T {
+            // SAFETY: `PinBox` acts like `Box`, `self.ptr` is non-null and points
+            // to a live `Box`.
+            unsafe { self.ptr.as_ref() }
+        }
+    }
+
+    impl<T: ?Sized> Drop for PinBox<T> {
+        fn drop(&mut self) {
+            // SAFETY: `PinBox` acts like `Box`.
+            unsafe {
+                drop(Box::from_raw(self.ptr.as_ptr()));
+            }
+        }
+    }
+
+    impl<T: ?Sized + fmt::Debug> fmt::Debug for PinBox<T> {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            // SAFETY: `PinBox` acts like `Box`.
+            let s = unsafe { self.as_ref() };
+            s.fmt(f)
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use core::fmt::Write;
+
+        use super::PinBox;
+
+        #[test]
+        fn test_drop() {
+            let x = "abc".to_string().into_boxed_str();
+            let x = PinBox::new(x);
+            drop(x);
+        }
+
+        #[test]
+        fn test_as_ref() {
+            let x = "abc".to_string().into_boxed_str();
+            let x = PinBox::new(x);
+
+            // SAFETY: `PinBox` acts like `Box` and contains a valid pointer.
+            assert_eq!(unsafe { x.as_ref() }, "abc");
+        }
+
+        #[test]
+        fn test_debug_format() {
+            let x = "abc".to_string().into_boxed_str();
+            let x = PinBox::new(x);
+
+            let mut buf = String::new();
+            write!(&mut buf, "{x:?}").unwrap();
+            assert_eq!(buf, "\"abc\"");
         }
     }
 }

--- a/src/osstr.rs
+++ b/src/osstr.rs
@@ -55,7 +55,6 @@
 //! [`OsString`]: std::ffi::OsString
 //! [`&OsStr`]: std::ffi::OsStr
 
-use core::convert::TryInto;
 use core::hash::BuildHasher;
 use core::iter::{FromIterator, FusedIterator, Zip};
 use core::marker::PhantomData;
@@ -716,7 +715,24 @@ where
             return Ok(id);
         }
         let name = Interned::from(contents);
-        let id = self.map.len().try_into()?;
+        let id = Symbol::try_from(self.map.len())?;
+
+        // The `Interned::Owned` variant contains a `Box`. When such a structure
+        // is assigned (as it is with the call to `self.vec.push`), the alloc
+        // is "retagged" in Miri/stacked borrows. Retagging an allocation pops
+        // all of the borrows derived from it off of the stack.
+        //
+        // Previously this function derived the `&'static OsStr` from the given
+        // contents before pushing it into the vec. The code was restructured in
+        // the fix for #235 to ensure borrows on the underlying `Box<OsStr>` only
+        // get created after the `Box` is done being moved.
+        self.vec.push(name);
+
+        // SAFETY: `self.map` and `self.vec` always have the same length, which
+        // means the derived `id` is the next index in `self.vec`. The preceding
+        // line of code pushes an entry into the vec at this position.
+        let name = unsafe { self.vec.get_unchecked(usize::from(id)) };
+
         // SAFETY: This expression creates a reference with a `'static` lifetime
         // from an owned and interned buffer, which is permissible because:
         //
@@ -728,10 +744,11 @@ where
         // - The `map` field of `SymbolTable`, which contains the `'static`
         //   references, is dropped before the owned buffers stored in this
         //   `Interned`.
+        // - The shared reference may be derived from a `Box` and that `Box`
+        //   will never be retagged/reassigned for the life of the symbol table.
         let slice = unsafe { name.as_static_slice() };
 
         self.map.insert(slice, id);
-        self.vec.push(name);
 
         debug_assert_eq!(self.get(id), Some(slice));
         debug_assert_eq!(self.intern(slice), Ok(id));

--- a/src/osstr.rs
+++ b/src/osstr.rs
@@ -728,10 +728,9 @@ where
         // get created after the `Box` is done being moved.
         self.vec.push(name);
 
-        // SAFETY: `self.map` and `self.vec` always have the same length, which
-        // means the derived `id` is the next index in `self.vec`. The preceding
-        // line of code pushes an entry into the vec at this position.
-        let name = unsafe { self.vec.get_unchecked(usize::from(id)) };
+        // SAFETY: `self.vec` is non-empty because the preceding line of code
+        // pushed an entry into it.
+        let name = unsafe { self.vec.last().unwrap_unchecked() };
 
         // SAFETY: This expression creates a reference with a `'static` lifetime
         // from an owned and interned buffer, which is permissible because:

--- a/src/path.rs
+++ b/src/path.rs
@@ -714,19 +714,43 @@ where
         if let Some(&id) = self.map.get(&*contents) {
             return Ok(id);
         }
+
+        // The `Interned::Owned` variant is derived from a `Box<T>`. When such
+        // a structure is moved or assigned, as it is below in the call to
+        // `self.vec.push`, the allocation is "retagged" in Miri/stacked borrows.
+        //
+        // Retagging an allocation pops all of the borrows derived from it off
+        // of the stack. This means we need to move the `Interned` into the
+        // `Vec` before calling `Interned::as_static_slice` to ensure the
+        // reference does not get invalidated by retagging.
+        //
+        // However, that alone may be insufficient as the `Interened` may be
+        // moved when the symbol table grows.
+        //
+        // The `SymbolTable` API prevents shared references to the `Interned`
+        // being invalidated by a retag by tying resolved symbol contents,
+        // `&'a T`, to `&'a SymbolTable`, which means the `SymbolTable` cannot
+        // grow, shrink, or otherwise reallocate/move contents while a reference
+        // to the `Interned`'s inner `T` is alive.
+        //
+        // To protect against future updates to stacked borrows or the unsafe
+        // code operational semantics, we can address this additional invariant
+        // with updated `Interned` internals which store the `Box<T>` in a raw
+        // pointer form, which allows moves to be treated as untyped copies.
+        //
+        // See:
+        //
+        // - <https://github.com/artichoke/intaglio/issues/235>
+        // - <https://github.com/artichoke/intaglio/pull/236>
         let name = Interned::from(contents);
         let id = Symbol::try_from(self.map.len())?;
 
-        // The `Interned::Owned` variant contains a `Box`. When such a structure
-        // is assigned (as it is with the call to `self.vec.push`), the alloc
-        // is "retagged" in Miri/stacked borrows. Retagging an allocation pops
-        // all of the borrows derived from it off of the stack.
-        //
-        // Previously this function derived the `&'static Path` from the given
-        // contents before pushing it into the vec. The code was restructured in
-        // the fix for #235 to ensure borrows on the underlying `Box<Path>` only
-        // get created after the `Box` is done being moved.
+        // Move the `Interned` into the `Vec`, causing it to be retagged under
+        // stacked borrows, before taking any references to its inner `T`.
         self.vec.push(name);
+        // Ensure we grow the map before we take any shared references to the
+        // inner `T`.
+        self.map.reserve(1);
 
         // SAFETY: `self.vec` is non-empty because the preceding line of code
         // pushed an entry into it.
@@ -737,14 +761,16 @@ where
         //
         // - `Interned` is an internal implementation detail of `SymbolTable`.
         // - `SymbolTable` never gives out `'static` references to underlying
-        //   path string byte contents.
+        //   contents.
         // - All slice references given out by the `SymbolTable` have the same
         //   lifetime as the `SymbolTable`.
         // - The `map` field of `SymbolTable`, which contains the `'static`
         //   references, is dropped before the owned buffers stored in this
         //   `Interned`.
-        // - The shared reference may be derived from a `Box` and that `Box`
-        //   will never be retagged/reassigned for the life of the symbol table.
+        // - The shared reference may be derived from a `PinBox` which prevents
+        //   moves from retagging the underlying boxed `T` under stacked borrows.
+        // - The symbol table cannot grow, shrink, or otherwise move its contents
+        //   while this reference is alive.
         let slice = unsafe { name.as_static_slice() };
 
         self.map.insert(slice, id);

--- a/src/path.rs
+++ b/src/path.rs
@@ -55,7 +55,6 @@
 //! [`PathBuf`]: std::path::PathBuf
 //! [`&Path`]: std::path::Path
 
-use core::convert::TryInto;
 use core::hash::BuildHasher;
 use core::iter::{FromIterator, FusedIterator, Zip};
 use core::marker::PhantomData;
@@ -716,7 +715,24 @@ where
             return Ok(id);
         }
         let name = Interned::from(contents);
-        let id = self.map.len().try_into()?;
+        let id = Symbol::try_from(self.map.len())?;
+
+        // The `Interned::Owned` variant contains a `Box`. When such a structure
+        // is assigned (as it is with the call to `self.vec.push`), the alloc
+        // is "retagged" in Miri/stacked borrows. Retagging an allocation pops
+        // all of the borrows derived from it off of the stack.
+        //
+        // Previously this function derived the `&'static Path` from the given
+        // contents before pushing it into the vec. The code was restructured in
+        // the fix for #235 to ensure borrows on the underlying `Box<Path>` only
+        // get created after the `Box` is done being moved.
+        self.vec.push(name);
+
+        // SAFETY: `self.map` and `self.vec` always have the same length, which
+        // means the derived `id` is the next index in `self.vec`. The preceding
+        // line of code pushes an entry into the vec at this position.
+        let name = unsafe { self.vec.get_unchecked(usize::from(id)) };
+
         // SAFETY: This expression creates a reference with a `'static` lifetime
         // from an owned and interned buffer, which is permissible because:
         //
@@ -728,10 +744,11 @@ where
         // - The `map` field of `SymbolTable`, which contains the `'static`
         //   references, is dropped before the owned buffers stored in this
         //   `Interned`.
+        // - The shared reference may be derived from a `Box` and that `Box`
+        //   will never be retagged/reassigned for the life of the symbol table.
         let slice = unsafe { name.as_static_slice() };
 
         self.map.insert(slice, id);
-        self.vec.push(name);
 
         debug_assert_eq!(self.get(id), Some(slice));
         debug_assert_eq!(self.intern(slice), Ok(id));

--- a/src/path.rs
+++ b/src/path.rs
@@ -728,10 +728,9 @@ where
         // get created after the `Box` is done being moved.
         self.vec.push(name);
 
-        // SAFETY: `self.map` and `self.vec` always have the same length, which
-        // means the derived `id` is the next index in `self.vec`. The preceding
-        // line of code pushes an entry into the vec at this position.
-        let name = unsafe { self.vec.get_unchecked(usize::from(id)) };
+        // SAFETY: `self.vec` is non-empty because the preceding line of code
+        // pushed an entry into it.
+        let name = unsafe { self.vec.last().unwrap_unchecked() };
 
         // SAFETY: This expression creates a reference with a `'static` lifetime
         // from an owned and interned buffer, which is permissible because:

--- a/src/str.rs
+++ b/src/str.rs
@@ -645,10 +645,9 @@ where
         // get created after the `Box` is done being moved.
         self.vec.push(name);
 
-        // SAFETY: `self.map` and `self.vec` always have the same length, which
-        // means the derived `id` is the next index in `self.vec`. The preceding
-        // line of code pushes an entry into the vec at this position.
-        let name = unsafe { self.vec.get_unchecked(usize::from(id)) };
+        // SAFETY: `self.vec` is non-empty because the preceding line of code
+        // pushed an entry into it.
+        let name = unsafe { self.vec.last().unwrap_unchecked() };
 
         // SAFETY: This expression creates a reference with a `'static` lifetime
         // from an owned and interned buffer, which is permissible because:

--- a/src/str.rs
+++ b/src/str.rs
@@ -631,19 +631,43 @@ where
         if let Some(&id) = self.map.get(&*contents) {
             return Ok(id);
         }
+
+        // The `Interned::Owned` variant is derived from a `Box<T>`. When such
+        // a structure is moved or assigned, as it is below in the call to
+        // `self.vec.push`, the allocation is "retagged" in Miri/stacked borrows.
+        //
+        // Retagging an allocation pops all of the borrows derived from it off
+        // of the stack. This means we need to move the `Interned` into the
+        // `Vec` before calling `Interned::as_static_slice` to ensure the
+        // reference does not get invalidated by retagging.
+        //
+        // However, that alone may be insufficient as the `Interened` may be
+        // moved when the symbol table grows.
+        //
+        // The `SymbolTable` API prevents shared references to the `Interned`
+        // being invalidated by a retag by tying resolved symbol contents,
+        // `&'a T`, to `&'a SymbolTable`, which means the `SymbolTable` cannot
+        // grow, shrink, or otherwise reallocate/move contents while a reference
+        // to the `Interned`'s inner `T` is alive.
+        //
+        // To protect against future updates to stacked borrows or the unsafe
+        // code operational semantics, we can address this additional invariant
+        // with updated `Interned` internals which store the `Box<T>` in a raw
+        // pointer form, which allows moves to be treated as untyped copies.
+        //
+        // See:
+        //
+        // - <https://github.com/artichoke/intaglio/issues/235>
+        // - <https://github.com/artichoke/intaglio/pull/236>
         let name = Interned::from(contents);
         let id = Symbol::try_from(self.map.len())?;
 
-        // The `Interned::Owned` variant contains a `Box`. When such a structure
-        // is assigned (as it is with the call to `self.vec.push`), the alloc
-        // is "retagged" in Miri/stacked borrows. Retagging an allocation pops
-        // all of the borrows derived from it off of the stack.
-        //
-        // Previously this function derived the `&'static str` from the given
-        // contents before pushing it into the vec. The code was restructured in
-        // the fix for #235 to ensure borrows on the underlying `Box<str>` only
-        // get created after the `Box` is done being moved.
+        // Move the `Interned` into the `Vec`, causing it to be retagged under
+        // stacked borrows, before taking any references to its inner `T`.
         self.vec.push(name);
+        // Ensure we grow the map before we take any shared references to the
+        // inner `T`.
+        self.map.reserve(1);
 
         // SAFETY: `self.vec` is non-empty because the preceding line of code
         // pushed an entry into it.
@@ -654,14 +678,16 @@ where
         //
         // - `Interned` is an internal implementation detail of `SymbolTable`.
         // - `SymbolTable` never gives out `'static` references to underlying
-        //   UTF-8 string byte contents.
+        //   contents.
         // - All slice references given out by the `SymbolTable` have the same
         //   lifetime as the `SymbolTable`.
         // - The `map` field of `SymbolTable`, which contains the `'static`
         //   references, is dropped before the owned buffers stored in this
         //   `Interned`.
-        // - The shared reference may be derived from a `Box` and that `Box`
-        //   will never be retagged/reassigned for the life of the symbol table.
+        // - The shared reference may be derived from a `PinBox` which prevents
+        //   moves from retagging the underlying boxed `T` under stacked borrows.
+        // - The symbol table cannot grow, shrink, or otherwise move its contents
+        //   while this reference is alive.
         let slice = unsafe { name.as_static_slice() };
 
         self.map.insert(slice, id);

--- a/tests/leak_drop/bytes.rs
+++ b/tests/leak_drop/bytes.rs
@@ -1,4 +1,5 @@
 use intaglio::bytes::SymbolTable;
+use intaglio::Symbol;
 
 #[test]
 fn dealloc_owned_data() {
@@ -15,5 +16,7 @@ fn dealloc_owned_data() {
         assert!(table.is_interned(&symbol));
         assert!(table.contains(sym_id));
         assert_eq!(Some(symbol.as_slice()), table.get(sym_id));
+
+        assert_eq!(table.get(Symbol::new(0)).unwrap().len(), 100);
     }
 }

--- a/tests/leak_drop/cstr.rs
+++ b/tests/leak_drop/cstr.rs
@@ -1,6 +1,7 @@
 use std::ffi::CString;
 
 use intaglio::cstr::SymbolTable;
+use intaglio::Symbol;
 
 #[test]
 fn dealloc_owned_data() {
@@ -17,5 +18,7 @@ fn dealloc_owned_data() {
         assert!(table.is_interned(&symbol));
         assert!(table.contains(sym_id));
         assert_eq!(Some(symbol.as_c_str()), table.get(sym_id));
+
+        assert_eq!(table.get(Symbol::new(0)).unwrap().to_bytes().len(), 100);
     }
 }

--- a/tests/leak_drop/osstr.rs
+++ b/tests/leak_drop/osstr.rs
@@ -1,6 +1,7 @@
 use std::ffi::OsString;
 
 use intaglio::osstr::SymbolTable;
+use intaglio::Symbol;
 
 #[test]
 fn dealloc_owned_data() {
@@ -17,5 +18,7 @@ fn dealloc_owned_data() {
         assert!(table.is_interned(&symbol));
         assert!(table.contains(sym_id));
         assert_eq!(Some(symbol.as_os_str()), table.get(sym_id));
+
+        assert_eq!(table.get(Symbol::new(0)).unwrap().len(), 100);
     }
 }

--- a/tests/leak_drop/path.rs
+++ b/tests/leak_drop/path.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use intaglio::path::SymbolTable;
+use intaglio::Symbol;
 
 #[test]
 fn dealloc_owned_data() {
@@ -17,5 +18,7 @@ fn dealloc_owned_data() {
         assert!(table.is_interned(&symbol));
         assert!(table.contains(sym_id));
         assert_eq!(Some(symbol.as_path()), table.get(sym_id));
+
+        assert_eq!(table.get(Symbol::new(0)).unwrap().as_os_str().len(), 100);
     }
 }

--- a/tests/leak_drop/str.rs
+++ b/tests/leak_drop/str.rs
@@ -1,4 +1,4 @@
-use intaglio::SymbolTable;
+use intaglio::{Symbol, SymbolTable};
 
 #[test]
 fn dealloc_owned_data() {
@@ -15,5 +15,7 @@ fn dealloc_owned_data() {
         assert!(table.is_interned(&symbol));
         assert!(table.contains(sym_id));
         assert_eq!(Some(symbol.as_str()), table.get(sym_id));
+
+        assert_eq!(table.get(Symbol::new(0)).unwrap().len(), 100);
     }
 }


### PR DESCRIPTION
This stacked borrows violation impacts all `SymbolTable` variants in this crate and has been present in all published versions.

The `SymbolTable::intern` function previously worked like this:

1. Convert the given contents to be interned into a `Cow<'static, T>`.
2. Check to see if this content is already interned by checking the internal bimap. If found, return the matching symbol.
3. Convert the `Cow` into an `Interned` which is an enum of either a `&'static T` or a `Box<T>`.
4. Borrow a `&'static T` from the `Interned`.
5. Push the `Interned` into the vec.
6. Add the `&'static T` to the map.
7. Check that the insertion happened correctly with some debug assertions.
8. Return the computed symbol.

As of at least rustc 1.73.0-nightly (31395ec38 2023-07-24), Miri pops all borrows from the `Interned` at step 5 when the `Interned` is moved into the vec, which means the borrow made at 4 is untracked when Miri executes the debug assertions.

The fix here is to make the assignment/move of the `Interned` happen first so Miri doesn't retag the inner `Box<T>`. This is accomplished by reordering the `self.vec.push` operation to immediately follow step 3. An additional unchecked index into the vec is used to get a shared access to that `Interned` object to later derive the `&'static T`.

This commit also adds an additional test to resolve a slice from the symbol table to ensure Miri does not disagree as the `Interned` is moved during growth of the `SymbolTable`.

Fixes #235.