### PR TITLE
Remove `version-sync` and version wholesome tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,13 +37,6 @@ path = []
 quickcheck = { version = "1.0.3", default-features = false }
 quickcheck_macros = "1.0.0"
 
-# Check that crate versions are properly updated in documentation and code when
-# bumping the version.
-[dev-dependencies.version-sync]
-version = "0.9.3"
-default-features = false
-features = ["markdown_deps_updated", "html_root_url_updated"]
-
 [package.metadata.docs.rs]
 # This sets the default target to `x86_64-unknown-linux-gnu` and only builds
 # that target. `intaglio` has the same API and code on all targets.

--- a/tests/version_numbers.rs
+++ b/tests/version_numbers.rs
@@ -1,9 +1,0 @@
-#[test]
-fn test_readme_deps() {
-    version_sync::assert_markdown_deps_updated!("README.md");
-}
-
-#[test]
-fn test_html_root_url() {
-    version_sync::assert_html_root_url_updated!("src/lib.rs");
-}


### PR DESCRIPTION
I use a tool called `version-sync` to run wholesome tests on `Cargo.toml`, `README.md`, and `src/lib.rs` to make sure the version of the crate in `Cargo.toml` matches in all of these places.

`version-sync` depends on the `toml` crate to do TOML parsing of "add to cargo.toml" dependency snippets.

The toml crate has undergone a lot of churn under its new maintainers.

The repository for the `toml` crate has rennovate bot set up to update the MSRV of the `toml` crate as declared in Cargo.toml automatically. These MSRV metadata updates are published in patch releases.

Cargo will download dependencies and do MSRV resolution even if the deps are cfg'd out.

This means either the `toml` crate is deciding my MSRV for me or I cannot use `version-sync` crate for wholesome tests.

It is not possible to move to `basic-toml`, which is a dtolnay fork of the `toml` v0.5 branch. `basic-toml` doesn't support parsing directly into a `Value`, only going through `serde`.