### PR TITLE
chore: allow Apache license in cargo deny

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -3,6 +3,7 @@ ignore = []
 
 [licenses]
 allow = [
+  "Apache-2.0",
   "MIT",
 ]
 


### PR DESCRIPTION
## Summary

- Allow Apache-2.0 in cargo-deny's license allowlist.
- Keep the audit policy aligned with the crate's Apache-2.0 OR MIT metadata.

## Validation

- mise exec -- cargo deny check bans licenses sources
- git diff --check

## Release PR follow-up

Publication/release mechanics should stay in the later release PR, including crates.io publish, GitHub release notes, and any release announcement.