### PR TITLE
[codex] Fix unwind safety in intern

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "intaglio"
-version = "1.13.2" # remember to set `html_root_url` in `src/lib.rs`.
+version = "1.13.3" # remember to set `html_root_url` in `src/lib.rs`.
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "MIT"
 edition = "2024"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-intaglio = "1.13.2"
+intaglio = "1.13.3"
 ```
 
 Then intern UTF-8 strings like:

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -62,7 +62,7 @@ use std::collections::{
     hash_map::{HashMap, RandomState},
 };
 
-use crate::internal::Interned;
+use crate::internal::{Interned, VecEntryRollbackGuard};
 use crate::{DEFAULT_SYMBOL_TABLE_CAPACITY, Symbol, SymbolOverflowError};
 
 /// An iterator over all [`Symbol`]s in a [`SymbolTable`].
@@ -725,35 +725,40 @@ where
         let name = Interned::from(contents);
         let id = Symbol::try_from(self.map.len())?;
 
-        // Move the `Interned` into the `Vec`, causing it to be retagged under
-        // stacked borrows, before taking any references to its inner `T`.
-        self.vec.push(name);
-        // Ensure we grow the map before we take any shared references to the
-        // inner `T`.
-        self.map.reserve(1);
+        let slice = {
+            // Move the `Interned` into the `Vec`, causing it to be retagged
+            // under stacked borrows, before taking any references to its inner
+            // `T`. If anything after this push panics, roll back the `Vec`
+            // mutation so the symbol table remains internally consistent.
+            let mut name = VecEntryRollbackGuard::new(&mut self.vec, name);
+            // Ensure we grow the map before we take any shared references to
+            // the inner `T`.
+            self.map.reserve(1);
 
-        // SAFETY: `self.vec` is non-empty because the preceding line of code
-        // pushed an entry into it.
-        let name = unsafe { self.vec.last().unwrap_unchecked() };
+            // SAFETY: This expression creates a reference with a `'static`
+            // lifetime from an owned and interned buffer, which is permissible
+            // because:
+            //
+            // - `Interned` is an internal implementation detail of
+            //   `SymbolTable`.
+            // - `SymbolTable` never gives out `'static` references to
+            //   underlying contents.
+            // - All slice references given out by the `SymbolTable` have the
+            //   same lifetime as the `SymbolTable`.
+            // - The `map` field of `SymbolTable`, which contains the `'static`
+            //   references, is dropped before the owned buffers stored in this
+            //   `Interned`.
+            // - The shared reference may be derived from a `PinBox` which
+            //   prevents moves from retagging the underlying boxed `T` under
+            //   stacked borrows.
+            // - The symbol table cannot grow, shrink, or otherwise move its
+            //   contents while this reference is alive.
+            let slice = unsafe { name.last().as_static_slice() };
 
-        // SAFETY: This expression creates a reference with a `'static` lifetime
-        // from an owned and interned buffer, which is permissible because:
-        //
-        // - `Interned` is an internal implementation detail of `SymbolTable`.
-        // - `SymbolTable` never gives out `'static` references to underlying
-        //   contents.
-        // - All slice references given out by the `SymbolTable` have the same
-        //   lifetime as the `SymbolTable`.
-        // - The `map` field of `SymbolTable`, which contains the `'static`
-        //   references, is dropped before the owned buffers stored in this
-        //   `Interned`.
-        // - The shared reference may be derived from a `PinBox` which prevents
-        //   moves from retagging the underlying boxed `T` under stacked borrows.
-        // - The symbol table cannot grow, shrink, or otherwise move its contents
-        //   while this reference is alive.
-        let slice = unsafe { name.as_static_slice() };
-
-        self.map.insert(slice, id);
+            self.map.insert(slice, id);
+            name.disarm();
+            slice
+        };
 
         debug_assert_eq!(self.get(id), Some(slice));
         debug_assert_eq!(self.intern(slice), Ok(id));

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -62,7 +62,8 @@ use std::collections::{
     hash_map::{HashMap, RandomState},
 };
 
-use crate::internal::{Interned, VecEntryRollbackGuard};
+use crate::internal::Interned;
+use crate::rollback::VecEntryRollbackGuard;
 use crate::{DEFAULT_SYMBOL_TABLE_CAPACITY, Symbol, SymbolOverflowError};
 
 /// An iterator over all [`Symbol`]s in a [`SymbolTable`].
@@ -756,7 +757,7 @@ where
             let slice = unsafe { name.last().as_static_slice() };
 
             self.map.insert(slice, id);
-            name.disarm();
+            name.defuse();
             slice
         };
 

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -731,7 +731,7 @@ where
             // under stacked borrows, before taking any references to its inner
             // `T`. If anything after this push panics, roll back the `Vec`
             // mutation so the symbol table remains internally consistent.
-            let mut guard = VecEntryRollbackGuard::new(&mut self.vec, name);
+            let guard = VecEntryRollbackGuard::new(&mut self.vec, name);
             // Ensure we grow the map before we take any shared references to
             // the inner `T`.
             self.map.reserve(1);

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -731,7 +731,7 @@ where
             // under stacked borrows, before taking any references to its inner
             // `T`. If anything after this push panics, roll back the `Vec`
             // mutation so the symbol table remains internally consistent.
-            let mut name = VecEntryRollbackGuard::new(&mut self.vec, name);
+            let mut guard = VecEntryRollbackGuard::new(&mut self.vec, name);
             // Ensure we grow the map before we take any shared references to
             // the inner `T`.
             self.map.reserve(1);
@@ -754,10 +754,10 @@ where
             //   stacked borrows.
             // - The symbol table cannot grow, shrink, or otherwise move its
             //   contents while this reference is alive.
-            let slice = unsafe { name.last().as_static_slice() };
+            let slice = unsafe { guard.last().as_static_slice() };
 
             self.map.insert(slice, id);
-            name.defuse();
+            guard.defuse();
             slice
         };
 

--- a/src/cstr.rs
+++ b/src/cstr.rs
@@ -67,7 +67,7 @@ use std::collections::{
 };
 use std::ffi::CStr;
 
-use crate::internal::Interned;
+use crate::internal::{Interned, VecEntryRollbackGuard};
 use crate::{DEFAULT_SYMBOL_TABLE_CAPACITY, Symbol, SymbolOverflowError};
 
 /// An iterator over all [`Symbol`]s in a [`SymbolTable`].
@@ -745,35 +745,40 @@ where
         let name = Interned::from(contents);
         let id = Symbol::try_from(self.map.len())?;
 
-        // Move the `Interned` into the `Vec`, causing it to be retagged under
-        // stacked borrows, before taking any references to its inner `T`.
-        self.vec.push(name);
-        // Ensure we grow the map before we take any shared references to the
-        // inner `T`.
-        self.map.reserve(1);
+        let slice = {
+            // Move the `Interned` into the `Vec`, causing it to be retagged
+            // under stacked borrows, before taking any references to its inner
+            // `T`. If anything after this push panics, roll back the `Vec`
+            // mutation so the symbol table remains internally consistent.
+            let mut name = VecEntryRollbackGuard::new(&mut self.vec, name);
+            // Ensure we grow the map before we take any shared references to
+            // the inner `T`.
+            self.map.reserve(1);
 
-        // SAFETY: `self.vec` is non-empty because the preceding line of code
-        // pushed an entry into it.
-        let name = unsafe { self.vec.last().unwrap_unchecked() };
+            // SAFETY: This expression creates a reference with a `'static`
+            // lifetime from an owned and interned buffer, which is permissible
+            // because:
+            //
+            // - `Interned` is an internal implementation detail of
+            //   `SymbolTable`.
+            // - `SymbolTable` never gives out `'static` references to
+            //   underlying contents.
+            // - All slice references given out by the `SymbolTable` have the
+            //   same lifetime as the `SymbolTable`.
+            // - The `map` field of `SymbolTable`, which contains the `'static`
+            //   references, is dropped before the owned buffers stored in this
+            //   `Interned`.
+            // - The shared reference may be derived from a `PinBox` which
+            //   prevents moves from retagging the underlying boxed `T` under
+            //   stacked borrows.
+            // - The symbol table cannot grow, shrink, or otherwise move its
+            //   contents while this reference is alive.
+            let slice = unsafe { name.last().as_static_slice() };
 
-        // SAFETY: This expression creates a reference with a `'static` lifetime
-        // from an owned and interned buffer, which is permissible because:
-        //
-        // - `Interned` is an internal implementation detail of `SymbolTable`.
-        // - `SymbolTable` never gives out `'static` references to underlying
-        //   contents.
-        // - All slice references given out by the `SymbolTable` have the same
-        //   lifetime as the `SymbolTable`.
-        // - The `map` field of `SymbolTable`, which contains the `'static`
-        //   references, is dropped before the owned buffers stored in this
-        //   `Interned`.
-        // - The shared reference may be derived from a `PinBox` which prevents
-        //   moves from retagging the underlying boxed `T` under stacked borrows.
-        // - The symbol table cannot grow, shrink, or otherwise move its contents
-        //   while this reference is alive.
-        let slice = unsafe { name.as_static_slice() };
-
-        self.map.insert(slice, id);
+            self.map.insert(slice, id);
+            name.disarm();
+            slice
+        };
 
         debug_assert_eq!(self.get(id), Some(slice));
         debug_assert_eq!(self.intern(slice), Ok(id));

--- a/src/cstr.rs
+++ b/src/cstr.rs
@@ -751,7 +751,7 @@ where
             // under stacked borrows, before taking any references to its inner
             // `T`. If anything after this push panics, roll back the `Vec`
             // mutation so the symbol table remains internally consistent.
-            let mut guard = VecEntryRollbackGuard::new(&mut self.vec, name);
+            let guard = VecEntryRollbackGuard::new(&mut self.vec, name);
             // Ensure we grow the map before we take any shared references to
             // the inner `T`.
             self.map.reserve(1);

--- a/src/cstr.rs
+++ b/src/cstr.rs
@@ -751,7 +751,7 @@ where
             // under stacked borrows, before taking any references to its inner
             // `T`. If anything after this push panics, roll back the `Vec`
             // mutation so the symbol table remains internally consistent.
-            let mut name = VecEntryRollbackGuard::new(&mut self.vec, name);
+            let mut guard = VecEntryRollbackGuard::new(&mut self.vec, name);
             // Ensure we grow the map before we take any shared references to
             // the inner `T`.
             self.map.reserve(1);
@@ -774,10 +774,10 @@ where
             //   stacked borrows.
             // - The symbol table cannot grow, shrink, or otherwise move its
             //   contents while this reference is alive.
-            let slice = unsafe { name.last().as_static_slice() };
+            let slice = unsafe { guard.last().as_static_slice() };
 
             self.map.insert(slice, id);
-            name.defuse();
+            guard.defuse();
             slice
         };
 

--- a/src/cstr.rs
+++ b/src/cstr.rs
@@ -67,7 +67,8 @@ use std::collections::{
 };
 use std::ffi::CStr;
 
-use crate::internal::{Interned, VecEntryRollbackGuard};
+use crate::internal::Interned;
+use crate::rollback::VecEntryRollbackGuard;
 use crate::{DEFAULT_SYMBOL_TABLE_CAPACITY, Symbol, SymbolOverflowError};
 
 /// An iterator over all [`Symbol`]s in a [`SymbolTable`].
@@ -776,7 +777,7 @@ where
             let slice = unsafe { name.last().as_static_slice() };
 
             self.map.insert(slice, id);
-            name.disarm();
+            name.defuse();
             slice
         };
 

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -115,6 +115,46 @@ impl fmt::Debug for Interned<Path> {
     }
 }
 
+/// Roll back the last push to an interner backing vector if unwinding occurs
+/// before the corresponding map insert succeeds.
+pub struct VecEntryRollbackGuard<'a, T: 'static + ?Sized> {
+    vec: &'a mut Vec<Interned<T>>,
+    armed: bool,
+}
+
+impl<'a, T> VecEntryRollbackGuard<'a, T>
+where
+    T: ?Sized,
+{
+    #[inline]
+    pub fn new(vec: &'a mut Vec<Interned<T>>, value: Interned<T>) -> Self {
+        vec.push(value);
+        Self { vec, armed: true }
+    }
+
+    #[inline]
+    pub fn last(&self) -> &Interned<T> {
+        // SAFETY: `VecEntryRollbackGuard::new` always pushes one element.
+        unsafe { self.vec.last().unwrap_unchecked() }
+    }
+
+    #[inline]
+    pub fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl<T> Drop for VecEntryRollbackGuard<'_, T>
+where
+    T: ?Sized,
+{
+    fn drop(&mut self) {
+        if self.armed {
+            drop(self.vec.pop());
+        }
+    }
+}
+
 /// Wrapper around `&'static` slices.
 ///
 /// # Safety

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -115,46 +115,6 @@ impl fmt::Debug for Interned<Path> {
     }
 }
 
-/// Roll back the last push to an interner backing vector if unwinding occurs
-/// before the corresponding map insert succeeds.
-pub struct VecEntryRollbackGuard<'a, T: 'static + ?Sized> {
-    vec: &'a mut Vec<Interned<T>>,
-    armed: bool,
-}
-
-impl<'a, T> VecEntryRollbackGuard<'a, T>
-where
-    T: ?Sized,
-{
-    #[inline]
-    pub fn new(vec: &'a mut Vec<Interned<T>>, value: Interned<T>) -> Self {
-        vec.push(value);
-        Self { vec, armed: true }
-    }
-
-    #[inline]
-    pub fn last(&self) -> &Interned<T> {
-        // SAFETY: `VecEntryRollbackGuard::new` always pushes one element.
-        unsafe { self.vec.last().unwrap_unchecked() }
-    }
-
-    #[inline]
-    pub fn disarm(&mut self) {
-        self.armed = false;
-    }
-}
-
-impl<T> Drop for VecEntryRollbackGuard<'_, T>
-where
-    T: ?Sized,
-{
-    fn drop(&mut self) {
-        if self.armed {
-            drop(self.vec.pop());
-        }
-    }
-}
-
 /// Wrapper around `&'static` slices.
 ///
 /// # Safety

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,7 @@
 //! [`&Path`]: std::path::Path
 //! [`&'static Path`]: std::path::Path
 
-#![doc(html_root_url = "https://docs.rs/intaglio/1.13.2")]
+#![doc(html_root_url = "https://docs.rs/intaglio/1.13.3")]
 
 use core::fmt;
 use core::num::TryFromIntError;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,6 +129,7 @@ pub mod osstr;
 #[cfg(feature = "path")]
 #[cfg_attr(docsrs, doc(cfg(feature = "path")))]
 pub mod path;
+mod rollback;
 mod str;
 
 pub use crate::str::*;

--- a/src/osstr.rs
+++ b/src/osstr.rs
@@ -68,7 +68,7 @@ use std::collections::{
 };
 use std::ffi::OsStr;
 
-use crate::internal::Interned;
+use crate::internal::{Interned, VecEntryRollbackGuard};
 use crate::{DEFAULT_SYMBOL_TABLE_CAPACITY, Symbol, SymbolOverflowError};
 
 /// An iterator over all [`Symbol`]s in a [`SymbolTable`].
@@ -748,35 +748,40 @@ where
         let name = Interned::from(contents);
         let id = Symbol::try_from(self.map.len())?;
 
-        // Move the `Interned` into the `Vec`, causing it to be retagged under
-        // stacked borrows, before taking any references to its inner `T`.
-        self.vec.push(name);
-        // Ensure we grow the map before we take any shared references to the
-        // inner `T`.
-        self.map.reserve(1);
+        let slice = {
+            // Move the `Interned` into the `Vec`, causing it to be retagged
+            // under stacked borrows, before taking any references to its inner
+            // `T`. If anything after this push panics, roll back the `Vec`
+            // mutation so the symbol table remains internally consistent.
+            let mut name = VecEntryRollbackGuard::new(&mut self.vec, name);
+            // Ensure we grow the map before we take any shared references to
+            // the inner `T`.
+            self.map.reserve(1);
 
-        // SAFETY: `self.vec` is non-empty because the preceding line of code
-        // pushed an entry into it.
-        let name = unsafe { self.vec.last().unwrap_unchecked() };
+            // SAFETY: This expression creates a reference with a `'static`
+            // lifetime from an owned and interned buffer, which is permissible
+            // because:
+            //
+            // - `Interned` is an internal implementation detail of
+            //   `SymbolTable`.
+            // - `SymbolTable` never gives out `'static` references to
+            //   underlying contents.
+            // - All slice references given out by the `SymbolTable` have the
+            //   same lifetime as the `SymbolTable`.
+            // - The `map` field of `SymbolTable`, which contains the `'static`
+            //   references, is dropped before the owned buffers stored in this
+            //   `Interned`.
+            // - The shared reference may be derived from a `PinBox` which
+            //   prevents moves from retagging the underlying boxed `T` under
+            //   stacked borrows.
+            // - The symbol table cannot grow, shrink, or otherwise move its
+            //   contents while this reference is alive.
+            let slice = unsafe { name.last().as_static_slice() };
 
-        // SAFETY: This expression creates a reference with a `'static` lifetime
-        // from an owned and interned buffer, which is permissible because:
-        //
-        // - `Interned` is an internal implementation detail of `SymbolTable`.
-        // - `SymbolTable` never gives out `'static` references to underlying
-        //   contents.
-        // - All slice references given out by the `SymbolTable` have the same
-        //   lifetime as the `SymbolTable`.
-        // - The `map` field of `SymbolTable`, which contains the `'static`
-        //   references, is dropped before the owned buffers stored in this
-        //   `Interned`.
-        // - The shared reference may be derived from a `PinBox` which prevents
-        //   moves from retagging the underlying boxed `T` under stacked borrows.
-        // - The symbol table cannot grow, shrink, or otherwise move its contents
-        //   while this reference is alive.
-        let slice = unsafe { name.as_static_slice() };
-
-        self.map.insert(slice, id);
+            self.map.insert(slice, id);
+            name.disarm();
+            slice
+        };
 
         debug_assert_eq!(self.get(id), Some(slice));
         debug_assert_eq!(self.intern(slice), Ok(id));

--- a/src/osstr.rs
+++ b/src/osstr.rs
@@ -754,7 +754,7 @@ where
             // under stacked borrows, before taking any references to its inner
             // `T`. If anything after this push panics, roll back the `Vec`
             // mutation so the symbol table remains internally consistent.
-            let mut guard = VecEntryRollbackGuard::new(&mut self.vec, name);
+            let guard = VecEntryRollbackGuard::new(&mut self.vec, name);
             // Ensure we grow the map before we take any shared references to
             // the inner `T`.
             self.map.reserve(1);

--- a/src/osstr.rs
+++ b/src/osstr.rs
@@ -754,7 +754,7 @@ where
             // under stacked borrows, before taking any references to its inner
             // `T`. If anything after this push panics, roll back the `Vec`
             // mutation so the symbol table remains internally consistent.
-            let mut name = VecEntryRollbackGuard::new(&mut self.vec, name);
+            let mut guard = VecEntryRollbackGuard::new(&mut self.vec, name);
             // Ensure we grow the map before we take any shared references to
             // the inner `T`.
             self.map.reserve(1);
@@ -777,10 +777,10 @@ where
             //   stacked borrows.
             // - The symbol table cannot grow, shrink, or otherwise move its
             //   contents while this reference is alive.
-            let slice = unsafe { name.last().as_static_slice() };
+            let slice = unsafe { guard.last().as_static_slice() };
 
             self.map.insert(slice, id);
-            name.defuse();
+            guard.defuse();
             slice
         };
 

--- a/src/osstr.rs
+++ b/src/osstr.rs
@@ -68,7 +68,8 @@ use std::collections::{
 };
 use std::ffi::OsStr;
 
-use crate::internal::{Interned, VecEntryRollbackGuard};
+use crate::internal::Interned;
+use crate::rollback::VecEntryRollbackGuard;
 use crate::{DEFAULT_SYMBOL_TABLE_CAPACITY, Symbol, SymbolOverflowError};
 
 /// An iterator over all [`Symbol`]s in a [`SymbolTable`].
@@ -779,7 +780,7 @@ where
             let slice = unsafe { name.last().as_static_slice() };
 
             self.map.insert(slice, id);
-            name.disarm();
+            name.defuse();
             slice
         };
 

--- a/src/path.rs
+++ b/src/path.rs
@@ -68,7 +68,8 @@ use std::collections::{
 };
 use std::path::Path;
 
-use crate::internal::{Interned, VecEntryRollbackGuard};
+use crate::internal::Interned;
+use crate::rollback::VecEntryRollbackGuard;
 use crate::{DEFAULT_SYMBOL_TABLE_CAPACITY, Symbol, SymbolOverflowError};
 
 /// An iterator over all [`Symbol`]s in a [`SymbolTable`].
@@ -779,7 +780,7 @@ where
             let slice = unsafe { name.last().as_static_slice() };
 
             self.map.insert(slice, id);
-            name.disarm();
+            name.defuse();
             slice
         };
 

--- a/src/path.rs
+++ b/src/path.rs
@@ -68,7 +68,7 @@ use std::collections::{
 };
 use std::path::Path;
 
-use crate::internal::Interned;
+use crate::internal::{Interned, VecEntryRollbackGuard};
 use crate::{DEFAULT_SYMBOL_TABLE_CAPACITY, Symbol, SymbolOverflowError};
 
 /// An iterator over all [`Symbol`]s in a [`SymbolTable`].
@@ -748,35 +748,40 @@ where
         let name = Interned::from(contents);
         let id = Symbol::try_from(self.map.len())?;
 
-        // Move the `Interned` into the `Vec`, causing it to be retagged under
-        // stacked borrows, before taking any references to its inner `T`.
-        self.vec.push(name);
-        // Ensure we grow the map before we take any shared references to the
-        // inner `T`.
-        self.map.reserve(1);
+        let slice = {
+            // Move the `Interned` into the `Vec`, causing it to be retagged
+            // under stacked borrows, before taking any references to its inner
+            // `T`. If anything after this push panics, roll back the `Vec`
+            // mutation so the symbol table remains internally consistent.
+            let mut name = VecEntryRollbackGuard::new(&mut self.vec, name);
+            // Ensure we grow the map before we take any shared references to
+            // the inner `T`.
+            self.map.reserve(1);
 
-        // SAFETY: `self.vec` is non-empty because the preceding line of code
-        // pushed an entry into it.
-        let name = unsafe { self.vec.last().unwrap_unchecked() };
+            // SAFETY: This expression creates a reference with a `'static`
+            // lifetime from an owned and interned buffer, which is permissible
+            // because:
+            //
+            // - `Interned` is an internal implementation detail of
+            //   `SymbolTable`.
+            // - `SymbolTable` never gives out `'static` references to
+            //   underlying contents.
+            // - All slice references given out by the `SymbolTable` have the
+            //   same lifetime as the `SymbolTable`.
+            // - The `map` field of `SymbolTable`, which contains the `'static`
+            //   references, is dropped before the owned buffers stored in this
+            //   `Interned`.
+            // - The shared reference may be derived from a `PinBox` which
+            //   prevents moves from retagging the underlying boxed `T` under
+            //   stacked borrows.
+            // - The symbol table cannot grow, shrink, or otherwise move its
+            //   contents while this reference is alive.
+            let slice = unsafe { name.last().as_static_slice() };
 
-        // SAFETY: This expression creates a reference with a `'static` lifetime
-        // from an owned and interned buffer, which is permissible because:
-        //
-        // - `Interned` is an internal implementation detail of `SymbolTable`.
-        // - `SymbolTable` never gives out `'static` references to underlying
-        //   contents.
-        // - All slice references given out by the `SymbolTable` have the same
-        //   lifetime as the `SymbolTable`.
-        // - The `map` field of `SymbolTable`, which contains the `'static`
-        //   references, is dropped before the owned buffers stored in this
-        //   `Interned`.
-        // - The shared reference may be derived from a `PinBox` which prevents
-        //   moves from retagging the underlying boxed `T` under stacked borrows.
-        // - The symbol table cannot grow, shrink, or otherwise move its contents
-        //   while this reference is alive.
-        let slice = unsafe { name.as_static_slice() };
-
-        self.map.insert(slice, id);
+            self.map.insert(slice, id);
+            name.disarm();
+            slice
+        };
 
         debug_assert_eq!(self.get(id), Some(slice));
         debug_assert_eq!(self.intern(slice), Ok(id));

--- a/src/path.rs
+++ b/src/path.rs
@@ -754,7 +754,7 @@ where
             // under stacked borrows, before taking any references to its inner
             // `T`. If anything after this push panics, roll back the `Vec`
             // mutation so the symbol table remains internally consistent.
-            let mut guard = VecEntryRollbackGuard::new(&mut self.vec, name);
+            let guard = VecEntryRollbackGuard::new(&mut self.vec, name);
             // Ensure we grow the map before we take any shared references to
             // the inner `T`.
             self.map.reserve(1);

--- a/src/path.rs
+++ b/src/path.rs
@@ -754,7 +754,7 @@ where
             // under stacked borrows, before taking any references to its inner
             // `T`. If anything after this push panics, roll back the `Vec`
             // mutation so the symbol table remains internally consistent.
-            let mut name = VecEntryRollbackGuard::new(&mut self.vec, name);
+            let mut guard = VecEntryRollbackGuard::new(&mut self.vec, name);
             // Ensure we grow the map before we take any shared references to
             // the inner `T`.
             self.map.reserve(1);
@@ -777,10 +777,10 @@ where
             //   stacked borrows.
             // - The symbol table cannot grow, shrink, or otherwise move its
             //   contents while this reference is alive.
-            let slice = unsafe { name.last().as_static_slice() };
+            let slice = unsafe { guard.last().as_static_slice() };
 
             self.map.insert(slice, id);
-            name.defuse();
+            guard.defuse();
             slice
         };
 

--- a/src/rollback.rs
+++ b/src/rollback.rs
@@ -1,0 +1,61 @@
+use crate::internal::Interned;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GuardState {
+    Armed,
+    Defused,
+}
+
+/// Roll back the last push to an interner backing vector if unwinding occurs
+/// before the corresponding map insert succeeds.
+pub(crate) struct VecEntryRollbackGuard<'a, T: 'static + ?Sized> {
+    vec: &'a mut Vec<Interned<T>>,
+    state: GuardState,
+}
+
+impl<'a, T> VecEntryRollbackGuard<'a, T>
+where
+    T: ?Sized,
+{
+    #[inline]
+    pub(crate) fn new(vec: &'a mut Vec<Interned<T>>, value: Interned<T>) -> Self {
+        vec.push(value);
+        Self {
+            vec,
+            state: GuardState::Armed,
+        }
+    }
+
+    #[inline]
+    pub(crate) fn last(&self) -> &Interned<T> {
+        debug_assert!(!self.vec.is_empty());
+        // SAFETY: `VecEntryRollbackGuard::new` always pushes one element.
+        unsafe { self.vec.last().unwrap_unchecked() }
+    }
+
+    #[inline]
+    pub(crate) fn defuse(&mut self) {
+        match self.state {
+            GuardState::Armed => {
+                self.state = GuardState::Defused;
+            }
+            GuardState::Defused => {
+                unreachable!("VecEntryRollbackGuard defused more than once");
+            }
+        }
+    }
+}
+
+impl<T> Drop for VecEntryRollbackGuard<'_, T>
+where
+    T: ?Sized,
+{
+    fn drop(&mut self) {
+        match self.state {
+            GuardState::Armed => {
+                drop(self.vec.pop());
+            }
+            GuardState::Defused => {}
+        }
+    }
+}

--- a/src/rollback.rs
+++ b/src/rollback.rs
@@ -34,15 +34,8 @@ where
     }
 
     #[inline]
-    pub(crate) fn defuse(&mut self) {
-        match self.state {
-            GuardState::Armed => {
-                self.state = GuardState::Defused;
-            }
-            GuardState::Defused => {
-                unreachable!("VecEntryRollbackGuard defused more than once");
-            }
-        }
+    pub(crate) fn defuse(mut self) {
+        self.state = GuardState::Defused;
     }
 }
 
@@ -86,7 +79,7 @@ mod tests {
         let mut vec = Vec::new();
 
         {
-            let mut guard =
+            let guard =
                 VecEntryRollbackGuard::new(&mut vec, Interned::from(Cow::Borrowed("persist")));
 
             assert_eq!(guard.last().as_slice(), "persist");
@@ -97,14 +90,4 @@ mod tests {
         assert_eq!(vec[0].as_slice(), "persist");
     }
 
-    #[test]
-    #[should_panic(expected = "VecEntryRollbackGuard defused more than once")]
-    fn defusing_guard_twice_panics() {
-        let mut vec = Vec::new();
-        let mut guard =
-            VecEntryRollbackGuard::new(&mut vec, Interned::from(Cow::Borrowed("persist")));
-
-        guard.defuse();
-        guard.defuse();
-    }
 }

--- a/src/rollback.rs
+++ b/src/rollback.rs
@@ -59,3 +59,52 @@ where
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::borrow::Cow;
+
+    use super::VecEntryRollbackGuard;
+    use crate::internal::Interned;
+
+    #[test]
+    fn armed_guard_rolls_back_last_push() {
+        let mut vec = vec![Interned::from(Cow::Borrowed("existing"))];
+
+        {
+            let guard = VecEntryRollbackGuard::new(&mut vec, Interned::from(Cow::Borrowed("new")));
+
+            assert_eq!(guard.last().as_slice(), "new");
+        }
+
+        assert_eq!(vec.len(), 1);
+        assert_eq!(vec[0].as_slice(), "existing");
+    }
+
+    #[test]
+    fn defused_guard_keeps_pushed_value() {
+        let mut vec = Vec::new();
+
+        {
+            let mut guard =
+                VecEntryRollbackGuard::new(&mut vec, Interned::from(Cow::Borrowed("persist")));
+
+            assert_eq!(guard.last().as_slice(), "persist");
+            guard.defuse();
+        }
+
+        assert_eq!(vec.len(), 1);
+        assert_eq!(vec[0].as_slice(), "persist");
+    }
+
+    #[test]
+    #[should_panic(expected = "VecEntryRollbackGuard defused more than once")]
+    fn defusing_guard_twice_panics() {
+        let mut vec = Vec::new();
+        let mut guard =
+            VecEntryRollbackGuard::new(&mut vec, Interned::from(Cow::Borrowed("persist")));
+
+        guard.defuse();
+        guard.defuse();
+    }
+}

--- a/src/rollback.rs
+++ b/src/rollback.rs
@@ -89,5 +89,4 @@ mod tests {
         assert_eq!(vec.len(), 1);
         assert_eq!(vec[0].as_slice(), "persist");
     }
-
 }

--- a/src/str.rs
+++ b/src/str.rs
@@ -12,7 +12,7 @@ use std::collections::{
     hash_map::{HashMap, RandomState},
 };
 
-use crate::internal::Interned;
+use crate::internal::{Interned, VecEntryRollbackGuard};
 use crate::{DEFAULT_SYMBOL_TABLE_CAPACITY, Symbol, SymbolOverflowError};
 
 /// An iterator over all [`Symbol`]s in a [`SymbolTable`].
@@ -665,35 +665,40 @@ where
         let name = Interned::from(contents);
         let id = Symbol::try_from(self.map.len())?;
 
-        // Move the `Interned` into the `Vec`, causing it to be retagged under
-        // stacked borrows, before taking any references to its inner `T`.
-        self.vec.push(name);
-        // Ensure we grow the map before we take any shared references to the
-        // inner `T`.
-        self.map.reserve(1);
+        let slice = {
+            // Move the `Interned` into the `Vec`, causing it to be retagged
+            // under stacked borrows, before taking any references to its inner
+            // `T`. If anything after this push panics, roll back the `Vec`
+            // mutation so the symbol table remains internally consistent.
+            let mut name = VecEntryRollbackGuard::new(&mut self.vec, name);
+            // Ensure we grow the map before we take any shared references to
+            // the inner `T`.
+            self.map.reserve(1);
 
-        // SAFETY: `self.vec` is non-empty because the preceding line of code
-        // pushed an entry into it.
-        let name = unsafe { self.vec.last().unwrap_unchecked() };
+            // SAFETY: This expression creates a reference with a `'static`
+            // lifetime from an owned and interned buffer, which is permissible
+            // because:
+            //
+            // - `Interned` is an internal implementation detail of
+            //   `SymbolTable`.
+            // - `SymbolTable` never gives out `'static` references to
+            //   underlying contents.
+            // - All slice references given out by the `SymbolTable` have the
+            //   same lifetime as the `SymbolTable`.
+            // - The `map` field of `SymbolTable`, which contains the `'static`
+            //   references, is dropped before the owned buffers stored in this
+            //   `Interned`.
+            // - The shared reference may be derived from a `PinBox` which
+            //   prevents moves from retagging the underlying boxed `T` under
+            //   stacked borrows.
+            // - The symbol table cannot grow, shrink, or otherwise move its
+            //   contents while this reference is alive.
+            let slice = unsafe { name.last().as_static_slice() };
 
-        // SAFETY: This expression creates a reference with a `'static` lifetime
-        // from an owned and interned buffer, which is permissible because:
-        //
-        // - `Interned` is an internal implementation detail of `SymbolTable`.
-        // - `SymbolTable` never gives out `'static` references to underlying
-        //   contents.
-        // - All slice references given out by the `SymbolTable` have the same
-        //   lifetime as the `SymbolTable`.
-        // - The `map` field of `SymbolTable`, which contains the `'static`
-        //   references, is dropped before the owned buffers stored in this
-        //   `Interned`.
-        // - The shared reference may be derived from a `PinBox` which prevents
-        //   moves from retagging the underlying boxed `T` under stacked borrows.
-        // - The symbol table cannot grow, shrink, or otherwise move its contents
-        //   while this reference is alive.
-        let slice = unsafe { name.as_static_slice() };
-
-        self.map.insert(slice, id);
+            self.map.insert(slice, id);
+            name.disarm();
+            slice
+        };
 
         debug_assert_eq!(self.get(id), Some(slice));
         debug_assert_eq!(self.intern(slice), Ok(id));

--- a/src/str.rs
+++ b/src/str.rs
@@ -12,7 +12,8 @@ use std::collections::{
     hash_map::{HashMap, RandomState},
 };
 
-use crate::internal::{Interned, VecEntryRollbackGuard};
+use crate::internal::Interned;
+use crate::rollback::VecEntryRollbackGuard;
 use crate::{DEFAULT_SYMBOL_TABLE_CAPACITY, Symbol, SymbolOverflowError};
 
 /// An iterator over all [`Symbol`]s in a [`SymbolTable`].
@@ -696,7 +697,7 @@ where
             let slice = unsafe { name.last().as_static_slice() };
 
             self.map.insert(slice, id);
-            name.disarm();
+            name.defuse();
             slice
         };
 

--- a/src/str.rs
+++ b/src/str.rs
@@ -671,7 +671,7 @@ where
             // under stacked borrows, before taking any references to its inner
             // `T`. If anything after this push panics, roll back the `Vec`
             // mutation so the symbol table remains internally consistent.
-            let mut guard = VecEntryRollbackGuard::new(&mut self.vec, name);
+            let guard = VecEntryRollbackGuard::new(&mut self.vec, name);
             // Ensure we grow the map before we take any shared references to
             // the inner `T`.
             self.map.reserve(1);

--- a/src/str.rs
+++ b/src/str.rs
@@ -671,7 +671,7 @@ where
             // under stacked borrows, before taking any references to its inner
             // `T`. If anything after this push panics, roll back the `Vec`
             // mutation so the symbol table remains internally consistent.
-            let mut name = VecEntryRollbackGuard::new(&mut self.vec, name);
+            let mut guard = VecEntryRollbackGuard::new(&mut self.vec, name);
             // Ensure we grow the map before we take any shared references to
             // the inner `T`.
             self.map.reserve(1);
@@ -694,10 +694,10 @@ where
             //   stacked borrows.
             // - The symbol table cannot grow, shrink, or otherwise move its
             //   contents while this reference is alive.
-            let slice = unsafe { name.last().as_static_slice() };
+            let slice = unsafe { guard.last().as_static_slice() };
 
             self.map.insert(slice, id);
-            name.defuse();
+            guard.defuse();
             slice
         };
 

--- a/tests/unwind_safety.rs
+++ b/tests/unwind_safety.rs
@@ -1,8 +1,10 @@
 #[cfg(feature = "cstr")]
 use std::ffi::CStr;
+#[cfg(feature = "osstr")]
 use std::ffi::OsStr;
 use std::hash::{BuildHasher, Hasher};
 use std::panic::{AssertUnwindSafe, catch_unwind};
+#[cfg(feature = "path")]
 use std::path::Path;
 use std::sync::{
     Arc,

--- a/tests/unwind_safety.rs
+++ b/tests/unwind_safety.rs
@@ -1,6 +1,6 @@
-use std::ffi::OsStr;
 #[cfg(feature = "cstr")]
 use std::ffi::CStr;
+use std::ffi::OsStr;
 use std::hash::{BuildHasher, Hasher};
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::path::Path;
@@ -107,8 +107,7 @@ fn cstr_symbol_table_rolls_back_after_hasher_panic() {
 fn osstr_symbol_table_rolls_back_after_hasher_panic() {
     let mut table = intaglio::osstr::SymbolTable::with_hasher(panic_build_hasher());
 
-    let result =
-        catch_unwind(AssertUnwindSafe(|| table.intern(OsStr::new("attacker"))));
+    let result = catch_unwind(AssertUnwindSafe(|| table.intern(OsStr::new("attacker"))));
 
     assert!(result.is_err());
     assert_eq!(table.len(), 0);

--- a/tests/unwind_safety.rs
+++ b/tests/unwind_safety.rs
@@ -1,0 +1,138 @@
+use std::ffi::OsStr;
+#[cfg(feature = "cstr")]
+use std::ffi::CStr;
+use std::hash::{BuildHasher, Hasher};
+use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::path::Path;
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
+
+use intaglio::{Symbol, SymbolTable};
+
+#[derive(Clone, Debug)]
+struct PanicBuildHasher {
+    builds: Arc<AtomicUsize>,
+}
+
+impl BuildHasher for PanicBuildHasher {
+    type Hasher = PanicHasher;
+
+    fn build_hasher(&self) -> Self::Hasher {
+        let build = self.builds.fetch_add(1, Ordering::SeqCst) + 1;
+        PanicHasher { build, hash: 0 }
+    }
+}
+
+#[derive(Debug)]
+struct PanicHasher {
+    build: usize,
+    hash: u64,
+}
+
+impl Hasher for PanicHasher {
+    fn finish(&self) -> u64 {
+        self.hash
+    }
+
+    fn write(&mut self, bytes: &[u8]) {
+        if self.build == 1 {
+            panic!("panic during first HashMap::insert hashing");
+        }
+        for byte in bytes {
+            self.hash = self.hash.wrapping_mul(131).wrapping_add(u64::from(*byte));
+        }
+    }
+}
+
+fn panic_build_hasher() -> PanicBuildHasher {
+    PanicBuildHasher {
+        builds: Arc::new(AtomicUsize::new(0)),
+    }
+}
+
+#[test]
+fn str_symbol_table_rolls_back_after_hasher_panic() {
+    let mut table = SymbolTable::with_hasher(panic_build_hasher());
+
+    let result = catch_unwind(AssertUnwindSafe(|| table.intern("attacker")));
+
+    assert!(result.is_err());
+    assert_eq!(table.len(), 0);
+    assert_eq!(table.check_interned("attacker"), None);
+
+    let sym = table.intern("victim").unwrap();
+    assert_eq!(sym, Symbol::new(0));
+    assert_eq!(table.get(sym), Some("victim"));
+    assert_eq!(table.check_interned("victim"), Some(sym));
+}
+
+#[cfg(feature = "bytes")]
+#[test]
+fn bytes_symbol_table_rolls_back_after_hasher_panic() {
+    let mut table = intaglio::bytes::SymbolTable::with_hasher(panic_build_hasher());
+
+    let result = catch_unwind(AssertUnwindSafe(|| table.intern(&b"attacker"[..])));
+
+    assert!(result.is_err());
+    assert_eq!(table.len(), 0);
+    assert_eq!(table.check_interned(&b"attacker"[..]), None);
+
+    let sym = table.intern(&b"victim"[..]).unwrap();
+    assert_eq!(sym, Symbol::new(0));
+    assert_eq!(table.get(sym), Some(&b"victim"[..]));
+    assert_eq!(table.check_interned(&b"victim"[..]), Some(sym));
+}
+
+#[cfg(feature = "cstr")]
+#[test]
+fn cstr_symbol_table_rolls_back_after_hasher_panic() {
+    let mut table = intaglio::cstr::SymbolTable::with_hasher(panic_build_hasher());
+
+    let result = catch_unwind(AssertUnwindSafe(|| table.intern(c"attacker")));
+
+    assert!(result.is_err());
+    assert_eq!(table.len(), 0);
+    assert_eq!(table.check_interned(c"attacker"), None);
+
+    let sym = table.intern(c"victim").unwrap();
+    assert_eq!(sym, Symbol::new(0));
+    assert_eq!(table.get(sym), Some::<&CStr>(c"victim"));
+    assert_eq!(table.check_interned(c"victim"), Some(sym));
+}
+
+#[cfg(feature = "osstr")]
+#[test]
+fn osstr_symbol_table_rolls_back_after_hasher_panic() {
+    let mut table = intaglio::osstr::SymbolTable::with_hasher(panic_build_hasher());
+
+    let result =
+        catch_unwind(AssertUnwindSafe(|| table.intern(OsStr::new("attacker"))));
+
+    assert!(result.is_err());
+    assert_eq!(table.len(), 0);
+    assert_eq!(table.check_interned(OsStr::new("attacker")), None);
+
+    let sym = table.intern(OsStr::new("victim")).unwrap();
+    assert_eq!(sym, Symbol::new(0));
+    assert_eq!(table.get(sym), Some(OsStr::new("victim")));
+    assert_eq!(table.check_interned(OsStr::new("victim")), Some(sym));
+}
+
+#[cfg(feature = "path")]
+#[test]
+fn path_symbol_table_rolls_back_after_hasher_panic() {
+    let mut table = intaglio::path::SymbolTable::with_hasher(panic_build_hasher());
+
+    let result = catch_unwind(AssertUnwindSafe(|| table.intern(Path::new("attacker"))));
+
+    assert!(result.is_err());
+    assert_eq!(table.len(), 0);
+    assert_eq!(table.check_interned(Path::new("attacker")), None);
+
+    let sym = table.intern(Path::new("victim")).unwrap();
+    assert_eq!(sym, Symbol::new(0));
+    assert_eq!(table.get(sym), Some(Path::new("victim")));
+    assert_eq!(table.check_interned(Path::new("victim")), Some(sym));
+}


### PR DESCRIPTION
Closes #359.

## What Changed

This PR makes `intern` transactional across panic boundaries for all five symbol table variants.

- add integration coverage for unwind safety across `str`, `bytes`, `cstr`, `osstr`, and `path`
- introduce `VecEntryRollbackGuard` to roll back the backing `Vec` if unwinding happens after `vec.push(...)` but before the corresponding `map.insert(...)` succeeds
- update each `intern` implementation to disarm the rollback guard only after the `HashMap` mutation succeeds

## Why

The previous write ordering let a panic-capable custom `BuildHasher` unwind after `self.vec.push(name)` but before `self.map.insert(slice, id)` completed. After `catch_unwind`, the table could be left with `vec.len() != map.len()`, which broke symbol stability.

In a release-mode reproducer, I was able to prove symbol confusion:

- `intern("attacker")` panicked during the first `HashMap::insert`
- after recovery, `len()` was `1` but `check_interned("attacker")` was `None`
- `intern("victim")` returned `Symbol(0)`
- `get(Symbol(0))` returned `"attacker"`

In debug builds, I was able to reproduce panics via the existing `debug_assert_eq!` checks after the table had already been left inconsistent. I did not reproduce a hard crash or abort.

## Impact

This is an integrity fix. The bug did not give me a proof of memory unsafety with the default configuration, but it did let a caller that used a panic-capable custom hasher and recovered with `catch_unwind` create a table where a newly interned symbol resolved to attacker-controlled prior contents.

## Validation

- `cargo test`
- `cargo test --release --test unwind_safety`

## Notes

The branch intentionally contains two commits:

- `Add unwind safety regression tests`
- `Rollback intern entries on unwind`

The first commit demonstrates the bug as failing integration tests on the old implementation; the second fixes it.
