### PR TITLE
Revert "Merge pull request #246 from artichoke/lopopolo/remove-versio…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,13 @@ path = []
 quickcheck = { version = "1.0.3", default-features = false }
 quickcheck_macros = "1.0.0"
 
+# Check that crate versions are properly updated in documentation and code when
+# bumping the version.
+[dev-dependencies.version-sync]
+version = "0.9.3"
+default-features = false
+features = ["markdown_deps_updated", "html_root_url_updated"]
+
 [package.metadata.docs.rs]
 # This sets the default target to `x86_64-unknown-linux-gnu` and only builds
 # that target. `intaglio` has the same API and code on all targets.

--- a/tests/version_numbers.rs
+++ b/tests/version_numbers.rs
@@ -1,0 +1,9 @@
+#[test]
+fn test_readme_deps() {
+    version_sync::assert_markdown_deps_updated!("README.md");
+}
+
+#[test]
+fn test_html_root_url() {
+    version_sync::assert_html_root_url_updated!("src/lib.rs");
+}


### PR DESCRIPTION
…n-sync"

This reverts commit ad03e44081640d743d6e5b89b1c6945929049520, reversing changes made to 8c5422d3ee78bf9aef15f8fcd1570772f1b3d4a6.

Cargo does the right thing with the lower version constriant.