### PR TITLE
Add `try_reserve` support with tests across symbol tables

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -57,7 +57,10 @@ use core::mem::ManuallyDrop;
 use core::ops::Range;
 use core::slice;
 use std::borrow::Cow;
-use std::collections::hash_map::{HashMap, RandomState};
+use std::collections::{
+    hash_map::{HashMap, RandomState},
+    TryReserveError,
+};
 
 use crate::internal::Interned;
 use crate::{Symbol, SymbolOverflowError, DEFAULT_SYMBOL_TABLE_CAPACITY};
@@ -839,6 +842,36 @@ where
         self.vec.reserve(additional);
     }
 
+    /// Tries to reserve capacity for at least `additional` more elements in
+    /// the `SymbolTable`, returning an error if the allocation fails.
+    ///
+    /// After calling `try_reserve`, capacity will be greater than or equal to
+    /// `self.len() + additional` on success. Does nothing if capacity is
+    /// already sufficient.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`TryReserveError`] if the allocation fails or if the new
+    /// capacity would overflow `usize`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use intaglio::bytes::SymbolTable;
+    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut table = SymbolTable::with_capacity(1);
+    /// table.intern(b"abc")?;
+    /// table.try_reserve(10)?;
+    /// assert!(table.capacity() >= 11);
+    /// # Ok(())
+    /// # }
+    /// # example().unwrap();
+    /// ```
+    pub fn try_reserve(&mut self, additional: usize) -> Result<(), TryReserveError> {
+        self.map.try_reserve(additional)?;
+        self.vec.try_reserve(additional)
+    }
+
     /// Shrinks the capacity of the symbol table as much as possible.
     ///
     /// It will drop down as close as possible to the length but the allocator
@@ -958,6 +991,26 @@ mod tests {
         assert_eq!(sym, table.intern(b"abc".to_vec()).unwrap());
         // intern borrowed value again
         assert_eq!(sym, table.intern(&b"abc"[..]).unwrap());
+    }
+
+    #[test]
+    fn try_reserve_grows_capacity() {
+        let mut table = SymbolTable::with_capacity(1);
+        table.intern(&b"abc"[..]).unwrap();
+        let len = table.len();
+
+        table.try_reserve(10).unwrap();
+
+        assert!(table.capacity() >= len + 10);
+    }
+
+    #[test]
+    fn try_reserve_overflow_errors() {
+        let mut table = SymbolTable::new();
+
+        let result = table.try_reserve(usize::MAX);
+
+        assert!(result.is_err());
     }
 
     quickcheck! {

--- a/src/cstr.rs
+++ b/src/cstr.rs
@@ -61,7 +61,10 @@ use core::mem::ManuallyDrop;
 use core::ops::Range;
 use core::slice;
 use std::borrow::Cow;
-use std::collections::hash_map::{HashMap, RandomState};
+use std::collections::{
+    hash_map::{HashMap, RandomState},
+    TryReserveError,
+};
 use std::ffi::CStr;
 
 use crate::internal::Interned;
@@ -862,6 +865,37 @@ where
         self.vec.reserve(additional);
     }
 
+    /// Tries to reserve capacity for at least `additional` more elements in
+    /// the `SymbolTable`, returning an error if the allocation fails.
+    ///
+    /// After calling `try_reserve`, capacity will be greater than or equal to
+    /// `self.len() + additional` on success. Does nothing if capacity is
+    /// already sufficient.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`TryReserveError`] if the allocation fails or if the new
+    /// capacity would overflow `usize`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use intaglio::cstr::SymbolTable;
+    /// # use std::ffi::CString;
+    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut table = SymbolTable::with_capacity(1);
+    /// table.intern(CString::new("abc")?)?;
+    /// table.try_reserve(10)?;
+    /// assert!(table.capacity() >= 11);
+    /// # Ok(())
+    /// # }
+    /// # example().unwrap();
+    /// ```
+    pub fn try_reserve(&mut self, additional: usize) -> Result<(), TryReserveError> {
+        self.map.try_reserve(additional)?;
+        self.vec.try_reserve(additional)
+    }
+
     /// Shrinks the capacity of the symbol table as much as possible.
     ///
     /// It will drop down as close as possible to the length but the allocator
@@ -985,6 +1019,26 @@ mod tests {
         assert_eq!(sym, table.intern(c"abc".to_owned()).unwrap());
         // intern borrowed value again
         assert_eq!(sym, table.intern(c"abc").unwrap());
+    }
+
+    #[test]
+    fn try_reserve_grows_capacity() {
+        let mut table = SymbolTable::with_capacity(1);
+        table.intern(c"abc").unwrap();
+        let len = table.len();
+
+        table.try_reserve(10).unwrap();
+
+        assert!(table.capacity() >= len + 10);
+    }
+
+    #[test]
+    fn try_reserve_overflow_errors() {
+        let mut table = SymbolTable::new();
+
+        let result = table.try_reserve(usize::MAX);
+
+        assert!(result.is_err());
     }
 
     quickcheck! {

--- a/src/osstr.rs
+++ b/src/osstr.rs
@@ -62,7 +62,10 @@ use core::mem::ManuallyDrop;
 use core::ops::Range;
 use core::slice;
 use std::borrow::Cow;
-use std::collections::hash_map::{HashMap, RandomState};
+use std::collections::{
+    hash_map::{HashMap, RandomState},
+    TryReserveError,
+};
 use std::ffi::OsStr;
 
 use crate::internal::Interned;
@@ -865,6 +868,37 @@ where
         self.vec.reserve(additional);
     }
 
+    /// Tries to reserve capacity for at least `additional` more elements in
+    /// the `SymbolTable`, returning an error if the allocation fails.
+    ///
+    /// After calling `try_reserve`, capacity will be greater than or equal to
+    /// `self.len() + additional` on success. Does nothing if capacity is
+    /// already sufficient.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`TryReserveError`] if the allocation fails or if the new
+    /// capacity would overflow `usize`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use intaglio::osstr::SymbolTable;
+    /// # use std::ffi::OsStr;
+    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut table = SymbolTable::with_capacity(1);
+    /// table.intern(OsStr::new("abc"))?;
+    /// table.try_reserve(10)?;
+    /// assert!(table.capacity() >= 11);
+    /// # Ok(())
+    /// # }
+    /// # example().unwrap();
+    /// ```
+    pub fn try_reserve(&mut self, additional: usize) -> Result<(), TryReserveError> {
+        self.map.try_reserve(additional)?;
+        self.vec.try_reserve(additional)
+    }
+
     /// Shrinks the capacity of the symbol table as much as possible.
     ///
     /// It will drop down as close as possible to the length but the allocator
@@ -988,6 +1022,26 @@ mod tests {
         assert_eq!(sym, table.intern(OsString::from("abc")).unwrap());
         // intern borrowed value again
         assert_eq!(sym, table.intern(OsStr::new("abc")).unwrap());
+    }
+
+    #[test]
+    fn try_reserve_grows_capacity() {
+        let mut table = SymbolTable::with_capacity(1);
+        table.intern(OsStr::new("abc")).unwrap();
+        let len = table.len();
+
+        table.try_reserve(10).unwrap();
+
+        assert!(table.capacity() >= len + 10);
+    }
+
+    #[test]
+    fn try_reserve_overflow_errors() {
+        let mut table = SymbolTable::new();
+
+        let result = table.try_reserve(usize::MAX);
+
+        assert!(result.is_err());
     }
 
     quickcheck! {

--- a/src/path.rs
+++ b/src/path.rs
@@ -62,7 +62,10 @@ use core::mem::ManuallyDrop;
 use core::ops::Range;
 use core::slice;
 use std::borrow::Cow;
-use std::collections::hash_map::{HashMap, RandomState};
+use std::collections::{
+    hash_map::{HashMap, RandomState},
+    TryReserveError,
+};
 use std::path::Path;
 
 use crate::internal::Interned;
@@ -865,6 +868,37 @@ where
         self.vec.reserve(additional);
     }
 
+    /// Tries to reserve capacity for at least `additional` more elements in
+    /// the `SymbolTable`, returning an error if the allocation fails.
+    ///
+    /// After calling `try_reserve`, capacity will be greater than or equal to
+    /// `self.len() + additional` on success. Does nothing if capacity is
+    /// already sufficient.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`TryReserveError`] if the allocation fails or if the new
+    /// capacity would overflow `usize`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use intaglio::path::SymbolTable;
+    /// # use std::path::PathBuf;
+    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut table = SymbolTable::with_capacity(1);
+    /// table.intern(PathBuf::from("abc"))?;
+    /// table.try_reserve(10)?;
+    /// assert!(table.capacity() >= 11);
+    /// # Ok(())
+    /// # }
+    /// # example().unwrap();
+    /// ```
+    pub fn try_reserve(&mut self, additional: usize) -> Result<(), TryReserveError> {
+        self.map.try_reserve(additional)?;
+        self.vec.try_reserve(additional)
+    }
+
     /// Shrinks the capacity of the symbol table as much as possible.
     ///
     /// It will drop down as close as possible to the length but the allocator
@@ -988,6 +1022,26 @@ mod tests {
         assert_eq!(sym, table.intern(PathBuf::from("abc")).unwrap());
         // intern borrowed value again
         assert_eq!(sym, table.intern(Path::new("abc")).unwrap());
+    }
+
+    #[test]
+    fn try_reserve_grows_capacity() {
+        let mut table = SymbolTable::with_capacity(1);
+        table.intern(Path::new("abc")).unwrap();
+        let len = table.len();
+
+        table.try_reserve(10).unwrap();
+
+        assert!(table.capacity() >= len + 10);
+    }
+
+    #[test]
+    fn try_reserve_overflow_errors() {
+        let mut table = SymbolTable::new();
+
+        let result = table.try_reserve(usize::MAX);
+
+        assert!(result.is_err());
     }
 
     quickcheck! {

--- a/src/str.rs
+++ b/src/str.rs
@@ -7,7 +7,10 @@ use core::mem::ManuallyDrop;
 use core::ops::Range;
 use core::slice;
 use std::borrow::Cow;
-use std::collections::hash_map::{HashMap, RandomState};
+use std::collections::{
+    hash_map::{HashMap, RandomState},
+    TryReserveError,
+};
 
 use crate::internal::Interned;
 use crate::{Symbol, SymbolOverflowError, DEFAULT_SYMBOL_TABLE_CAPACITY};
@@ -777,6 +780,36 @@ where
         self.vec.reserve(additional);
     }
 
+    /// Tries to reserve capacity for at least `additional` more elements in
+    /// the `SymbolTable`, returning an error if the allocation fails.
+    ///
+    /// After calling `try_reserve`, capacity will be greater than or equal to
+    /// `self.len() + additional` on success. Does nothing if capacity is
+    /// already sufficient.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`TryReserveError`] if the allocation fails or if the new
+    /// capacity would overflow `usize`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use intaglio::SymbolTable;
+    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut table = SymbolTable::with_capacity(1);
+    /// table.intern("abc")?;
+    /// table.try_reserve(10)?;
+    /// assert!(table.capacity() >= 11);
+    /// # Ok(())
+    /// # }
+    /// # example().unwrap();
+    /// ```
+    pub fn try_reserve(&mut self, additional: usize) -> Result<(), TryReserveError> {
+        self.map.try_reserve(additional)?;
+        self.vec.try_reserve(additional)
+    }
+
     /// Shrinks the capacity of the symbol table as much as possible.
     ///
     /// It will drop down as close as possible to the length but the allocator
@@ -896,6 +929,26 @@ mod tests {
         assert_eq!(sym, table.intern("abc".to_string()).unwrap());
         // intern borrowed value again
         assert_eq!(sym, table.intern("abc").unwrap());
+    }
+
+    #[test]
+    fn try_reserve_grows_capacity() {
+        let mut table = SymbolTable::with_capacity(1);
+        table.intern("abc").unwrap();
+        let len = table.len();
+
+        table.try_reserve(10).unwrap();
+
+        assert!(table.capacity() >= len + 10);
+    }
+
+    #[test]
+    fn try_reserve_overflow_errors() {
+        let mut table = SymbolTable::new();
+
+        let result = table.try_reserve(usize::MAX);
+
+        assert!(result.is_err());
     }
 
     quickcheck! {


### PR DESCRIPTION
- expose fallible reserve on all SymbolTable variants using HashMap/Vec try_reserve
- add capacity growth and overflow unit tests for str, bytes, cstr, osstr, path tables

Fixes #173.