### PR TITLE
Add hardened trusted publishing workflow

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -56,7 +56,9 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: artichoke/setup-rust/audit@68e0ebb3b406970de1cc2ca807797c9156a198a7 # v2.0.1
+        uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1.15.2
+        with:
+          cache: false
 
       - name: Generate Cargo.lock
         run: |

--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -57,6 +57,8 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
+        with:
+          toolchain: stable
 
       - name: Generate Cargo.lock
         run: |

--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -56,9 +56,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1.15.2
-        with:
-          cache: false
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
 
       - name: Generate Cargo.lock
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,9 +39,8 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1.15.2
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
         with:
-          cache: false
           toolchain: stable
 
       - name: Compile
@@ -82,9 +81,8 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1.15.2
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
         with:
-          cache: false
           toolchain: stable
           target: ${{ matrix.target }}
 
@@ -126,9 +124,8 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1.15.2
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
         with:
-          cache: false
           toolchain: "1.85.0"
 
       - name: Compile
@@ -168,9 +165,8 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1.15.2
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
         with:
-          cache: false
           toolchain: nightly
           target: ${{ matrix.target }}
 
@@ -195,16 +191,14 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1.15.2
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
         with:
-          cache: false
           components: rustfmt
           toolchain: nightly
 
       - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1.15.2
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
         with:
-          cache: false
           components: clippy
           toolchain: stable
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,8 +39,9 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: artichoke/setup-rust/build-and-test@68e0ebb3b406970de1cc2ca807797c9156a198a7 # v2.0.1
+        uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1.15.2
         with:
+          cache: false
           toolchain: stable
 
       - name: Compile
@@ -81,8 +82,9 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: artichoke/setup-rust/build-and-test@68e0ebb3b406970de1cc2ca807797c9156a198a7 # v2.0.1
+        uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1.15.2
         with:
+          cache: false
           toolchain: stable
           target: ${{ matrix.target }}
 
@@ -124,8 +126,9 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: artichoke/setup-rust/build-and-test@68e0ebb3b406970de1cc2ca807797c9156a198a7 # v2.0.1
+        uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1.15.2
         with:
+          cache: false
           toolchain: "1.85.0"
 
       - name: Compile
@@ -165,8 +168,9 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: artichoke/setup-rust/build-and-test@68e0ebb3b406970de1cc2ca807797c9156a198a7 # v2.0.1
+        uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1.15.2
         with:
+          cache: false
           toolchain: nightly
           target: ${{ matrix.target }}
 
@@ -191,13 +195,17 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: artichoke/setup-rust/lint-and-format@68e0ebb3b406970de1cc2ca807797c9156a198a7 # v2.0.1
+        uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1.15.2
         with:
+          cache: false
+          components: rustfmt
           toolchain: nightly
 
       - name: Install Rust toolchain
-        uses: artichoke/setup-rust/lint-and-format@68e0ebb3b406970de1cc2ca807797c9156a198a7 # v2.0.1
+        uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1.15.2
         with:
+          cache: false
+          components: clippy
           toolchain: stable
 
       - name: Check formatting

--- a/.github/workflows/code-coverage.yaml
+++ b/.github/workflows/code-coverage.yaml
@@ -30,9 +30,8 @@ jobs:
           persist-credentials: false
 
       - name: Install nightly Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1.15.2
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
         with:
-          cache: false
           toolchain: nightly
           components: llvm-tools-preview
 

--- a/.github/workflows/code-coverage.yaml
+++ b/.github/workflows/code-coverage.yaml
@@ -30,7 +30,11 @@ jobs:
           persist-credentials: false
 
       - name: Install nightly Rust toolchain
-        uses: artichoke/setup-rust/code-coverage@68e0ebb3b406970de1cc2ca807797c9156a198a7 # v2.0.1
+        uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1.15.2
+        with:
+          cache: false
+          toolchain: nightly
+          components: llvm-tools-preview
 
       - name: Setup grcov
         env:

--- a/.github/workflows/miri.yaml
+++ b/.github/workflows/miri.yaml
@@ -29,9 +29,8 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1.15.2
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
         with:
-          cache: false
           components: miri,rust-src
           toolchain: nightly
 

--- a/.github/workflows/miri.yaml
+++ b/.github/workflows/miri.yaml
@@ -29,8 +29,10 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: artichoke/setup-rust/miri@68e0ebb3b406970de1cc2ca807797c9156a198a7 # v2.0.1
+        uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1.15.2
         with:
+          cache: false
+          components: miri,rust-src
           toolchain: nightly
 
       - name: Miri setup

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -76,7 +76,7 @@ jobs:
       - name: Wait for CI on tagged commit
         shell: bash
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           SHA: ${{ github.sha }}
           CI_WORKFLOW_NAME: CI
@@ -86,39 +86,37 @@ jobs:
           set -euo pipefail
 
           deadline="$(( $(date +%s) + MAX_WAIT_SECONDS ))"
-          api="https://api.github.com/repos/${REPO}/actions/runs?head_sha=${SHA}&per_page=100"
+          run_list=(
+            gh run list
+            --repo "${REPO}"
+            --workflow "${CI_WORKFLOW_NAME}"
+            --commit "${SHA}"
+            --limit 50
+          )
 
           while true; do
-            response="$(
-              curl --fail --silent --show-error \
-                --header "Accept: application/vnd.github+json" \
-                --header "Authorization: Bearer ${GITHUB_TOKEN}" \
-                --header "X-GitHub-Api-Version: 2022-11-28" \
-                "${api}"
-            )"
-
             ci_count="$(
-              jq '[.workflow_runs[] | select(.name == env.CI_WORKFLOW_NAME)] | length' <<<"${response}"
+              "${run_list[@]}" --json status --jq 'length'
             )"
 
             if [[ "${ci_count}" -eq 0 ]]; then
               echo "no '${CI_WORKFLOW_NAME}' workflow runs found yet for ${SHA}; waiting..."
             else
               pending_count="$(
-                jq '[.workflow_runs[] | select(.name == env.CI_WORKFLOW_NAME and .status != "completed")] | length' <<<"${response}"
+                "${run_list[@]}" --json status --jq '[.[] | select(.status != "completed")] | length'
               )"
               if [[ "${pending_count}" -gt 0 ]]; then
                 echo "${pending_count} '${CI_WORKFLOW_NAME}' runs pending for ${SHA}; waiting..."
               else
                 non_success_count="$(
-                  jq '[.workflow_runs[] | select(.name == env.CI_WORKFLOW_NAME and .conclusion != "success")] | length' <<<"${response}"
+                  "${run_list[@]}" --json conclusion --jq '[.[] | select(.conclusion != "success")] | length'
                 )"
                 if [[ "${non_success_count}" -eq 0 ]]; then
                   echo "all '${CI_WORKFLOW_NAME}' runs for ${SHA} completed successfully."
                   break
                 fi
                 echo "'${CI_WORKFLOW_NAME}' is not green for ${SHA}:"
-                jq -r '.workflow_runs[] | select(.name == env.CI_WORKFLOW_NAME and .conclusion != "success") | "- \(.html_url) => \(.conclusion)"' <<<"${response}"
+                "${run_list[@]}" --json conclusion,url --jq '.[] | select(.conclusion != "success") | "- \(.url) => \(.conclusion)"'
                 exit 1
               fi
             fi

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,6 +15,8 @@ jobs:
     name: Publish to crates.io
     if: github.event.created == true
     runs-on: ubuntu-latest
+    environment:
+      name: crates-io-publish
     permissions:
       contents: read # required to checkout repository
       id-token: write # required for trusted publishing to crates.io

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -25,15 +25,21 @@ jobs:
       CARGO_INCREMENTAL: 0
       CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
       RUST_BACKTRACE: 1
-      # Use ephemeral per-job directories and avoid cross-run caches.
-      CARGO_HOME: ${{ runner.temp }}/cargo-home
-      RUSTUP_HOME: ${{ runner.temp }}/rustup-home
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
           fetch-depth: 1
+
+      - name: Configure ephemeral Rust homes
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Use per-job temporary directories and avoid cross-run caches.
+          mkdir -p "${RUNNER_TEMP}/cargo-home" "${RUNNER_TEMP}/rustup-home"
+          echo "CARGO_HOME=${RUNNER_TEMP}/cargo-home" >> "$GITHUB_ENV"
+          echo "RUSTUP_HOME=${RUNNER_TEMP}/rustup-home" >> "$GITHUB_ENV"
 
       - name: Validate release tag
         shell: bash

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -18,6 +18,7 @@ jobs:
     environment:
       name: crates-io-publish
     permissions:
+      actions: read # required to inspect CI workflow run status
       contents: read # required to checkout repository
       id-token: write # required for trusted publishing to crates.io
     env:
@@ -71,6 +72,63 @@ jobs:
             echo "tag version '$TAG_VERSION' does not match crate version '$CARGO_VERSION'"
             exit 1
           fi
+
+      - name: Wait for CI on tagged commit
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+          CI_WORKFLOW_NAME: CI
+          POLL_INTERVAL_SECONDS: 20
+          MAX_WAIT_SECONDS: 10800
+        run: |
+          set -euo pipefail
+
+          deadline="$(( $(date +%s) + MAX_WAIT_SECONDS ))"
+          api="https://api.github.com/repos/${REPO}/actions/runs?head_sha=${SHA}&per_page=100"
+
+          while true; do
+            response="$(
+              curl --fail --silent --show-error \
+                --header "Accept: application/vnd.github+json" \
+                --header "Authorization: Bearer ${GITHUB_TOKEN}" \
+                --header "X-GitHub-Api-Version: 2022-11-28" \
+                "${api}"
+            )"
+
+            ci_count="$(
+              jq '[.workflow_runs[] | select(.name == env.CI_WORKFLOW_NAME)] | length' <<<"${response}"
+            )"
+
+            if [[ "${ci_count}" -eq 0 ]]; then
+              echo "no '${CI_WORKFLOW_NAME}' workflow runs found yet for ${SHA}; waiting..."
+            else
+              pending_count="$(
+                jq '[.workflow_runs[] | select(.name == env.CI_WORKFLOW_NAME and .status != "completed")] | length' <<<"${response}"
+              )"
+              if [[ "${pending_count}" -gt 0 ]]; then
+                echo "${pending_count} '${CI_WORKFLOW_NAME}' runs pending for ${SHA}; waiting..."
+              else
+                non_success_count="$(
+                  jq '[.workflow_runs[] | select(.name == env.CI_WORKFLOW_NAME and .conclusion != "success")] | length' <<<"${response}"
+                )"
+                if [[ "${non_success_count}" -eq 0 ]]; then
+                  echo "all '${CI_WORKFLOW_NAME}' runs for ${SHA} completed successfully."
+                  break
+                fi
+                echo "'${CI_WORKFLOW_NAME}' is not green for ${SHA}:"
+                jq -r '.workflow_runs[] | select(.name == env.CI_WORKFLOW_NAME and .conclusion != "success") | "- \(.html_url) => \(.conclusion)"' <<<"${response}"
+                exit 1
+              fi
+            fi
+
+            if [[ "$(date +%s)" -ge "${deadline}" ]]; then
+              echo "timed out waiting for '${CI_WORKFLOW_NAME}' to complete for ${SHA}"
+              exit 1
+            fi
+            sleep "${POLL_INTERVAL_SECONDS}"
+          done
 
       - name: Authenticate with crates.io
         id: auth

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -36,9 +36,10 @@ jobs:
 
       - name: Validate release tag
         shell: bash
+        env:
+          TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
-          TAG='${{ github.ref_name }}'
           if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "release tag '$TAG' does not match vX.Y.Z"
             exit 1
@@ -56,9 +57,10 @@ jobs:
 
       - name: Ensure Cargo.toml version matches tag
         shell: bash
+        env:
+          TAG_VERSION: ${{ github.ref_name }}
         run: |
           set -euo pipefail
-          TAG_VERSION='${{ github.ref_name }}'
           TAG_VERSION="${TAG_VERSION#v}"
           CARGO_VERSION="$(sed -n 's/^version = "\([0-9][0-9.]*\)".*/\1/p' Cargo.toml | head -n1)"
           if [[ -z "$CARGO_VERSION" ]]; then

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,79 @@
+---
+name: Publish
+"on":
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions: {}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  crates-io:
+    name: Publish to crates.io
+    if: github.event.created == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # required to checkout repository
+      id-token: write # required for trusted publishing to crates.io
+    env:
+      CARGO_INCREMENTAL: 0
+      CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+      RUST_BACKTRACE: 1
+      # Use ephemeral per-job directories and avoid cross-run caches.
+      CARGO_HOME: ${{ runner.temp }}/cargo-home
+      RUSTUP_HOME: ${{ runner.temp }}/rustup-home
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Validate release tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG='${{ github.ref_name }}'
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "release tag '$TAG' does not match vX.Y.Z"
+            exit 1
+          fi
+
+      - name: Install Rust toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          rustup set profile minimal
+          rustup toolchain install stable --no-self-update
+          rustup default stable
+          rustc -Vv
+          cargo -V
+
+      - name: Ensure Cargo.toml version matches tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG_VERSION='${{ github.ref_name }}'
+          TAG_VERSION="${TAG_VERSION#v}"
+          CARGO_VERSION="$(sed -n 's/^version = "\([0-9][0-9.]*\)".*/\1/p' Cargo.toml | head -n1)"
+          if [[ -z "$CARGO_VERSION" ]]; then
+            echo "failed to parse crate version from Cargo.toml"
+            exit 1
+          fi
+          if [[ "$TAG_VERSION" != "$CARGO_VERSION" ]]; then
+            echo "tag version '$TAG_VERSION' does not match crate version '$CARGO_VERSION'"
+            exit 1
+          fi
+
+      - name: Authenticate with crates.io
+        id: auth
+        uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # v1.0.3
+
+      - name: Publish crate
+        shell: bash
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+        run: cargo publish

--- a/.github/workflows/rustdoc.yaml
+++ b/.github/workflows/rustdoc.yaml
@@ -40,9 +40,8 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1.15.2
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
         with:
-          cache: false
           toolchain: nightly
 
       - name: Check docs with no default features

--- a/.github/workflows/rustdoc.yaml
+++ b/.github/workflows/rustdoc.yaml
@@ -40,7 +40,10 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: artichoke/setup-rust/rustdoc@68e0ebb3b406970de1cc2ca807797c9156a198a7 # v2.0.1
+        uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1.15.2
+        with:
+          cache: false
+          toolchain: nightly
 
       - name: Check docs with no default features
         run: cargo doc --workspace --no-default-features


### PR DESCRIPTION
## Summary
- add a `Publish` GitHub Actions workflow triggered by creation of semver tags (`vX.Y.Z`)
- use crates.io trusted publishing via OIDC (`id-token: write`) and `rust-lang/crates-io-auth-action`
- add strict tag and version validation before publishing
- harden the job with pinned action SHAs, minimal permissions, and no cache actions
- bind publishing to dedicated GitHub Actions environment `crates-io-publish`

## Notes
To complete setup, configure the `crates-io-publish` environment in repository settings and use that exact name when registering trusted publishers on crates.io.
