### PR TITLE
Expose additional SymbolTable container APIs

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -409,6 +409,21 @@ impl<S> SymbolTable<S> {
         }
     }
 
+    /// Returns a reference to the symbol table's [`BuildHasher`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::collections::hash_map::RandomState;
+    /// # use intaglio::bytes::SymbolTable;
+    /// let hash_builder = RandomState::new();
+    /// let table = SymbolTable::with_hasher(hash_builder);
+    /// let _: &RandomState = table.hasher();
+    /// ```
+    pub fn hasher(&self) -> &S {
+        self.map.hasher()
+    }
+
     /// Returns the number of byte strings the table can hold without
     /// reallocating.
     ///
@@ -464,6 +479,29 @@ impl<S> SymbolTable<S> {
     /// ```
     pub fn is_empty(&self) -> bool {
         self.vec.is_empty()
+    }
+
+    /// Clears the symbol table, removing all interned byte strings.
+    ///
+    /// Keeps the allocated memory for reuse.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use intaglio::bytes::SymbolTable;
+    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut table = SymbolTable::new();
+    /// table.intern(b"abc")?;
+    /// table.clear();
+    /// assert!(table.is_empty());
+    /// assert!(!table.is_interned(b"abc"));
+    /// # Ok(())
+    /// # }
+    /// # example().unwrap();
+    /// ```
+    pub fn clear(&mut self) {
+        self.map.clear();
+        self.vec.clear();
     }
 
     /// Returns `true` if the symbol table contains the given symbol.
@@ -792,6 +830,33 @@ where
     #[must_use]
     pub fn check_interned(&self, contents: &[u8]) -> Option<Symbol> {
         self.map.get(contents).copied()
+    }
+
+    /// Returns the `Symbol` identifier and interned byte string for `contents`
+    /// if it has been interned before, `None` otherwise.
+    ///
+    /// This method does not modify the symbol table. The returned byte string
+    /// has the same lifetime as the symbol table.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use intaglio::bytes::SymbolTable;
+    /// # use intaglio::Symbol;
+    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut table = SymbolTable::new();
+    /// assert_eq!(None, table.get_interned(b"abc"));
+    ///
+    /// table.intern(b"abc".to_vec())?;
+    /// assert_eq!(Some((Symbol::new(0), &b"abc"[..])), table.get_interned(b"abc"));
+    /// # Ok(())
+    /// # }
+    /// # example().unwrap();
+    /// ```
+    #[must_use]
+    pub fn get_interned(&self, contents: &[u8]) -> Option<(Symbol, &[u8])> {
+        let (&slice, &id) = self.map.get_key_value(contents)?;
+        Some((id, slice))
     }
 
     /// Returns `true` if the given byte string has been interned before.

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -54,7 +54,7 @@ use core::hash::BuildHasher;
 use core::iter::{FromIterator, FusedIterator, Zip};
 use core::marker::PhantomData;
 use core::mem::ManuallyDrop;
-use core::ops::Range;
+use core::ops::{Index, Range};
 use core::slice;
 use std::borrow::Cow;
 use std::collections::{
@@ -278,6 +278,32 @@ impl<'a, S> IntoIterator for &'a SymbolTable<S> {
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
+    }
+}
+
+impl<S> Index<Symbol> for SymbolTable<S> {
+    type Output = [u8];
+
+    /// Returns a reference to the byte string associated with the given symbol.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the given symbol does not exist in the symbol table.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use intaglio::bytes::SymbolTable;
+    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut table = SymbolTable::new();
+    /// let sym = table.intern(b"abc")?;
+    /// assert_eq!(b"abc", &table[sym]);
+    /// # Ok(())
+    /// # }
+    /// # example().unwrap();
+    /// ```
+    fn index(&self, index: Symbol) -> &Self::Output {
+        self.get(index).expect("no entry found for symbol")
     }
 }
 

--- a/src/cstr.rs
+++ b/src/cstr.rs
@@ -58,7 +58,7 @@ use core::hash::BuildHasher;
 use core::iter::{FromIterator, FusedIterator, Zip};
 use core::marker::PhantomData;
 use core::mem::ManuallyDrop;
-use core::ops::Range;
+use core::ops::{Index, Range};
 use core::slice;
 use std::borrow::Cow;
 use std::collections::{
@@ -284,6 +284,32 @@ impl<'a, S> IntoIterator for &'a SymbolTable<S> {
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
+    }
+}
+
+impl<S> Index<Symbol> for SymbolTable<S> {
+    type Output = CStr;
+
+    /// Returns a reference to the C string associated with the given symbol.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the given symbol does not exist in the symbol table.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use intaglio::cstr::SymbolTable;
+    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut table = SymbolTable::new();
+    /// let sym = table.intern(c"abc")?;
+    /// assert_eq!(c"abc", &table[sym]);
+    /// # Ok(())
+    /// # }
+    /// # example().unwrap();
+    /// ```
+    fn index(&self, index: Symbol) -> &Self::Output {
+        self.get(index).expect("no entry found for symbol")
     }
 }
 

--- a/src/cstr.rs
+++ b/src/cstr.rs
@@ -419,6 +419,21 @@ impl<S> SymbolTable<S> {
         }
     }
 
+    /// Returns a reference to the symbol table's [`BuildHasher`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::collections::hash_map::RandomState;
+    /// # use intaglio::cstr::SymbolTable;
+    /// let hash_builder = RandomState::new();
+    /// let table = SymbolTable::with_hasher(hash_builder);
+    /// let _: &RandomState = table.hasher();
+    /// ```
+    pub fn hasher(&self) -> &S {
+        self.map.hasher()
+    }
+
     /// Returns the number of C strings the table can hold without reallocating.
     ///
     /// # Examples
@@ -475,6 +490,29 @@ impl<S> SymbolTable<S> {
     /// ```
     pub fn is_empty(&self) -> bool {
         self.vec.is_empty()
+    }
+
+    /// Clears the symbol table, removing all interned C strings.
+    ///
+    /// Keeps the allocated memory for reuse.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use intaglio::cstr::SymbolTable;
+    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut table = SymbolTable::new();
+    /// table.intern(c"abc")?;
+    /// table.clear();
+    /// assert!(table.is_empty());
+    /// assert!(!table.is_interned(c"abc"));
+    /// # Ok(())
+    /// # }
+    /// # example().unwrap();
+    /// ```
+    pub fn clear(&mut self) {
+        self.map.clear();
+        self.vec.clear();
     }
 
     /// Returns `true` if the symbol table contains the given symbol.
@@ -813,6 +851,33 @@ where
     #[must_use]
     pub fn check_interned(&self, contents: &CStr) -> Option<Symbol> {
         self.map.get(contents).copied()
+    }
+
+    /// Returns the `Symbol` identifier and interned C string for `contents` if
+    /// it has been interned before, `None` otherwise.
+    ///
+    /// This method does not modify the symbol table. The returned C string has
+    /// the same lifetime as the symbol table.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use intaglio::cstr::SymbolTable;
+    /// # use intaglio::Symbol;
+    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut table = SymbolTable::new();
+    /// assert_eq!(None, table.get_interned(c"abc"));
+    ///
+    /// table.intern(c"abc")?;
+    /// assert_eq!(Some((Symbol::new(0), c"abc")), table.get_interned(c"abc"));
+    /// # Ok(())
+    /// # }
+    /// # example().unwrap();
+    /// ```
+    #[must_use]
+    pub fn get_interned(&self, contents: &CStr) -> Option<(Symbol, &CStr)> {
+        let (&cstr, &id) = self.map.get_key_value(contents)?;
+        Some((id, cstr))
     }
 
     /// Returns `true` if the given C string has been interned before.

--- a/src/osstr.rs
+++ b/src/osstr.rs
@@ -59,7 +59,7 @@ use core::hash::BuildHasher;
 use core::iter::{FromIterator, FusedIterator, Zip};
 use core::marker::PhantomData;
 use core::mem::ManuallyDrop;
-use core::ops::Range;
+use core::ops::{Index, Range};
 use core::slice;
 use std::borrow::Cow;
 use std::collections::{
@@ -287,6 +287,33 @@ impl<'a, S> IntoIterator for &'a SymbolTable<S> {
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
+    }
+}
+
+impl<S> Index<Symbol> for SymbolTable<S> {
+    type Output = OsStr;
+
+    /// Returns a reference to the platform string associated with the given symbol.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the given symbol does not exist in the symbol table.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::ffi::OsStr;
+    /// # use intaglio::osstr::SymbolTable;
+    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut table = SymbolTable::new();
+    /// let sym = table.intern(OsStr::new("abc"))?;
+    /// assert_eq!(OsStr::new("abc"), &table[sym]);
+    /// # Ok(())
+    /// # }
+    /// # example().unwrap();
+    /// ```
+    fn index(&self, index: Symbol) -> &Self::Output {
+        self.get(index).expect("no entry found for symbol")
     }
 }
 

--- a/src/osstr.rs
+++ b/src/osstr.rs
@@ -422,6 +422,21 @@ impl<S> SymbolTable<S> {
         }
     }
 
+    /// Returns a reference to the symbol table's [`BuildHasher`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::collections::hash_map::RandomState;
+    /// # use intaglio::osstr::SymbolTable;
+    /// let hash_builder = RandomState::new();
+    /// let table = SymbolTable::with_hasher(hash_builder);
+    /// let _: &RandomState = table.hasher();
+    /// ```
+    pub fn hasher(&self) -> &S {
+        self.map.hasher()
+    }
+
     /// Returns the number of platform strings the table can hold without reallocating.
     ///
     /// # Examples
@@ -478,6 +493,30 @@ impl<S> SymbolTable<S> {
     /// ```
     pub fn is_empty(&self) -> bool {
         self.vec.is_empty()
+    }
+
+    /// Clears the symbol table, removing all interned platform strings.
+    ///
+    /// Keeps the allocated memory for reuse.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::ffi::OsStr;
+    /// # use intaglio::osstr::SymbolTable;
+    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut table = SymbolTable::new();
+    /// table.intern(OsStr::new("abc"))?;
+    /// table.clear();
+    /// assert!(table.is_empty());
+    /// assert!(!table.is_interned(OsStr::new("abc")));
+    /// # Ok(())
+    /// # }
+    /// # example().unwrap();
+    /// ```
+    pub fn clear(&mut self) {
+        self.map.clear();
+        self.vec.clear();
     }
 
     /// Returns `true` if the symbol table contains the given symbol.
@@ -816,6 +855,37 @@ where
     #[must_use]
     pub fn check_interned(&self, contents: &OsStr) -> Option<Symbol> {
         self.map.get(contents).copied()
+    }
+
+    /// Returns the `Symbol` identifier and interned platform string for
+    /// `contents` if it has been interned before, `None` otherwise.
+    ///
+    /// This method does not modify the symbol table. The returned platform
+    /// string has the same lifetime as the symbol table.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::ffi::{OsStr, OsString};
+    /// # use intaglio::osstr::SymbolTable;
+    /// # use intaglio::Symbol;
+    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut table = SymbolTable::new();
+    /// assert_eq!(None, table.get_interned(OsStr::new("abc")));
+    ///
+    /// table.intern(OsString::from("abc"))?;
+    /// assert_eq!(
+    ///     Some((Symbol::new(0), OsStr::new("abc"))),
+    ///     table.get_interned(OsStr::new("abc"))
+    /// );
+    /// # Ok(())
+    /// # }
+    /// # example().unwrap();
+    /// ```
+    #[must_use]
+    pub fn get_interned(&self, contents: &OsStr) -> Option<(Symbol, &OsStr)> {
+        let (&os_str, &id) = self.map.get_key_value(contents)?;
+        Some((id, os_str))
     }
 
     /// Returns `true` if the given platform string has been interned before.

--- a/src/path.rs
+++ b/src/path.rs
@@ -422,6 +422,21 @@ impl<S> SymbolTable<S> {
         }
     }
 
+    /// Returns a reference to the symbol table's [`BuildHasher`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::collections::hash_map::RandomState;
+    /// # use intaglio::path::SymbolTable;
+    /// let hash_builder = RandomState::new();
+    /// let table = SymbolTable::with_hasher(hash_builder);
+    /// let _: &RandomState = table.hasher();
+    /// ```
+    pub fn hasher(&self) -> &S {
+        self.map.hasher()
+    }
+
     /// Returns the number of path strings the table can hold without reallocating.
     ///
     /// # Examples
@@ -478,6 +493,30 @@ impl<S> SymbolTable<S> {
     /// ```
     pub fn is_empty(&self) -> bool {
         self.vec.is_empty()
+    }
+
+    /// Clears the symbol table, removing all interned path strings.
+    ///
+    /// Keeps the allocated memory for reuse.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::path::Path;
+    /// # use intaglio::path::SymbolTable;
+    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut table = SymbolTable::new();
+    /// table.intern(Path::new("abc"))?;
+    /// table.clear();
+    /// assert!(table.is_empty());
+    /// assert!(!table.is_interned(Path::new("abc")));
+    /// # Ok(())
+    /// # }
+    /// # example().unwrap();
+    /// ```
+    pub fn clear(&mut self) {
+        self.map.clear();
+        self.vec.clear();
     }
 
     /// Returns `true` if the symbol table contains the given symbol.
@@ -816,6 +855,37 @@ where
     #[must_use]
     pub fn check_interned(&self, contents: &Path) -> Option<Symbol> {
         self.map.get(contents).copied()
+    }
+
+    /// Returns the `Symbol` identifier and interned path string for `contents`
+    /// if it has been interned before, `None` otherwise.
+    ///
+    /// This method does not modify the symbol table. The returned path string
+    /// has the same lifetime as the symbol table.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::path::{Path, PathBuf};
+    /// # use intaglio::path::SymbolTable;
+    /// # use intaglio::Symbol;
+    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut table = SymbolTable::new();
+    /// assert_eq!(None, table.get_interned(Path::new("abc")));
+    ///
+    /// table.intern(PathBuf::from("abc"))?;
+    /// assert_eq!(
+    ///     Some((Symbol::new(0), Path::new("abc"))),
+    ///     table.get_interned(Path::new("abc"))
+    /// );
+    /// # Ok(())
+    /// # }
+    /// # example().unwrap();
+    /// ```
+    #[must_use]
+    pub fn get_interned(&self, contents: &Path) -> Option<(Symbol, &Path)> {
+        let (&path, &id) = self.map.get_key_value(contents)?;
+        Some((id, path))
     }
 
     /// Returns `true` if the given path string has been interned before.

--- a/src/path.rs
+++ b/src/path.rs
@@ -59,7 +59,7 @@ use core::hash::BuildHasher;
 use core::iter::{FromIterator, FusedIterator, Zip};
 use core::marker::PhantomData;
 use core::mem::ManuallyDrop;
-use core::ops::Range;
+use core::ops::{Index, Range};
 use core::slice;
 use std::borrow::Cow;
 use std::collections::{
@@ -287,6 +287,33 @@ impl<'a, S> IntoIterator for &'a SymbolTable<S> {
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
+    }
+}
+
+impl<S> Index<Symbol> for SymbolTable<S> {
+    type Output = Path;
+
+    /// Returns a reference to the path string associated with the given symbol.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the given symbol does not exist in the symbol table.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::path::Path;
+    /// # use intaglio::path::SymbolTable;
+    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut table = SymbolTable::new();
+    /// let sym = table.intern(Path::new("abc"))?;
+    /// assert_eq!(Path::new("abc"), &table[sym]);
+    /// # Ok(())
+    /// # }
+    /// # example().unwrap();
+    /// ```
+    fn index(&self, index: Symbol) -> &Self::Output {
+        self.get(index).expect("no entry found for symbol")
     }
 }
 

--- a/src/str.rs
+++ b/src/str.rs
@@ -354,6 +354,21 @@ impl<S> SymbolTable<S> {
         }
     }
 
+    /// Returns a reference to the symbol table's [`BuildHasher`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::collections::hash_map::RandomState;
+    /// # use intaglio::SymbolTable;
+    /// let hash_builder = RandomState::new();
+    /// let table = SymbolTable::with_hasher(hash_builder);
+    /// let _: &RandomState = table.hasher();
+    /// ```
+    pub fn hasher(&self) -> &S {
+        self.map.hasher()
+    }
+
     /// Returns the number of strings the table can hold without reallocating.
     ///
     /// # Examples
@@ -408,6 +423,29 @@ impl<S> SymbolTable<S> {
     /// ```
     pub fn is_empty(&self) -> bool {
         self.vec.is_empty()
+    }
+
+    /// Clears the symbol table, removing all interned strings.
+    ///
+    /// Keeps the allocated memory for reuse.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use intaglio::SymbolTable;
+    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut table = SymbolTable::new();
+    /// table.intern("abc")?;
+    /// table.clear();
+    /// assert!(table.is_empty());
+    /// assert!(!table.is_interned("abc"));
+    /// # Ok(())
+    /// # }
+    /// # example().unwrap();
+    /// ```
+    pub fn clear(&mut self) {
+        self.map.clear();
+        self.vec.clear();
     }
 
     /// Returns `true` if the symbol table contains the given symbol.
@@ -731,6 +769,32 @@ where
     #[must_use]
     pub fn check_interned(&self, contents: &str) -> Option<Symbol> {
         self.map.get(contents).copied()
+    }
+
+    /// Returns the `Symbol` identifier and interned string for `contents` if
+    /// it has been interned before, `None` otherwise.
+    ///
+    /// This method does not modify the symbol table. The returned string has
+    /// the same lifetime as the symbol table.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use intaglio::{Symbol, SymbolTable};
+    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut table = SymbolTable::new();
+    /// assert_eq!(None, table.get_interned("abc"));
+    ///
+    /// table.intern("abc".to_string())?;
+    /// assert_eq!(Some((Symbol::new(0), "abc")), table.get_interned("abc"));
+    /// # Ok(())
+    /// # }
+    /// # example().unwrap();
+    /// ```
+    #[must_use]
+    pub fn get_interned(&self, contents: &str) -> Option<(Symbol, &str)> {
+        let (&slice, &id) = self.map.get_key_value(contents)?;
+        Some((id, slice))
     }
 
     /// Returns `true` if the given string has been interned before.

--- a/src/str.rs
+++ b/src/str.rs
@@ -4,7 +4,7 @@ use core::hash::BuildHasher;
 use core::iter::{FromIterator, FusedIterator, Zip};
 use core::marker::PhantomData;
 use core::mem::ManuallyDrop;
-use core::ops::Range;
+use core::ops::{Index, Range};
 use core::slice;
 use std::borrow::Cow;
 use std::collections::{
@@ -224,6 +224,32 @@ impl<'a, S> IntoIterator for &'a SymbolTable<S> {
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
+    }
+}
+
+impl<S> Index<Symbol> for SymbolTable<S> {
+    type Output = str;
+
+    /// Returns a reference to the string associated with the given symbol.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the given symbol does not exist in the symbol table.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use intaglio::SymbolTable;
+    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut table = SymbolTable::new();
+    /// let sym = table.intern("abc")?;
+    /// assert_eq!("abc", &table[sym]);
+    /// # Ok(())
+    /// # }
+    /// # example().unwrap();
+    /// ```
+    fn index(&self, index: Symbol) -> &Self::Output {
+        self.get(index).expect("no entry found for symbol")
     }
 }
 


### PR DESCRIPTION
## Summary

- add `hasher` accessors mirroring `HashMap::hasher` for custom hash builders
- add `clear` across all symbol table variants, clearing lookup maps before backing storage
- add `get_interned` lookup APIs that return both the `Symbol` and canonical interned contents
- implement `Index<Symbol>` for panic-on-missing lookups, matching standard container indexing ergonomics

## Verification

- `cargo fmt --check`
- `cargo test`
- `cargo clippy --workspace --all-features --all-targets`

`npm run fmt` could not be run because `npm` is not available on PATH in this environment.
