### PR TITLE
Fix clippy lint failures for Rust 1.75.0, relax trait bounds on `impl IntoIterator for &SymbolTable`

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -268,7 +268,7 @@ impl<'a> Iterator for Iter<'a> {
 
 impl<'a> FusedIterator for Iter<'a> {}
 
-impl<'a> IntoIterator for &'a SymbolTable {
+impl<'a, S> IntoIterator for &'a SymbolTable<S> {
     type Item = (Symbol, &'a [u8]);
     type IntoIter = Iter<'a>;
 

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -254,7 +254,7 @@ mod tests {
         #[cfg(target_pointer_width = "64")]
         {
             Symbol::try_from(usize::MAX).unwrap_err();
-            Symbol::try_from(u64::try_from(u32::MAX).unwrap() + 1).unwrap_err();
+            Symbol::try_from(u64::from(u32::MAX) + 1).unwrap_err();
         }
     }
 
@@ -281,7 +281,7 @@ mod tests {
         #[cfg(target_pointer_width = "64")]
         {
             Symbol::try_from(&usize::MAX).unwrap_err();
-            Symbol::try_from(&(u64::try_from(u32::MAX).unwrap() + 1)).unwrap_err();
+            Symbol::try_from(&(u64::from(u32::MAX) + 1)).unwrap_err();
         }
     }
 

--- a/src/cstr.rs
+++ b/src/cstr.rs
@@ -277,7 +277,7 @@ impl<'a> Iterator for Iter<'a> {
 
 impl<'a> FusedIterator for Iter<'a> {}
 
-impl<'a> IntoIterator for &'a SymbolTable {
+impl<'a, S> IntoIterator for &'a SymbolTable<S> {
     type Item = (Symbol, &'a CStr);
     type IntoIter = Iter<'a>;
 

--- a/src/osstr.rs
+++ b/src/osstr.rs
@@ -277,7 +277,7 @@ impl<'a> Iterator for Iter<'a> {
 
 impl<'a> FusedIterator for Iter<'a> {}
 
-impl<'a> IntoIterator for &'a SymbolTable {
+impl<'a, S> IntoIterator for &'a SymbolTable<S> {
     type Item = (Symbol, &'a OsStr);
     type IntoIter = Iter<'a>;
 

--- a/src/path.rs
+++ b/src/path.rs
@@ -277,7 +277,7 @@ impl<'a> Iterator for Iter<'a> {
 
 impl<'a> FusedIterator for Iter<'a> {}
 
-impl<'a> IntoIterator for &'a SymbolTable {
+impl<'a, S> IntoIterator for &'a SymbolTable<S> {
     type Item = (Symbol, &'a Path);
     type IntoIter = Iter<'a>;
 

--- a/src/str.rs
+++ b/src/str.rs
@@ -214,7 +214,7 @@ impl<'a> Iterator for Iter<'a> {
 
 impl<'a> FusedIterator for Iter<'a> {}
 
-impl<'a> IntoIterator for &'a SymbolTable {
+impl<'a, S> IntoIterator for &'a SymbolTable<S> {
     type Item = (Symbol, &'a str);
     type IntoIter = Iter<'a>;
 


### PR DESCRIPTION
I'll prep a release after this is merged.