### PR TITLE
Bump crate version to 1.13.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "intaglio"
-version = "1.13.0" # remember to set `html_root_url` in `src/lib.rs`.
+version = "1.13.1" # remember to set `html_root_url` in `src/lib.rs`.
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "MIT"
 edition = "2024"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-intaglio = "1.13.0"
+intaglio = "1.13.1"
 ```
 
 Then intern UTF-8 strings like:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,7 @@
 //! [`&Path`]: std::path::Path
 //! [`&'static Path`]: std::path::Path
 
-#![doc(html_root_url = "https://docs.rs/intaglio/1.13.0")]
+#![doc(html_root_url = "https://docs.rs/intaglio/1.13.1")]
 
 use core::fmt;
 use core::num::TryFromIntError;


### PR DESCRIPTION
## Summary
- bump crate version from 1.13.0 to 1.13.1
- update `html_root_url` in `src/lib.rs` to 1.13.1
- update README dependency snippet to 1.13.1

## Validation
- bundle exec rake fmt lint test
