### PR TITLE
Remove dependency on `quickcheck_macros`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,13 @@ path = []
 quickcheck = { version = "1.0.3", default-features = false }
 quickcheck_macros = "1.0.0"
 
+# Check that crate versions are properly updated in documentation and code when
+# bumping the version.
+[dev-dependencies.version-sync]
+version = "0.9.3"
+default-features = false
+features = ["markdown_deps_updated", "html_root_url_updated"]
+
 [package.metadata.docs.rs]
 # This sets the default target to `x86_64-unknown-linux-gnu` and only builds
 # that target. `intaglio` has the same API and code on all targets.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ path = []
 [dev-dependencies]
 # Property testing for interner getters and setters.
 quickcheck = { version = "1.0.3", default-features = false }
-quickcheck_macros = "1.0.0"
 
 [package.metadata.docs.rs]
 # This sets the default target to `x86_64-unknown-linux-gnu` and only builds

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -896,7 +896,7 @@ where
 #[cfg(test)]
 #[allow(clippy::needless_pass_by_value)]
 mod tests {
-    use quickcheck_macros::quickcheck;
+    use quickcheck::quickcheck;
 
     use super::SymbolTable;
 
@@ -960,45 +960,41 @@ mod tests {
         assert_eq!(sym, table.intern(&b"abc"[..]).unwrap());
     }
 
-    #[quickcheck]
-    fn intern_twice_symbol_equality(bytes: Vec<u8>) -> bool {
-        let mut table = SymbolTable::new();
-        let sym = table.intern(bytes.clone()).unwrap();
-        let sym_again = table.intern(bytes).unwrap();
-        sym == sym_again
-    }
+    quickcheck! {
+        fn intern_twice_symbol_equality(bytes: Vec<u8>) -> bool {
+            let mut table = SymbolTable::new();
+            let sym = table.intern(bytes.clone()).unwrap();
+            let sym_again = table.intern(bytes).unwrap();
+            sym == sym_again
+        }
 
-    #[quickcheck]
-    fn intern_get_roundtrip(bytes: Vec<u8>) -> bool {
-        let mut table = SymbolTable::new();
-        let sym = table.intern(bytes.clone()).unwrap();
-        let retrieved_bytes = table.get(sym).unwrap();
-        bytes == retrieved_bytes
-    }
+        fn intern_get_roundtrip(bytes: Vec<u8>) -> bool {
+            let mut table = SymbolTable::new();
+            let sym = table.intern(bytes.clone()).unwrap();
+            let retrieved_bytes = table.get(sym).unwrap();
+            bytes == retrieved_bytes
+        }
 
-    #[quickcheck]
-    fn table_contains_sym(bytes: Vec<u8>) -> bool {
-        let mut table = SymbolTable::new();
-        let sym = table.intern(bytes).unwrap();
-        table.contains(sym)
-    }
+        fn table_contains_sym(bytes: Vec<u8>) -> bool {
+            let mut table = SymbolTable::new();
+            let sym = table.intern(bytes).unwrap();
+            table.contains(sym)
+        }
 
-    #[quickcheck]
-    fn table_does_not_contain_missing_symbol_ids(sym: u32) -> bool {
-        let table = SymbolTable::new();
-        !table.contains(sym.into())
-    }
+        fn table_does_not_contain_missing_symbol_ids(sym: u32) -> bool {
+            let table = SymbolTable::new();
+            !table.contains(sym.into())
+        }
 
-    #[quickcheck]
-    fn empty_table_does_not_report_any_interned_byte_strings(bytes: Vec<u8>) -> bool {
-        let table = SymbolTable::new();
-        !table.is_interned(bytes.as_slice())
-    }
+        fn empty_table_does_not_report_any_interned_byte_strings(bytes: Vec<u8>) -> bool {
+            let table = SymbolTable::new();
+            !table.is_interned(bytes.as_slice())
+        }
 
-    #[quickcheck]
-    fn table_reports_interned_byte_strings_as_interned(bytes: Vec<u8>) -> bool {
-        let mut table = SymbolTable::new();
-        table.intern(bytes.clone()).unwrap();
-        table.is_interned(bytes.as_slice())
+        fn table_reports_interned_byte_strings_as_interned(bytes: Vec<u8>) -> bool {
+            let mut table = SymbolTable::new();
+            table.intern(bytes.clone()).unwrap();
+            table.is_interned(bytes.as_slice())
+        }
     }
 }

--- a/src/cstr.rs
+++ b/src/cstr.rs
@@ -926,7 +926,7 @@ where
 mod tests {
     use std::ffi::{CStr, CString};
 
-    use quickcheck_macros::quickcheck;
+    use quickcheck::quickcheck;
 
     use super::SymbolTable;
 
@@ -1012,45 +1012,41 @@ mod tests {
         );
     }
 
-    #[quickcheck]
-    fn intern_twice_symbol_equality(cstring: CString) -> bool {
-        let mut table = SymbolTable::new();
-        let sym = table.intern(cstring.clone()).unwrap();
-        let sym_again = table.intern(cstring).unwrap();
-        sym == sym_again
-    }
+    quickcheck! {
+        fn intern_twice_symbol_equality(cstring: CString) -> bool {
+            let mut table = SymbolTable::new();
+            let sym = table.intern(cstring.clone()).unwrap();
+            let sym_again = table.intern(cstring).unwrap();
+            sym == sym_again
+        }
 
-    #[quickcheck]
-    fn intern_get_roundtrip(cstring: CString) -> bool {
-        let mut table = SymbolTable::new();
-        let sym = table.intern(cstring.clone()).unwrap();
-        let retrieved_c_string = table.get(sym).unwrap();
-        &*cstring == retrieved_c_string
-    }
+        fn intern_get_roundtrip(cstring: CString) -> bool {
+            let mut table = SymbolTable::new();
+            let sym = table.intern(cstring.clone()).unwrap();
+            let retrieved_c_string = table.get(sym).unwrap();
+            &*cstring == retrieved_c_string
+        }
 
-    #[quickcheck]
-    fn table_contains_sym(cstring: CString) -> bool {
-        let mut table = SymbolTable::new();
-        let sym = table.intern(cstring).unwrap();
-        table.contains(sym)
-    }
+        fn table_contains_sym(cstring: CString) -> bool {
+            let mut table = SymbolTable::new();
+            let sym = table.intern(cstring).unwrap();
+            table.contains(sym)
+        }
 
-    #[quickcheck]
-    fn table_does_not_contain_missing_symbol_ids(sym: u32) -> bool {
-        let table = SymbolTable::new();
-        !table.contains(sym.into())
-    }
+        fn table_does_not_contain_missing_symbol_ids(sym: u32) -> bool {
+            let table = SymbolTable::new();
+            !table.contains(sym.into())
+        }
 
-    #[quickcheck]
-    fn empty_table_does_not_report_any_interned_c_strings(cstring: CString) -> bool {
-        let table = SymbolTable::new();
-        !table.is_interned(cstring.as_c_str())
-    }
+        fn empty_table_does_not_report_any_interned_c_strings(cstring: CString) -> bool {
+            let table = SymbolTable::new();
+            !table.is_interned(cstring.as_c_str())
+        }
 
-    #[quickcheck]
-    fn table_reports_interned_c_strings_as_interned(cstring: CString) -> bool {
-        let mut table = SymbolTable::new();
-        table.intern(cstring.clone()).unwrap();
-        table.is_interned(cstring.as_c_str())
+        fn table_reports_interned_c_strings_as_interned(cstring: CString) -> bool {
+            let mut table = SymbolTable::new();
+            table.intern(cstring.clone()).unwrap();
+            table.is_interned(cstring.as_c_str())
+        }
     }
 }

--- a/src/osstr.rs
+++ b/src/osstr.rs
@@ -926,7 +926,7 @@ where
 mod tests {
     use std::ffi::{OsStr, OsString};
 
-    use quickcheck_macros::quickcheck;
+    use quickcheck::quickcheck;
 
     use super::SymbolTable;
 
@@ -990,45 +990,41 @@ mod tests {
         assert_eq!(sym, table.intern(OsStr::new("abc")).unwrap());
     }
 
-    #[quickcheck]
-    fn intern_twice_symbol_equality(os_string: OsString) -> bool {
-        let mut table = SymbolTable::new();
-        let sym = table.intern(os_string.clone()).unwrap();
-        let sym_again = table.intern(os_string).unwrap();
-        sym == sym_again
-    }
+    quickcheck! {
+        fn intern_twice_symbol_equality(os_string: OsString) -> bool {
+            let mut table = SymbolTable::new();
+            let sym = table.intern(os_string.clone()).unwrap();
+            let sym_again = table.intern(os_string).unwrap();
+            sym == sym_again
+        }
 
-    #[quickcheck]
-    fn intern_get_roundtrip(os_string: OsString) -> bool {
-        let mut table = SymbolTable::new();
-        let sym = table.intern(os_string.clone()).unwrap();
-        let retrieved_os_string = table.get(sym).unwrap();
-        &*os_string == retrieved_os_string
-    }
+        fn intern_get_roundtrip(os_string: OsString) -> bool {
+            let mut table = SymbolTable::new();
+            let sym = table.intern(os_string.clone()).unwrap();
+            let retrieved_os_string = table.get(sym).unwrap();
+            &*os_string == retrieved_os_string
+        }
 
-    #[quickcheck]
-    fn table_contains_sym(os_string: OsString) -> bool {
-        let mut table = SymbolTable::new();
-        let sym = table.intern(os_string).unwrap();
-        table.contains(sym)
-    }
+        fn table_contains_sym(os_string: OsString) -> bool {
+            let mut table = SymbolTable::new();
+            let sym = table.intern(os_string).unwrap();
+            table.contains(sym)
+        }
 
-    #[quickcheck]
-    fn table_does_not_contain_missing_symbol_ids(sym: u32) -> bool {
-        let table = SymbolTable::new();
-        !table.contains(sym.into())
-    }
+        fn table_does_not_contain_missing_symbol_ids(sym: u32) -> bool {
+            let table = SymbolTable::new();
+            !table.contains(sym.into())
+        }
 
-    #[quickcheck]
-    fn empty_table_does_not_report_any_interned_os_strings(os_string: OsString) -> bool {
-        let table = SymbolTable::new();
-        !table.is_interned(os_string.as_os_str())
-    }
+        fn empty_table_does_not_report_any_interned_os_strings(os_string: OsString) -> bool {
+            let table = SymbolTable::new();
+            !table.is_interned(os_string.as_os_str())
+        }
 
-    #[quickcheck]
-    fn table_reports_interned_os_strs_as_interned(os_string: OsString) -> bool {
-        let mut table = SymbolTable::new();
-        table.intern(os_string.clone()).unwrap();
-        table.is_interned(os_string.as_os_str())
+        fn table_reports_interned_os_strs_as_interned(os_string: OsString) -> bool {
+            let mut table = SymbolTable::new();
+            table.intern(os_string.clone()).unwrap();
+            table.is_interned(os_string.as_os_str())
+        }
     }
 }

--- a/src/path.rs
+++ b/src/path.rs
@@ -926,7 +926,7 @@ where
 mod tests {
     use std::path::{Path, PathBuf};
 
-    use quickcheck_macros::quickcheck;
+    use quickcheck::quickcheck;
 
     use super::SymbolTable;
 
@@ -990,45 +990,41 @@ mod tests {
         assert_eq!(sym, table.intern(Path::new("abc")).unwrap());
     }
 
-    #[quickcheck]
-    fn intern_twice_symbol_equality(path: PathBuf) -> bool {
-        let mut table = SymbolTable::new();
-        let sym = table.intern(path.clone()).unwrap();
-        let sym_again = table.intern(path).unwrap();
-        sym == sym_again
-    }
+    quickcheck! {
+        fn intern_twice_symbol_equality(path: PathBuf) -> bool {
+            let mut table = SymbolTable::new();
+            let sym = table.intern(path.clone()).unwrap();
+            let sym_again = table.intern(path).unwrap();
+            sym == sym_again
+        }
 
-    #[quickcheck]
-    fn intern_get_roundtrip(path: PathBuf) -> bool {
-        let mut table = SymbolTable::new();
-        let sym = table.intern(path.clone()).unwrap();
-        let retrieved_path = table.get(sym).unwrap();
-        &*path == retrieved_path
-    }
+        fn intern_get_roundtrip(path: PathBuf) -> bool {
+            let mut table = SymbolTable::new();
+            let sym = table.intern(path.clone()).unwrap();
+            let retrieved_path = table.get(sym).unwrap();
+            &*path == retrieved_path
+        }
 
-    #[quickcheck]
-    fn table_contains_sym(path: PathBuf) -> bool {
-        let mut table = SymbolTable::new();
-        let sym = table.intern(path).unwrap();
-        table.contains(sym)
-    }
+        fn table_contains_sym(path: PathBuf) -> bool {
+            let mut table = SymbolTable::new();
+            let sym = table.intern(path).unwrap();
+            table.contains(sym)
+        }
 
-    #[quickcheck]
-    fn table_does_not_contain_missing_symbol_ids(sym: u32) -> bool {
-        let table = SymbolTable::new();
-        !table.contains(sym.into())
-    }
+        fn table_does_not_contain_missing_symbol_ids(sym: u32) -> bool {
+            let table = SymbolTable::new();
+            !table.contains(sym.into())
+        }
 
-    #[quickcheck]
-    fn empty_table_does_not_report_any_interned_paths(path: PathBuf) -> bool {
-        let table = SymbolTable::new();
-        !table.is_interned(path.as_path())
-    }
+        fn empty_table_does_not_report_any_interned_paths(path: PathBuf) -> bool {
+            let table = SymbolTable::new();
+            !table.is_interned(path.as_path())
+        }
 
-    #[quickcheck]
-    fn table_reports_interned_paths_as_interned(path: PathBuf) -> bool {
-        let mut table = SymbolTable::new();
-        table.intern(path.clone()).unwrap();
-        table.is_interned(path.as_path())
+        fn table_reports_interned_paths_as_interned(path: PathBuf) -> bool {
+            let mut table = SymbolTable::new();
+            table.intern(path.clone()).unwrap();
+            table.is_interned(path.as_path())
+        }
     }
 }

--- a/src/str.rs
+++ b/src/str.rs
@@ -834,7 +834,7 @@ where
 #[cfg(test)]
 #[allow(clippy::needless_pass_by_value)]
 mod tests {
-    use quickcheck_macros::quickcheck;
+    use quickcheck::quickcheck;
 
     use super::SymbolTable;
 
@@ -898,45 +898,41 @@ mod tests {
         assert_eq!(sym, table.intern("abc").unwrap());
     }
 
-    #[quickcheck]
-    fn intern_twice_symbol_equality(string: String) -> bool {
-        let mut table = SymbolTable::new();
-        let sym = table.intern(string.clone()).unwrap();
-        let sym_again = table.intern(string).unwrap();
-        sym == sym_again
-    }
+    quickcheck! {
+        fn intern_twice_symbol_equality(string: String) -> bool {
+            let mut table = SymbolTable::new();
+            let sym = table.intern(string.clone()).unwrap();
+            let sym_again = table.intern(string).unwrap();
+            sym == sym_again
+        }
 
-    #[quickcheck]
-    fn intern_get_roundtrip(string: String) -> bool {
-        let mut table = SymbolTable::new();
-        let sym = table.intern(string.clone()).unwrap();
-        let retrieved_str = table.get(sym).unwrap();
-        string == retrieved_str
-    }
+        fn intern_get_roundtrip(string: String) -> bool {
+            let mut table = SymbolTable::new();
+            let sym = table.intern(string.clone()).unwrap();
+            let retrieved_str = table.get(sym).unwrap();
+            string == retrieved_str
+        }
 
-    #[quickcheck]
-    fn table_contains_sym(string: String) -> bool {
-        let mut table = SymbolTable::new();
-        let sym = table.intern(string).unwrap();
-        table.contains(sym)
-    }
+        fn table_contains_sym(string: String) -> bool {
+            let mut table = SymbolTable::new();
+            let sym = table.intern(string).unwrap();
+            table.contains(sym)
+        }
 
-    #[quickcheck]
-    fn table_does_not_contain_missing_symbol_ids(sym: u32) -> bool {
-        let table = SymbolTable::new();
-        !table.contains(sym.into())
-    }
+        fn table_does_not_contain_missing_symbol_ids(sym: u32) -> bool {
+            let table = SymbolTable::new();
+            !table.contains(sym.into())
+        }
 
-    #[quickcheck]
-    fn empty_table_does_not_report_any_interned_strings(string: String) -> bool {
-        let table = SymbolTable::new();
-        !table.is_interned(string.as_str())
-    }
+        fn empty_table_does_not_report_any_interned_strings(string: String) -> bool {
+            let table = SymbolTable::new();
+            !table.is_interned(string.as_str())
+        }
 
-    #[quickcheck]
-    fn table_reports_interned_strings_as_interned(string: String) -> bool {
-        let mut table = SymbolTable::new();
-        table.intern(string.clone()).unwrap();
-        table.is_interned(string.as_str())
+        fn table_reports_interned_strings_as_interned(string: String) -> bool {
+            let mut table = SymbolTable::new();
+            table.intern(string.clone()).unwrap();
+            table.is_interned(string.as_str())
+        }
     }
 }

--- a/tests/version_numbers.rs
+++ b/tests/version_numbers.rs
@@ -1,0 +1,9 @@
+#[test]
+fn test_readme_deps() {
+    version_sync::assert_markdown_deps_updated!("README.md");
+}
+
+#[test]
+fn test_html_root_url() {
+    version_sync::assert_html_root_url_updated!("src/lib.rs");
+}


### PR DESCRIPTION
The `macro_rules` macro `quickcheck::quickcheck` is the preferred way to use `quickcheck` in tests. The crate author is not a user of the `syn`-based `quickcheck_macros` attribute macro. This dep has atrophied and has not been updated to `syn` v2.

Remove the attribute macro and replace its use with the equivalent `macro_rules` macro. Update minimum bound on `version-sync` to v0.9.5.

These changes combine to fix the duplicate crate warnings found by `cargo-deny` on trunk:

```
error[duplicate]: found 2 duplicate entries for crate 'syn'
   ┌─ /github/workspace/Cargo.lock:23:1
   │
23 │ ╭ syn 1.0.109 registry+https://github.com/rust-lang/crates.io-index
24 │ │ syn 2.0.32 registry+https://github.com/rust-lang/crates.io-index
   │ ╰────────────────────────────────────────────────────────────────^ lock entries
   │
   = syn v1.0.109
     └── quickcheck_macros v1.0.0
         └── (dev) intaglio v1.9.1
   = syn v2.0.32
     └── version-sync v0.9.5
         └── (dev) intaglio v1.9.1
```

Fixes build failure in https://github.com/artichoke/intaglio/actions/runs/6153154527/job/16696558548.

This diff is best viewed when ignoring whitespace.