### PR TITLE
Fix v1.9.0 regression where `SymbolTable` is no longer `Send`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "intaglio"
-version = "1.9.0" # remember to set `html_root_url` in `src/lib.rs`.
+version = "1.9.1" # remember to set `html_root_url` in `src/lib.rs`.
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "MIT"
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-intaglio = "1.9.0"
+intaglio = "1.9.1"
 ```
 
 Then intern UTF-8 strings like:

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -425,6 +425,22 @@ mod boxed {
         }
     }
 
+    // SAFETY: `PinBox` acts like `Box`.
+    unsafe impl<T> Send for PinBox<T>
+    where
+        T: ?Sized,
+        Box<T>: Send,
+    {
+    }
+
+    // SAFETY: `PinBox` acts like `Box`.
+    unsafe impl<T> Sync for PinBox<T>
+    where
+        T: ?Sized,
+        Box<T>: Sync,
+    {
+    }
+
     #[cfg(test)]
     mod tests {
         use core::fmt::Write;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -272,6 +272,8 @@ mod tests {
     use core::cmp::Ordering;
     use core::fmt::Write as _;
     use core::hash::{BuildHasher as _, Hash as _, Hasher as _};
+    use core::marker::Unpin;
+    use core::panic::{RefUnwindSafe, UnwindSafe};
     use std::collections::hash_map::RandomState;
 
     use super::SymbolOverflowError;
@@ -356,6 +358,21 @@ mod tests {
         };
 
         assert_eq!(default_hash, new_hash);
+    }
+
+    #[test]
+    fn auto_traits_are_implemented() {
+        fn constraint<T: RefUnwindSafe + Send + Sync + Unpin + UnwindSafe>(_table: T) {}
+
+        constraint(crate::SymbolTable::with_capacity(0));
+        #[cfg(feature = "bytes")]
+        constraint(crate::bytes::SymbolTable::with_capacity(0));
+        #[cfg(feature = "cstr")]
+        constraint(crate::cstr::SymbolTable::with_capacity(0));
+        #[cfg(feature = "osstr")]
+        constraint(crate::osstr::SymbolTable::with_capacity(0));
+        #[cfg(feature = "path")]
+        constraint(crate::path::SymbolTable::with_capacity(0));
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,7 @@
 //! [`&Path`]: std::path::Path
 //! [`&'static Path`]: std::path::Path
 
-#![doc(html_root_url = "https://docs.rs/intaglio/1.9.0")]
+#![doc(html_root_url = "https://docs.rs/intaglio/1.9.1")]
 
 use core::fmt;
 use core::num::TryFromIntError;


### PR DESCRIPTION
Fixes https://github.com/artichoke/intaglio/issues/239.

These unsafe trait impls rely on the fact that `PinBox` is functionally a `Box`.