### PR TITLE
Prepare 1.14.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "intaglio"
-version = "1.13.3" # remember to set `html_root_url` in `src/lib.rs`.
+version = "1.14.0" # remember to set `html_root_url` in `src/lib.rs`.
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "Apache-2.0 OR MIT"
 edition = "2024"

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-intaglio = "1.13.3"
+intaglio = "1.14.0"
 ```
 
 Then intern UTF-8 strings like:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,7 @@
 //! [`&Path`]: std::path::Path
 //! [`&'static Path`]: std::path::Path
 
-#![doc(html_root_url = "https://docs.rs/intaglio/1.13.3")]
+#![doc(html_root_url = "https://docs.rs/intaglio/1.14.0")]
 
 use core::fmt;
 use core::num::TryFromIntError;


### PR DESCRIPTION
Bump crate version for the next minor release.

- Update `Cargo.toml` version to `1.14.0`.
- Update `src/lib.rs` `html_root_url`.
- Update README dependency snippet.

Follow-up: publish via the existing release workflow once merged.