### PR TITLE
Remove superfluous Rust toolchain actions

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -35,7 +35,9 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        run: rustup toolchain install stable --profile minimal
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
 
       - name: Generate Cargo.lock
         run: |

--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -35,9 +35,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
-        with:
-          toolchain: stable
+        run: rustup toolchain install stable --profile minimal
 
       - name: Generate Cargo.lock
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,9 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        run: rustup toolchain install stable --profile minimal
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
 
       - name: Compile
         run: cargo build --verbose
@@ -79,7 +81,9 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        run: rustup toolchain install stable --profile minimal --target "$CI_TARGET_TRIPLE"
+        run: |
+          rustup toolchain install stable --profile minimal --target "$CI_TARGET_TRIPLE"
+          rustup default stable
         shell: bash
 
       - name: Install 32-bit platform support
@@ -120,7 +124,9 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        run: rustup toolchain install 1.85.0 --profile minimal
+        run: |
+          rustup toolchain install 1.85.0 --profile minimal
+          rustup default 1.85.0
 
       - name: Compile
         run: cargo build --verbose
@@ -159,7 +165,9 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        run: rustup toolchain install nightly --profile minimal --target "$CI_TARGET_TRIPLE"
+        run: |
+          rustup toolchain install nightly --profile minimal --target "$CI_TARGET_TRIPLE"
+          rustup default nightly
         shell: bash
 
       - name: Test with leak sanitizer and all features
@@ -183,10 +191,14 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        run: rustup toolchain install nightly --profile minimal --component rustfmt
+        run: |
+          rustup toolchain install nightly --profile minimal --component rustfmt
+          rustup default nightly
 
       - name: Install Rust toolchain
-        run: rustup toolchain install stable --profile minimal --component clippy
+        run: |
+          rustup toolchain install stable --profile minimal --component clippy
+          rustup default stable
 
       - name: Check formatting
         run: cargo +nightly fmt --check

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,9 +39,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
-        with:
-          toolchain: stable
+        run: rustup toolchain install stable --profile minimal
 
       - name: Compile
         run: cargo build --verbose
@@ -81,10 +79,8 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
-        with:
-          toolchain: stable
-          target: ${{ matrix.target }}
+        run: rustup toolchain install stable --profile minimal --target "$CI_TARGET_TRIPLE"
+        shell: bash
 
       - name: Install 32-bit platform support
         if: matrix.os == 'ubuntu-latest'
@@ -124,9 +120,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
-        with:
-          toolchain: "1.85.0"
+        run: rustup toolchain install 1.85.0 --profile minimal
 
       - name: Compile
         run: cargo build --verbose
@@ -165,10 +159,8 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
-        with:
-          toolchain: nightly
-          target: ${{ matrix.target }}
+        run: rustup toolchain install nightly --profile minimal --target "$CI_TARGET_TRIPLE"
+        shell: bash
 
       - name: Test with leak sanitizer and all features
         # LeakSanitzier is broken: https://github.com/rust-lang/rust/issues/111073
@@ -191,16 +183,10 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
-        with:
-          components: rustfmt
-          toolchain: nightly
+        run: rustup toolchain install nightly --profile minimal --component rustfmt
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
-        with:
-          components: clippy
-          toolchain: stable
+        run: rustup toolchain install stable --profile minimal --component clippy
 
       - name: Check formatting
         run: cargo +nightly fmt --check

--- a/.github/workflows/code-coverage.yaml
+++ b/.github/workflows/code-coverage.yaml
@@ -30,10 +30,7 @@ jobs:
           persist-credentials: false
 
       - name: Install nightly Rust toolchain
-        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
-        with:
-          toolchain: nightly
-          components: llvm-tools-preview
+        run: rustup toolchain install nightly --profile minimal --component llvm-tools-preview
 
       - name: Setup grcov
         env:

--- a/.github/workflows/code-coverage.yaml
+++ b/.github/workflows/code-coverage.yaml
@@ -30,7 +30,9 @@ jobs:
           persist-credentials: false
 
       - name: Install nightly Rust toolchain
-        run: rustup toolchain install nightly --profile minimal --component llvm-tools-preview
+        run: |
+          rustup toolchain install nightly --profile minimal --component llvm-tools-preview
+          rustup default nightly
 
       - name: Setup grcov
         env:

--- a/.github/workflows/miri.yaml
+++ b/.github/workflows/miri.yaml
@@ -29,10 +29,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
-        with:
-          components: miri,rust-src
-          toolchain: nightly
+        run: rustup toolchain install nightly --profile minimal --component miri --component rust-src
 
       - name: Miri setup
         run: cargo miri setup

--- a/.github/workflows/miri.yaml
+++ b/.github/workflows/miri.yaml
@@ -29,7 +29,9 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        run: rustup toolchain install nightly --profile minimal --component miri --component rust-src
+        run: |
+          rustup toolchain install nightly --profile minimal --component miri --component rust-src
+          rustup default nightly
 
       - name: Miri setup
         run: cargo miri setup

--- a/.github/workflows/rustdoc.yaml
+++ b/.github/workflows/rustdoc.yaml
@@ -40,7 +40,9 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        run: rustup toolchain install nightly --profile minimal
+        run: |
+          rustup toolchain install nightly --profile minimal
+          rustup default nightly
 
       - name: Check docs with no default features
         run: cargo doc --workspace --no-default-features

--- a/.github/workflows/rustdoc.yaml
+++ b/.github/workflows/rustdoc.yaml
@@ -40,9 +40,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
-        with:
-          toolchain: nightly
+        run: rustup toolchain install nightly --profile minimal
 
       - name: Check docs with no default features
         run: cargo doc --workspace --no-default-features

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,11 @@ interesting and leave a comment that you're beginning to investigate. If there
 is no issue, please file one before beginning to work on a PR. [Good first
 issues are labeled `E-easy`].
 
+Maintenance of this repository is Codex-first. Prefer asking Codex to prepare
+routine code, documentation, CI, and dependency changes. Contributors should
+focus on issue selection, review, release decisions, and validating that the
+resulting diff and CI status match the intended change.
+
 ## Setup
 
 Intaglio includes Rust and Text sources. Developing on Intaglio requires
@@ -149,6 +154,16 @@ cargo test drop
 ```
 
 Tests are run for every PR. All builds must pass before merging a PR.
+
+## Codex Maintenance Workflow
+
+Prefer asking Codex to prepare changes on a branch, including any docs and CI
+updates needed for the patch. Review the resulting diff as authored code:
+
+- Confirm the change is scoped to the issue or maintenance task.
+- Confirm generated or mechanical changes are intentional.
+- Confirm CI passes before merging.
+- Ask Codex to follow up on review comments or failed checks.
 
 ## Updating Dependencies
 


### PR DESCRIPTION
## Summary

- replace `dtolnay/rust-toolchain` workflow steps with direct `rustup toolchain install` commands
- preserve each workflow job’s requested toolchain, target, and component setup
- document that Intaglio maintenance is Codex-first, matching the known-folders-rs contributor guidance

## Security

This addresses the open `zizmor/superfluous-actions` code-scanning findings on GitHub by removing the action wrapper that duplicates runner-provided `rustup` functionality.

## Validation

- `mise exec -- npm run fmt`
- `mise exec -- uv run yamllint --strict .`
- `/Users/lopopolo/.local/share/mise/installs/zizmor/1.23.1/zizmor --persona pedantic .`