### PR TITLE
Fix rustdoc build and prepare v1.13.2 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "intaglio"
-version = "1.13.1" # remember to set `html_root_url` in `src/lib.rs`.
+version = "1.13.2" # remember to set `html_root_url` in `src/lib.rs`.
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "MIT"
 edition = "2024"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-intaglio = "1.13.1"
+intaglio = "1.13.2"
 ```
 
 Then intern UTF-8 strings like:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,6 @@
 //
 // This approach is borrowed from tokio.
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![cfg_attr(docsrs, feature(doc_alias))]
 
 //! This crate provides a library for interning strings.
 //!
@@ -109,7 +108,7 @@
 //! [`&Path`]: std::path::Path
 //! [`&'static Path`]: std::path::Path
 
-#![doc(html_root_url = "https://docs.rs/intaglio/1.13.1")]
+#![doc(html_root_url = "https://docs.rs/intaglio/1.13.2")]
 
 use core::fmt;
 use core::num::TryFromIntError;


### PR DESCRIPTION
## Summary
- remove the stale docsrs doc_alias feature gate that now fails under -D warnings
- bump the crate and docs metadata from 1.13.1 to 1.13.2
- update the README dependency snippet for the patch release

## Verification
- cargo test
- cargo +nightly test
- RUSTDOCFLAGS="-D warnings -D rustdoc::broken_intra_doc_links --cfg docsrs" cargo +nightly doc --no-deps
- cargo package --allow-dirty