### PR TITLE
Bump MSRV to 1.85 and adopt Rust 2024

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -126,7 +126,7 @@ jobs:
       - name: Install Rust toolchain
         uses: artichoke/setup-rust/build-and-test@68e0ebb3b406970de1cc2ca807797c9156a198a7 # v2.0.1
         with:
-          toolchain: "1.81.0"
+          toolchain: "1.85.0"
 
       - name: Compile
         run: cargo build --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "intaglio"
-version = "1.12.0" # remember to set `html_root_url` in `src/lib.rs`.
+version = "1.13.0" # remember to set `html_root_url` in `src/lib.rs`.
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "MIT"
-edition = "2021"
-rust-version = "1.81.0"
+edition = "2024"
+rust-version = "1.85.0"
 readme = "README.md"
 repository = "https://github.com/artichoke/intaglio"
 documentation = "https://docs.rs/intaglio"
@@ -34,7 +34,7 @@ path = []
 
 [dev-dependencies]
 # Property testing for interner getters and setters.
-quickcheck = { version = "1.0.3", default-features = false }
+quickcheck = { version = "1.1.0", default-features = false }
 
 [package.metadata.docs.rs]
 # This sets the default target to `x86_64-unknown-linux-gnu` and only builds

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-intaglio = "1.12.0"
+intaglio = "1.13.0"
 ```
 
 Then intern UTF-8 strings like:
@@ -135,7 +135,7 @@ All features are enabled by default.
 
 ### Minimum Supported Rust Version
 
-This crate requires at least Rust 1.81.0. This version can be bumped in minor
+This crate requires at least Rust 1.85.0. This version can be bumped in minor
 releases.
 
 ## License

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -58,12 +58,12 @@ use core::ops::Range;
 use core::slice;
 use std::borrow::Cow;
 use std::collections::{
-    hash_map::{HashMap, RandomState},
     TryReserveError,
+    hash_map::{HashMap, RandomState},
 };
 
 use crate::internal::Interned;
-use crate::{Symbol, SymbolOverflowError, DEFAULT_SYMBOL_TABLE_CAPACITY};
+use crate::{DEFAULT_SYMBOL_TABLE_CAPACITY, Symbol, SymbolOverflowError};
 
 /// An iterator over all [`Symbol`]s in a [`SymbolTable`].
 ///

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -184,7 +184,7 @@ impl From<Symbol> for usize {
     #[inline]
     fn from(sym: Symbol) -> Self {
         // Ensure this cast is lossless.
-        const_assert!(usize::BITS >= u32::BITS);
+        const _: () = assert!(usize::BITS >= u32::BITS);
 
         sym.id() as usize
     }

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -1,4 +1,4 @@
-use core::num::{NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize};
+use core::num::{NonZeroU8, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroUsize};
 
 use crate::{Symbol, SymbolOverflowError};
 
@@ -227,7 +227,7 @@ impl From<&Symbol> for i64 {
 
 #[cfg(test)]
 mod tests {
-    use core::num::{NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize};
+    use core::num::{NonZeroU8, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroUsize};
 
     use crate::Symbol;
 

--- a/src/cstr.rs
+++ b/src/cstr.rs
@@ -62,13 +62,13 @@ use core::ops::Range;
 use core::slice;
 use std::borrow::Cow;
 use std::collections::{
-    hash_map::{HashMap, RandomState},
     TryReserveError,
+    hash_map::{HashMap, RandomState},
 };
 use std::ffi::CStr;
 
 use crate::internal::Interned;
-use crate::{Symbol, SymbolOverflowError, DEFAULT_SYMBOL_TABLE_CAPACITY};
+use crate::{DEFAULT_SYMBOL_TABLE_CAPACITY, Symbol, SymbolOverflowError};
 
 /// An iterator over all [`Symbol`]s in a [`SymbolTable`].
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,21 +109,11 @@
 //! [`&Path`]: std::path::Path
 //! [`&'static Path`]: std::path::Path
 
-#![doc(html_root_url = "https://docs.rs/intaglio/1.12.0")]
+#![doc(html_root_url = "https://docs.rs/intaglio/1.13.0")]
 
 use core::fmt;
 use core::num::TryFromIntError;
 use std::error;
-
-macro_rules! const_assert {
-    ($x:expr $(,)?) => {
-        #[allow(unknown_lints, clippy::eq_op)]
-        const _: [(); 0 - !{
-            const ASSERT: bool = $x;
-            ASSERT
-        } as usize] = [];
-    };
-}
 
 #[cfg(feature = "bytes")]
 #[cfg_attr(docsrs, doc(cfg(feature = "bytes")))]
@@ -146,7 +136,7 @@ pub use crate::str::*;
 
 // To prevent overflows when indexing into the backing `Vec`, `intaglio`
 // requires `usize` to be at least as big as `u32`.
-const_assert!(usize::BITS >= u32::BITS);
+const _: () = assert!(usize::BITS >= u32::BITS);
 
 /// Default capacity for a new [`SymbolTable`] created with
 /// [`SymbolTable::new`].

--- a/src/osstr.rs
+++ b/src/osstr.rs
@@ -63,13 +63,13 @@ use core::ops::Range;
 use core::slice;
 use std::borrow::Cow;
 use std::collections::{
-    hash_map::{HashMap, RandomState},
     TryReserveError,
+    hash_map::{HashMap, RandomState},
 };
 use std::ffi::OsStr;
 
 use crate::internal::Interned;
-use crate::{Symbol, SymbolOverflowError, DEFAULT_SYMBOL_TABLE_CAPACITY};
+use crate::{DEFAULT_SYMBOL_TABLE_CAPACITY, Symbol, SymbolOverflowError};
 
 /// An iterator over all [`Symbol`]s in a [`SymbolTable`].
 ///

--- a/src/path.rs
+++ b/src/path.rs
@@ -63,13 +63,13 @@ use core::ops::Range;
 use core::slice;
 use std::borrow::Cow;
 use std::collections::{
-    hash_map::{HashMap, RandomState},
     TryReserveError,
+    hash_map::{HashMap, RandomState},
 };
 use std::path::Path;
 
 use crate::internal::Interned;
-use crate::{Symbol, SymbolOverflowError, DEFAULT_SYMBOL_TABLE_CAPACITY};
+use crate::{DEFAULT_SYMBOL_TABLE_CAPACITY, Symbol, SymbolOverflowError};
 
 /// An iterator over all [`Symbol`]s in a [`SymbolTable`].
 ///

--- a/src/str.rs
+++ b/src/str.rs
@@ -8,12 +8,12 @@ use core::ops::Range;
 use core::slice;
 use std::borrow::Cow;
 use std::collections::{
-    hash_map::{HashMap, RandomState},
     TryReserveError,
+    hash_map::{HashMap, RandomState},
 };
 
 use crate::internal::Interned;
-use crate::{Symbol, SymbolOverflowError, DEFAULT_SYMBOL_TABLE_CAPACITY};
+use crate::{DEFAULT_SYMBOL_TABLE_CAPACITY, Symbol, SymbolOverflowError};
 
 /// An iterator over all [`Symbol`]s in a [`SymbolTable`].
 ///

--- a/tests/leak_drop/bytes.rs
+++ b/tests/leak_drop/bytes.rs
@@ -1,5 +1,5 @@
-use intaglio::bytes::SymbolTable;
 use intaglio::Symbol;
+use intaglio::bytes::SymbolTable;
 
 #[test]
 fn dealloc_owned_data() {

--- a/tests/leak_drop/cstr.rs
+++ b/tests/leak_drop/cstr.rs
@@ -1,7 +1,7 @@
 use std::ffi::CString;
 
-use intaglio::cstr::SymbolTable;
 use intaglio::Symbol;
+use intaglio::cstr::SymbolTable;
 
 #[test]
 fn dealloc_owned_data() {

--- a/tests/leak_drop/main.rs
+++ b/tests/leak_drop/main.rs
@@ -29,7 +29,7 @@ mod vectors {
             .take(ITERATIONS)
             .map(|(i, ch)| {
                 let len = (i / 256) + 100;
-                iter::repeat(ch).take(len).collect::<String>()
+                iter::repeat_n(ch, len).collect::<String>()
             })
     }
 
@@ -40,7 +40,7 @@ mod vectors {
             .take(ITERATIONS)
             .map(|(i, ch)| {
                 let len = (i / 256) + 100;
-                iter::repeat(ch).take(len).collect::<Vec<_>>()
+                iter::repeat_n(ch, len).collect::<Vec<_>>()
             })
     }
 
@@ -51,7 +51,7 @@ mod vectors {
             .take(ITERATIONS)
             .map(|(i, ch)| {
                 let len = (i / 256) + 100;
-                iter::repeat(ch).take(len).collect::<Vec<_>>()
+                iter::repeat_n(ch, len).collect::<Vec<_>>()
             })
     }
 }

--- a/tests/leak_drop/osstr.rs
+++ b/tests/leak_drop/osstr.rs
@@ -1,7 +1,7 @@
 use std::ffi::OsString;
 
-use intaglio::osstr::SymbolTable;
 use intaglio::Symbol;
+use intaglio::osstr::SymbolTable;
 
 #[test]
 fn dealloc_owned_data() {

--- a/tests/leak_drop/path.rs
+++ b/tests/leak_drop/path.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
-use intaglio::path::SymbolTable;
 use intaglio::Symbol;
+use intaglio::path::SymbolTable;
 
 #[test]
 fn dealloc_owned_data() {


### PR DESCRIPTION
## Summary
- raise crate MSRV to Rust 1.85.0 and pin the CI MSRV job toolchain to `1.85.0`
- migrate the crate from Rust 2021 to Rust 2024 (`cargo fix --edition`)
- bump crate version to `1.13.0`
- raise `quickcheck` dev-dependency minimum to `1.1.0`
- update README and docs.rs metadata (`html_root_url`) for the new version/MSRV
- remove the `const_assert!` macro and use direct const assertions

## Why
The MSRV CI job on `trunk` was failing because unlocked dependency resolution selected `quickcheck 1.1.0`, which pulls edition-2024 crates requiring newer Cargo than Rust 1.81. Raising MSRV to 1.85 aligns the crate and CI with the new dependency floor.

## Validation
- `cargo +1.85.0 test`
- `cargo +1.85.0 test --no-run`
- CI-like no-lockfile check in a temp copy: `cargo +1.85.0 build` and `cargo +1.85.0 test --no-run`
