### PR TITLE
Remove version-sync dependency and tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,13 +36,6 @@ path = []
 # Property testing for interner getters and setters.
 quickcheck = { version = "1.0.3", default-features = false }
 
-# Check that crate versions are properly updated in documentation and code when
-# bumping the version.
-[dev-dependencies.version-sync]
-version = "0.9.3"
-default-features = false
-features = ["markdown_deps_updated", "html_root_url_updated"]
-
 [package.metadata.docs.rs]
 # This sets the default target to `x86_64-unknown-linux-gnu` and only builds
 # that target. `intaglio` has the same API and code on all targets.

--- a/tests/version_numbers.rs
+++ b/tests/version_numbers.rs
@@ -1,9 +1,0 @@
-#[test]
-fn test_readme_deps() {
-    version_sync::assert_markdown_deps_updated!("README.md");
-}
-
-#[test]
-fn test_html_root_url() {
-    version_sync::assert_html_root_url_updated!("src/lib.rs");
-}


### PR DESCRIPTION
`version-sync` depends on `url`. A patch version of `url` moved from `unicode-bidi` as a dep to the icu4x ecosystem which has a huge dep tree and an aggressive MSRV policy. To avoid maintenance churn, remove this dep and the associated tests.