### PR TITLE
Add optional bstr symbol table

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ osstr = []
 path = []
 
 [dependencies]
-bstr = { version = "1.12.1", optional = true, default-features = false, features = ["alloc"] }
+bstr = { version = "1.0.0", optional = true, default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
 # Property testing for interner getters and setters.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,12 @@ categories = ["caching", "data-structures"]
 include = ["/src/**/*", "/tests/**/*", "/LICENSE-*", "/README.md"]
 
 [features]
-# All features are enabled by default.
+# All string table features except `bstr` are enabled by default.
 default = ["bytes", "cstr", "osstr", "path"]
+# `bstr` feature enables an additional symbol table implementation for
+# interning byte strings (`bstr::BString` and `&'static bstr::BStr`) from the
+# `bstr` crate. This feature is not enabled by default.
+bstr = ["dep:bstr"]
 # `bytes` feature enables an additional symbol table implementation for
 # interning byte strings (`Vec<u8>` and `&'static [u8]`).
 bytes = []
@@ -31,6 +35,7 @@ osstr = []
 path = []
 
 [dependencies]
+bstr = { version = "1.12.1", optional = true, default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
 # Property testing for interner getters and setters.

--- a/README.md
+++ b/README.md
@@ -140,8 +140,8 @@ LeakSanitizer.
 All string table features except **bstr** are enabled by default.
 
 - **bstr** - Enables an additional symbol table implementation for interning
-  bstr byte strings (`bstr::BString` and `&'static bstr::BStr`). This feature is
-  disabled by default.
+  [`bstr`] byte strings (`bstr::BString` and `&'static bstr::BStr`). This
+  feature is disabled by default.
 - **bytes** - Enables an additional symbol table implementation for interning
   byte strings (`Vec<u8>` and `&'static [u8]`).
 - **cstr** - Enables an additional symbol table implementation for interning C
@@ -167,3 +167,4 @@ releases.
 
 [symbol]: https://ruby-doc.org/core-3.1.2/Symbol.html
 [artichoke]: https://github.com/artichoke/artichoke
+[bstr]: https://crates.io/crates/bstr

--- a/README.md
+++ b/README.md
@@ -65,6 +65,22 @@ fn intern_and_get() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
+Or intern bstr byte strings like:
+
+```rust
+use bstr::{BStr, BString};
+
+fn intern_and_get() -> Result<(), Box<dyn std::error::Error>> {
+    let mut table = intaglio::bstr::SymbolTable::new();
+    let name: &'static BStr = BStr::new(b"abc");
+    let sym = table.intern(name)?;
+    let retrieved = table.get(sym);
+    assert_eq!(Some(name), retrieved);
+    assert_eq!(sym, table.intern(BString::from("abc"))?);
+    Ok(())
+}
+```
+
 Or intern C strings like:
 
 ```rust
@@ -121,8 +137,11 @@ LeakSanitizer.
 
 ## Crate features
 
-All features are enabled by default.
+All string table features except **bstr** are enabled by default.
 
+- **bstr** - Enables an additional symbol table implementation for interning
+  bstr byte strings (`bstr::BString` and `&'static bstr::BStr`). This feature is
+  disabled by default.
 - **bytes** - Enables an additional symbol table implementation for interning
   byte strings (`Vec<u8>` and `&'static [u8]`).
 - **cstr** - Enables an additional symbol table implementation for interning C

--- a/src/bstr.rs
+++ b/src/bstr.rs
@@ -56,7 +56,7 @@ use core::hash::BuildHasher;
 use core::iter::{FromIterator, FusedIterator, Zip};
 use core::marker::PhantomData;
 use core::mem::ManuallyDrop;
-use core::ops::Range;
+use core::ops::{Index, Range};
 use core::slice;
 use std::borrow::Cow;
 use std::collections::{
@@ -290,6 +290,33 @@ impl<'a, S> IntoIterator for &'a SymbolTable<S> {
     }
 }
 
+impl<S> Index<Symbol> for SymbolTable<S> {
+    type Output = BStr;
+
+    /// Returns a reference to the `BStr` byte string associated with the given symbol.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the given symbol does not exist in the symbol table.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use intaglio::bstr::SymbolTable;
+    /// # use bstr::BStr;
+    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut table = SymbolTable::new();
+    /// let sym = table.intern(BStr::new(b"abc"))?;
+    /// assert_eq!(BStr::new(b"abc"), &table[sym]);
+    /// # Ok(())
+    /// # }
+    /// # example().unwrap();
+    /// ```
+    fn index(&self, index: Symbol) -> &Self::Output {
+        self.get(index).expect("no entry found for symbol")
+    }
+}
+
 /// `BStr` byte string interner.
 ///
 /// This symbol table is implemented by storing bstr byte strings with a fast path for
@@ -428,6 +455,21 @@ impl<S> SymbolTable<S> {
         }
     }
 
+    /// Returns a reference to the symbol table's [`BuildHasher`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::collections::hash_map::RandomState;
+    /// # use intaglio::bstr::SymbolTable;
+    /// let hash_builder = RandomState::new();
+    /// let table = SymbolTable::with_hasher(hash_builder);
+    /// let _: &RandomState = table.hasher();
+    /// ```
+    pub fn hasher(&self) -> &S {
+        self.map.hasher()
+    }
+
     /// Returns the number of bstr byte strings the table can hold without
     /// reallocating.
     ///
@@ -489,6 +531,30 @@ impl<S> SymbolTable<S> {
     /// ```
     pub fn is_empty(&self) -> bool {
         self.vec.is_empty()
+    }
+
+    /// Clears the symbol table, removing all interned bstr byte strings.
+    ///
+    /// Keeps the allocated memory for reuse.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use intaglio::bstr::SymbolTable;
+    /// # use bstr::BStr;
+    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut table = SymbolTable::new();
+    /// table.intern(BStr::new(b"abc"))?;
+    /// table.clear();
+    /// assert!(table.is_empty());
+    /// assert!(!table.is_interned(BStr::new(b"abc")));
+    /// # Ok(())
+    /// # }
+    /// # example().unwrap();
+    /// ```
+    pub fn clear(&mut self) {
+        self.map.clear();
+        self.vec.clear();
     }
 
     /// Returns `true` if the symbol table contains the given symbol.
@@ -837,6 +903,37 @@ where
     #[must_use]
     pub fn check_interned(&self, contents: &BStr) -> Option<Symbol> {
         self.map.get(contents).copied()
+    }
+
+    /// Returns the `Symbol` identifier and interned `BStr` byte string for
+    /// `contents` if it has been interned before, `None` otherwise.
+    ///
+    /// This method does not modify the symbol table. The returned byte string
+    /// has the same lifetime as the symbol table.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use intaglio::bstr::SymbolTable;
+    /// # use bstr::{BStr, BString};
+    /// # use intaglio::Symbol;
+    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut table = SymbolTable::new();
+    /// assert_eq!(None, table.get_interned(BStr::new(b"abc")));
+    ///
+    /// table.intern(BString::from("abc"))?;
+    /// assert_eq!(
+    ///     Some((Symbol::new(0), BStr::new(b"abc"))),
+    ///     table.get_interned(BStr::new(b"abc"))
+    /// );
+    /// # Ok(())
+    /// # }
+    /// # example().unwrap();
+    /// ```
+    #[must_use]
+    pub fn get_interned(&self, contents: &BStr) -> Option<(Symbol, &BStr)> {
+        let (&slice, &id) = self.map.get_key_value(contents)?;
+        Some((id, slice))
     }
 
     /// Returns `true` if the given `BStr` byte string has been interned before.

--- a/src/bstr.rs
+++ b/src/bstr.rs
@@ -1,0 +1,1115 @@
+//! Intern bstr byte strings.
+//!
+//! This module provides a nearly identical API to the one found in the
+//! top-level of this crate. There is one important difference:
+//!
+//! 1. Interned contents are `&BStr` instead of `&str`. Additionally, `BString`
+//!    is used where `String` would have been used.
+//!
+//! # Example: intern `BStr` byte string
+//!
+//! ```
+//! # use intaglio::bstr::SymbolTable;
+//! # use bstr::{BStr, BString};
+//! # fn example() -> Result<(), Box<dyn std::error::Error>> {
+//! let mut table = SymbolTable::new();
+//! let sym = table.intern(BStr::new(b"abc"))?;
+//! assert_eq!(sym, table.intern(BString::from("abc"))?);
+//! assert_eq!(Some(BStr::new(b"abc")), table.get(sym));
+//! # Ok(())
+//! # }
+//! # example().unwrap();
+//! ```
+//!
+//! # Example: symbol iterators
+//!
+//! ```
+//! # use std::collections::HashMap;
+//! # use intaglio::bstr::SymbolTable;
+//! # use bstr::{BStr, BString};
+//! # use intaglio::Symbol;
+//! # fn example() -> Result<(), Box<dyn std::error::Error>> {
+//! let mut table = SymbolTable::new();
+//! let sym = table.intern(BStr::new(b"abc"))?;
+//! // Retrieve set of `Symbol`s.
+//! let all_symbols = table.all_symbols();
+//! assert_eq!(vec![sym], all_symbols.collect::<Vec<_>>());
+//!
+//! table.intern(BStr::new(b"xyz"))?;
+//! let mut map = HashMap::new();
+//! map.insert(Symbol::new(0), BStr::new(b"abc"));
+//! map.insert(Symbol::new(1), BStr::new(b"xyz"));
+//! // Retrieve symbol to BStr content mappings.
+//! let iter = table.iter();
+//! assert_eq!(map, iter.collect::<HashMap<_, _>>());
+//! # Ok(())
+//! # }
+//! # example().unwrap();
+//! ```
+//!
+//! # Performance
+//!
+//! In general, one should expect this crate's performance on `&BStr` to be
+//! roughly similar to performance on `&[u8]`.
+
+use core::hash::BuildHasher;
+use core::iter::{FromIterator, FusedIterator, Zip};
+use core::marker::PhantomData;
+use core::mem::ManuallyDrop;
+use core::ops::Range;
+use core::slice;
+use std::borrow::Cow;
+use std::collections::{
+    TryReserveError,
+    hash_map::{HashMap, RandomState},
+};
+
+use crate::internal::Interned;
+use crate::rollback::VecEntryRollbackGuard;
+use crate::{DEFAULT_SYMBOL_TABLE_CAPACITY, Symbol, SymbolOverflowError};
+use ::bstr::BStr;
+
+/// An iterator over all [`Symbol`]s in a [`SymbolTable`].
+///
+/// See the [`all_symbols`](SymbolTable::all_symbols) method in [`SymbolTable`].
+///
+/// # Usage
+///
+/// ```
+/// # use intaglio::bstr::SymbolTable;
+/// # use bstr::BStr;
+/// # use bstr::BString;
+/// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// let mut table = SymbolTable::new();
+/// let sym = table.intern(BStr::new(b"abc"))?;
+/// let all_symbols = table.all_symbols();
+/// assert_eq!(vec![sym], all_symbols.collect::<Vec<_>>());
+/// # Ok(())
+/// # }
+/// # example().unwrap();
+/// ```
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+#[cfg_attr(docsrs, doc(cfg(feature = "bstr")))]
+pub struct AllSymbols<'a> {
+    range: Range<usize>,
+    // Hold a shared reference to the underlying `SymbolTable` to ensure the
+    // table is not modified while we are iterating which would make the results
+    // not match the real state.
+    phantom: PhantomData<&'a SymbolTable>,
+}
+
+impl Iterator for AllSymbols<'_> {
+    type Item = Symbol;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let next = self.range.next()?;
+        debug_assert!(u32::try_from(next).is_ok());
+        Some((next as u32).into())
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.range.size_hint()
+    }
+
+    fn count(self) -> usize {
+        self.range.count()
+    }
+
+    fn last(self) -> Option<Self::Item> {
+        let last = self.range.last()?;
+        debug_assert!(u32::try_from(last).is_ok());
+        Some((last as u32).into())
+    }
+
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        let nth = self.range.nth(n)?;
+        debug_assert!(u32::try_from(nth).is_ok());
+        Some((nth as u32).into())
+    }
+
+    fn collect<B: FromIterator<Self::Item>>(self) -> B {
+        self.range.map(|sym| Symbol::from(sym as u32)).collect()
+    }
+}
+
+impl DoubleEndedIterator for AllSymbols<'_> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        let next = self.range.next_back()?;
+        debug_assert!(u32::try_from(next).is_ok());
+        Some((next as u32).into())
+    }
+
+    fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
+        let nth = self.range.nth_back(n)?;
+        debug_assert!(u32::try_from(nth).is_ok());
+        Some((nth as u32).into())
+    }
+}
+
+impl FusedIterator for AllSymbols<'_> {}
+
+/// An iterator over all interned bstr byte strings in a [`SymbolTable`].
+///
+/// See the [`bstrings`](SymbolTable::bstrings) method in [`SymbolTable`].
+///
+/// # Usage
+///
+/// ```
+/// # use intaglio::bstr::SymbolTable;
+/// # use bstr::BStr;
+/// # use bstr::BString;
+/// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// let mut table = SymbolTable::new();
+/// let sym = table.intern(BString::from("abc"))?;
+/// let bstrings = table.bstrings();
+/// assert_eq!(vec![BStr::new(b"abc")], bstrings.collect::<Vec<_>>());
+/// # Ok(())
+/// # }
+/// # example().unwrap();
+/// ```
+#[derive(Debug, Clone)]
+#[cfg_attr(docsrs, doc(cfg(feature = "bstr")))]
+pub struct BStrings<'a>(slice::Iter<'a, Interned<BStr>>);
+
+impl<'a> Iterator for BStrings<'a> {
+    type Item = &'a BStr;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(Interned::as_slice)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
+
+    fn count(self) -> usize {
+        self.0.count()
+    }
+
+    fn last(self) -> Option<Self::Item> {
+        self.0.last().map(Interned::as_slice)
+    }
+
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.0.nth(n).map(Interned::as_slice)
+    }
+
+    fn collect<B: FromIterator<Self::Item>>(self) -> B {
+        self.0.map(Interned::as_slice).collect()
+    }
+}
+
+impl DoubleEndedIterator for BStrings<'_> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.0.next_back().map(Interned::as_slice)
+    }
+
+    fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
+        self.0.nth_back(n).map(Interned::as_slice)
+    }
+
+    fn rfold<B, F>(self, accum: B, f: F) -> B
+    where
+        F: FnMut(B, Self::Item) -> B,
+    {
+        self.0.map(Interned::as_slice).rfold(accum, f)
+    }
+}
+
+impl ExactSizeIterator for BStrings<'_> {
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+impl FusedIterator for BStrings<'_> {}
+
+/// An iterator over all symbols and interned bstr byte strings in a [`SymbolTable`].
+///
+/// See the [`iter`](SymbolTable::iter) method in [`SymbolTable`].
+///
+/// # Usage
+///
+/// ```
+/// # use std::collections::HashMap;
+/// # use intaglio::bstr::SymbolTable;
+/// # use bstr::BStr;
+/// # use bstr::BString;
+/// # use intaglio::Symbol;
+/// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// let mut table = SymbolTable::new();
+/// let sym = table.intern(BString::from("abc"))?;
+/// let iter = table.iter();
+/// let mut map = HashMap::new();
+/// map.insert(Symbol::new(0), BStr::new(b"abc"));
+/// assert_eq!(map, iter.collect::<HashMap<_, _>>());
+/// # Ok(())
+/// # }
+/// # example().unwrap();
+/// ```
+#[derive(Debug, Clone)]
+#[cfg_attr(docsrs, doc(cfg(feature = "bstr")))]
+pub struct Iter<'a>(Zip<AllSymbols<'a>, BStrings<'a>>);
+
+impl<'a> Iterator for Iter<'a> {
+    type Item = (Symbol, &'a BStr);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
+
+    fn count(self) -> usize {
+        self.0.count()
+    }
+
+    fn last(self) -> Option<Self::Item> {
+        self.0.last()
+    }
+
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.0.nth(n)
+    }
+
+    fn collect<B: FromIterator<Self::Item>>(self) -> B {
+        self.0.collect()
+    }
+}
+
+impl FusedIterator for Iter<'_> {}
+
+impl<'a, S> IntoIterator for &'a SymbolTable<S> {
+    type Item = (Symbol, &'a BStr);
+    type IntoIter = Iter<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+/// `BStr` byte string interner.
+///
+/// This symbol table is implemented by storing bstr byte strings with a fast path for
+/// `&BStr` that are already `'static`.
+///
+/// See module documentation for more.
+///
+/// # Usage
+///
+/// ```
+/// # use intaglio::bstr::SymbolTable;
+/// # use bstr::BStr;
+/// # use bstr::BString;
+/// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// let mut table = SymbolTable::new();
+/// let sym = table.intern(BStr::new(b"abc"))?;
+/// assert_eq!(sym, table.intern(BString::from("abc"))?);
+/// assert!(table.contains(sym));
+/// assert!(table.is_interned(BStr::new(b"abc")));
+/// # Ok(())
+/// # }
+/// # example().unwrap();
+/// ```
+#[derive(Default, Debug)]
+#[cfg_attr(docsrs, doc(cfg(feature = "bstr")))]
+pub struct SymbolTable<S = RandomState> {
+    map: ManuallyDrop<HashMap<&'static BStr, Symbol, S>>,
+    vec: ManuallyDrop<Vec<Interned<BStr>>>,
+}
+
+impl<S> Drop for SymbolTable<S> {
+    fn drop(&mut self) {
+        // SAFETY: No mutable references to `SymbolTable` internal fields are
+        // given out, which means `ManuallyDrop::drop` can only be invoked in
+        // this `Drop::drop` impl. Interal fields are guaranteed to be
+        // initialized by `SymbolTable` constructors.
+        unsafe {
+            // `Interned` requires that the `'static` references it gives out
+            // are dropped before the owning buffer stored in the `Interned`.
+            ManuallyDrop::drop(&mut self.map);
+            ManuallyDrop::drop(&mut self.vec);
+        }
+    }
+}
+
+impl SymbolTable<RandomState> {
+    /// Constructs a new, empty `SymbolTable` with [default capacity].
+    ///
+    /// This function will always allocate. To construct a symbol table without
+    /// allocating, call [`SymbolTable::with_capacity(0)`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use intaglio::bstr::SymbolTable;
+    /// # use bstr::BStr;
+    /// # use bstr::BString;
+    /// let table = SymbolTable::new();
+    /// assert_eq!(0, table.len());
+    /// assert!(table.capacity() >= 4096);
+    /// ```
+    ///
+    /// [default capacity]: DEFAULT_SYMBOL_TABLE_CAPACITY
+    /// [`SymbolTable::with_capacity(0)`]: Self::with_capacity
+    #[must_use]
+    pub fn new() -> Self {
+        Self::with_capacity(DEFAULT_SYMBOL_TABLE_CAPACITY)
+    }
+
+    /// Constructs a new, empty `SymbolTable` with the specified capacity.
+    ///
+    /// The symbol table will be able to hold at least `capacity` bstr byte strings
+    /// without reallocating. If `capacity` is 0, the symbol table will not
+    /// allocate.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use intaglio::bstr::SymbolTable;
+    /// # use bstr::BStr;
+    /// # use bstr::BString;
+    /// let table = SymbolTable::with_capacity(10);
+    /// assert_eq!(0, table.len());
+    /// assert!(table.capacity() >= 10);
+    /// ```
+    #[must_use]
+    pub fn with_capacity(capacity: usize) -> Self {
+        let capacity = capacity.next_power_of_two();
+        Self {
+            map: ManuallyDrop::new(HashMap::with_capacity(capacity)),
+            vec: ManuallyDrop::new(Vec::with_capacity(capacity)),
+        }
+    }
+}
+
+impl<S> SymbolTable<S> {
+    /// Constructs a new, empty `SymbolTable` with
+    /// [default capacity](DEFAULT_SYMBOL_TABLE_CAPACITY) and the given hash
+    /// builder.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::collections::hash_map::RandomState;
+    /// # use intaglio::bstr::SymbolTable;
+    /// # use bstr::BStr;
+    /// # use bstr::BString;
+    /// let hash_builder = RandomState::new();
+    /// let table = SymbolTable::with_hasher(hash_builder);
+    /// assert_eq!(0, table.len());
+    /// assert!(table.capacity() >= 4096);
+    /// ```
+    pub fn with_hasher(hash_builder: S) -> Self {
+        Self::with_capacity_and_hasher(DEFAULT_SYMBOL_TABLE_CAPACITY, hash_builder)
+    }
+
+    /// Constructs a new, empty `SymbolTable` with the specified capacity and
+    /// the given hash builder.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::collections::hash_map::RandomState;
+    /// # use intaglio::bstr::SymbolTable;
+    /// # use bstr::BStr;
+    /// # use bstr::BString;
+    /// let hash_builder = RandomState::new();
+    /// let table = SymbolTable::with_capacity_and_hasher(10, hash_builder);
+    /// assert_eq!(0, table.len());
+    /// assert!(table.capacity() >= 10);
+    /// ```
+    pub fn with_capacity_and_hasher(capacity: usize, hash_builder: S) -> Self {
+        Self {
+            map: ManuallyDrop::new(HashMap::with_capacity_and_hasher(capacity, hash_builder)),
+            vec: ManuallyDrop::new(Vec::with_capacity(capacity)),
+        }
+    }
+
+    /// Returns the number of bstr byte strings the table can hold without
+    /// reallocating.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use intaglio::bstr::SymbolTable;
+    /// # use bstr::BStr;
+    /// # use bstr::BString;
+    /// let table = SymbolTable::with_capacity(10);
+    /// assert!(table.capacity() >= 10);
+    /// ```
+    pub fn capacity(&self) -> usize {
+        usize::min(self.vec.capacity(), self.map.capacity())
+    }
+
+    /// Returns the number of interned bstr byte strings in the table.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use intaglio::bstr::SymbolTable;
+    /// # use bstr::BStr;
+    /// # use bstr::BString;
+    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut table = SymbolTable::new();
+    /// assert_eq!(0, table.len());
+    ///
+    /// table.intern(BString::from("abc"))?;
+    /// // only uniquely interned bstr byte strings grow the symbol table.
+    /// table.intern(BString::from("abc"))?;
+    /// table.intern(BString::from("xyz"))?;
+    /// assert_eq!(2, table.len());
+    /// # Ok(())
+    /// # }
+    /// # example().unwrap();
+    /// ```
+    pub fn len(&self) -> usize {
+        self.vec.len()
+    }
+
+    /// Returns `true` if the symbol table contains no interned bstr byte strings.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use intaglio::bstr::SymbolTable;
+    /// # use bstr::BStr;
+    /// # use bstr::BString;
+    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut table = SymbolTable::new();
+    /// assert!(table.is_empty());
+    ///
+    /// table.intern(BString::from("abc"))?;
+    /// assert!(!table.is_empty());
+    /// # Ok(())
+    /// # }
+    /// # example().unwrap();
+    /// ```
+    pub fn is_empty(&self) -> bool {
+        self.vec.is_empty()
+    }
+
+    /// Returns `true` if the symbol table contains the given symbol.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use intaglio::bstr::SymbolTable;
+    /// # use bstr::BStr;
+    /// # use bstr::BString;
+    /// # use intaglio::Symbol;
+    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut table = SymbolTable::new();
+    /// assert!(!table.contains(Symbol::new(0)));
+    ///
+    /// let sym = table.intern(BString::from("abc"))?;
+    /// assert!(table.contains(Symbol::new(0)));
+    /// assert!(table.contains(sym));
+    /// # Ok(())
+    /// # }
+    /// # example().unwrap();
+    /// ```
+    #[must_use]
+    pub fn contains(&self, id: Symbol) -> bool {
+        self.get(id).is_some()
+    }
+
+    /// Returns a reference to the `BStr` byte string associated with the given symbol.
+    ///
+    /// If the given symbol does not exist in the underlying symbol table,
+    /// `None` is returned.
+    ///
+    /// The lifetime of the returned reference is bound to the symbol table.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use intaglio::bstr::SymbolTable;
+    /// # use bstr::BStr;
+    /// # use bstr::BString;
+    /// # use intaglio::Symbol;
+    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut table = SymbolTable::new();
+    /// assert!(table.get(Symbol::new(0)).is_none());
+    ///
+    /// let sym = table.intern(BString::from("abc"))?;
+    /// assert_eq!(Some(BStr::new(b"abc")), table.get(Symbol::new(0)));
+    /// assert_eq!(Some(BStr::new(b"abc")), table.get(sym));
+    /// # Ok(())
+    /// # }
+    /// # example().unwrap();
+    /// ```
+    #[must_use]
+    pub fn get(&self, id: Symbol) -> Option<&BStr> {
+        let bytes = self.vec.get(usize::from(id))?;
+        Some(bytes.as_slice())
+    }
+
+    /// Returns an iterator over all [`Symbol`]s and bstr byte strings in the
+    /// [`SymbolTable`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::collections::HashMap;
+    /// # use intaglio::bstr::SymbolTable;
+    /// # use bstr::BStr;
+    /// # use bstr::BString;
+    /// # use intaglio::Symbol;
+    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut table = SymbolTable::new();
+    /// table.intern(BString::from("abc"))?;
+    /// table.intern(BString::from("xyz"))?;
+    /// table.intern(BString::from("123"))?;
+    /// table.intern(BString::from("789"))?;
+    ///
+    /// let iter = table.iter();
+    /// let mut map = HashMap::new();
+    /// map.insert(Symbol::new(0), BStr::new(b"abc"));
+    /// map.insert(Symbol::new(1), BStr::new(b"xyz"));
+    /// map.insert(Symbol::new(2), BStr::new(b"123"));
+    /// map.insert(Symbol::new(3), BStr::new(b"789"));
+    /// assert_eq!(map, iter.collect::<HashMap<_, _>>());
+    /// # Ok(())
+    /// # }
+    /// # example().unwrap();
+    /// ```
+    ///
+    /// ```
+    /// # use intaglio::bstr::SymbolTable;
+    /// # use bstr::BStr;
+    /// # use bstr::BString;
+    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut table = SymbolTable::new();
+    /// table.intern(BString::from("abc"))?;
+    /// table.intern(BString::from("xyz"))?;
+    /// table.intern(BString::from("123"))?;
+    /// table.intern(BString::from("789"))?;
+    ///
+    /// let iter = table.iter();
+    /// assert_eq!(table.len(), iter.count());
+    /// # Ok(())
+    /// # }
+    /// # example().unwrap();
+    /// ```
+    pub fn iter(&self) -> Iter<'_> {
+        Iter(self.all_symbols().zip(self.bstrings()))
+    }
+
+    /// Returns an iterator over all [`Symbol`]s in the [`SymbolTable`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use intaglio::bstr::SymbolTable;
+    /// # use bstr::BStr;
+    /// # use bstr::BString;
+    /// # use intaglio::Symbol;
+    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut table = SymbolTable::new();
+    /// table.intern(BString::from("abc"))?;
+    /// table.intern(BString::from("xyz"))?;
+    /// table.intern(BString::from("123"))?;
+    /// table.intern(BString::from("789"))?;
+    ///
+    /// let mut all_symbols = table.all_symbols();
+    /// assert_eq!(Some(Symbol::new(0)), all_symbols.next());
+    /// assert_eq!(Some(Symbol::new(1)), all_symbols.nth_back(2));
+    /// assert_eq!(None, all_symbols.next());
+    /// # Ok(())
+    /// # }
+    /// # example().unwrap();
+    /// ```
+    ///
+    /// ```
+    /// # use intaglio::bstr::SymbolTable;
+    /// # use bstr::BStr;
+    /// # use bstr::BString;
+    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut table = SymbolTable::new();
+    /// table.intern(BString::from("abc"))?;
+    /// table.intern(BString::from("xyz"))?;
+    /// table.intern(BString::from("123"))?;
+    /// table.intern(BString::from("789"))?;
+    ///
+    /// let all_symbols = table.all_symbols();
+    /// assert_eq!(table.len(), all_symbols.count());
+    /// # Ok(())
+    /// # }
+    /// # example().unwrap();
+    /// ```
+    pub fn all_symbols(&self) -> AllSymbols<'_> {
+        AllSymbols {
+            range: 0..self.len(),
+            phantom: PhantomData,
+        }
+    }
+
+    /// Returns an iterator over all bstr byte strings in the [`SymbolTable`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use intaglio::bstr::SymbolTable;
+    /// # use bstr::BStr;
+    /// # use bstr::BString;
+    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut table = SymbolTable::new();
+    /// table.intern(BString::from("abc"))?;
+    /// table.intern(BString::from("xyz"))?;
+    /// table.intern(BString::from("123"))?;
+    /// table.intern(BString::from("789"))?;
+    ///
+    /// let mut bstrings = table.bstrings();
+    /// assert_eq!(Some(BStr::new(b"abc")), bstrings.next());
+    /// assert_eq!(Some(BStr::new(b"xyz")), bstrings.nth_back(2));
+    /// assert_eq!(None, bstrings.next());
+    /// # Ok(())
+    /// # }
+    /// # example().unwrap();
+    /// ```
+    ///
+    /// ```
+    /// # use intaglio::bstr::SymbolTable;
+    /// # use bstr::BStr;
+    /// # use bstr::BString;
+    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut table = SymbolTable::new();
+    /// table.intern(BString::from("abc"))?;
+    /// table.intern(BString::from("xyz"))?;
+    /// table.intern(BString::from("123"))?;
+    /// table.intern(BString::from("789"))?;
+    ///
+    /// let bstrings = table.bstrings();
+    /// assert_eq!(table.len(), bstrings.count());
+    /// # Ok(())
+    /// # }
+    /// # example().unwrap();
+    /// ```
+    pub fn bstrings(&self) -> BStrings<'_> {
+        BStrings(self.vec.iter())
+    }
+}
+
+impl<S> SymbolTable<S>
+where
+    S: BuildHasher,
+{
+    /// Intern a `BStr` byte string for the lifetime of the symbol table.
+    ///
+    /// The returned `Symbol` allows retrieving of the underlying bytes.
+    /// Equal bstr byte strings will be inserted into the symbol table exactly once.
+    ///
+    /// This function only allocates if the underlying symbol table has no
+    /// remaining capacity.
+    ///
+    /// # Errors
+    ///
+    /// If the symbol table would grow larger than `u32::MAX` interned
+    /// bstr byte strings, the [`Symbol`] counter would overflow and a
+    /// [`SymbolOverflowError`] is returned.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use intaglio::bstr::SymbolTable;
+    /// # use bstr::BStr;
+    /// # use bstr::BString;
+    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut table = SymbolTable::new();
+    /// let sym = table.intern(BString::from("abc"))?;
+    /// table.intern(BString::from("xyz"))?;
+    /// table.intern(BStr::new(b"123"))?;
+    /// table.intern(BStr::new(b"789"))?;
+    ///
+    /// assert_eq!(4, table.len());
+    /// assert_eq!(Some(BStr::new(b"abc")), table.get(sym));
+    /// # Ok(())
+    /// # }
+    /// # example().unwrap();
+    /// ```
+    pub fn intern<T>(&mut self, contents: T) -> Result<Symbol, SymbolOverflowError>
+    where
+        T: Into<Cow<'static, BStr>>,
+    {
+        let contents = contents.into();
+        if let Some(&id) = self.map.get(&*contents) {
+            return Ok(id);
+        }
+
+        // The `Interned::Owned` variant is derived from a `Box<T>`. When such
+        // a structure is moved or assigned, as it is below in the call to
+        // `self.vec.push`, the allocation is "retagged" in Miri/stacked borrows.
+        //
+        // Retagging an allocation pops all of the borrows derived from it off
+        // of the stack. This means we need to move the `Interned` into the
+        // `Vec` before calling `Interned::as_static_slice` to ensure the
+        // reference does not get invalidated by retagging.
+        //
+        // However, that alone may be insufficient as the `Interened` may be
+        // moved when the symbol table grows.
+        //
+        // The `SymbolTable` API prevents shared references to the `Interned`
+        // being invalidated by a retag by tying resolved symbol contents,
+        // `&'a T`, to `&'a SymbolTable`, which means the `SymbolTable` cannot
+        // grow, shrink, or otherwise reallocate/move contents while a reference
+        // to the `Interned`'s inner `T` is alive.
+        //
+        // To protect against future updates to stacked borrows or the unsafe
+        // code operational semantics, we can address this additional invariant
+        // with updated `Interned` internals which store the `Box<T>` in a raw
+        // pointer form, which allows moves to be treated as untyped copies.
+        //
+        // See:
+        //
+        // - <https://github.com/artichoke/intaglio/issues/235>
+        // - <https://github.com/artichoke/intaglio/pull/236>
+        let name = Interned::from(contents);
+        let id = Symbol::try_from(self.map.len())?;
+
+        let slice = {
+            // Move the `Interned` into the `Vec`, causing it to be retagged
+            // under stacked borrows, before taking any references to its inner
+            // `T`. If anything after this push panics, roll back the `Vec`
+            // mutation so the symbol table remains internally consistent.
+            let guard = VecEntryRollbackGuard::new(&mut self.vec, name);
+            // Ensure we grow the map before we take any shared references to
+            // the inner `T`.
+            self.map.reserve(1);
+
+            // SAFETY: This expression creates a reference with a `'static`
+            // lifetime from an owned and interned buffer, which is permissible
+            // because:
+            //
+            // - `Interned` is an internal implementation detail of
+            //   `SymbolTable`.
+            // - `SymbolTable` never gives out `'static` references to
+            //   underlying contents.
+            // - All slice references given out by the `SymbolTable` have the
+            //   same lifetime as the `SymbolTable`.
+            // - The `map` field of `SymbolTable`, which contains the `'static`
+            //   references, is dropped before the owned buffers stored in this
+            //   `Interned`.
+            // - The shared reference may be derived from a `PinBox` which
+            //   prevents moves from retagging the underlying boxed `T` under
+            //   stacked borrows.
+            // - The symbol table cannot grow, shrink, or otherwise move its
+            //   contents while this reference is alive.
+            let slice = unsafe { guard.last().as_static_slice() };
+
+            self.map.insert(slice, id);
+            guard.defuse();
+            slice
+        };
+
+        debug_assert_eq!(self.get(id), Some(slice));
+        debug_assert_eq!(self.intern(slice), Ok(id));
+
+        Ok(id)
+    }
+
+    /// Returns the `Symbol` identifier for `contents` if it has been interned
+    /// before, `None` otherwise.
+    ///
+    /// This method does not modify the symbol table.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use intaglio::bstr::SymbolTable;
+    /// # use bstr::BStr;
+    /// # use bstr::BString;
+    /// # use intaglio::Symbol;
+    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut table = SymbolTable::new();
+    /// assert!(!table.is_interned(BStr::new(b"abc")));
+    /// assert_eq!(None, table.check_interned(BStr::new(b"abc")));
+    ///
+    /// table.intern(BString::from("abc"))?;
+    /// assert!(table.is_interned(BStr::new(b"abc")));
+    /// assert_eq!(Some(Symbol::new(0)), table.check_interned(BStr::new(b"abc")));
+    /// # Ok(())
+    /// # }
+    /// # example().unwrap();
+    /// ```
+    #[must_use]
+    pub fn check_interned(&self, contents: &BStr) -> Option<Symbol> {
+        self.map.get(contents).copied()
+    }
+
+    /// Returns `true` if the given `BStr` byte string has been interned before.
+    ///
+    /// This method does not modify the symbol table.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use intaglio::bstr::SymbolTable;
+    /// # use bstr::BStr;
+    /// # use bstr::BString;
+    /// # use intaglio::Symbol;
+    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut table = SymbolTable::new();
+    /// assert!(!table.is_interned(BStr::new(b"abc")));
+    /// assert_eq!(None, table.check_interned(BStr::new(b"abc")));
+    ///
+    /// table.intern(BString::from("abc"))?;
+    /// assert!(table.is_interned(BStr::new(b"abc")));
+    /// assert_eq!(Some(Symbol::new(0)), table.check_interned(BStr::new(b"abc")));
+    /// # Ok(())
+    /// # }
+    /// # example().unwrap();
+    /// ```
+    #[must_use]
+    pub fn is_interned(&self, contents: &BStr) -> bool {
+        self.map.contains_key(contents)
+    }
+
+    /// Reserves capacity for at least additional more elements to be inserted
+    /// in the given `SymbolTable`. The collection may reserve more space to
+    /// avoid frequent reallocations. After calling reserve, capacity will be
+    /// greater than or equal to `self.len() + additional`. Does nothing if
+    /// capacity is already sufficient.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the new capacity overflows `usize`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use intaglio::bstr::SymbolTable;
+    /// # use bstr::BStr;
+    /// # use bstr::BString;
+    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut table = SymbolTable::with_capacity(1);
+    /// table.intern(BString::from("abc"))?;
+    /// table.reserve(10);
+    /// assert!(table.capacity() >= 11);
+    /// # Ok(())
+    /// # }
+    /// # example().unwrap();
+    /// ```
+    pub fn reserve(&mut self, additional: usize) {
+        self.map.reserve(additional);
+        self.vec.reserve(additional);
+    }
+
+    /// Tries to reserve capacity for at least `additional` more elements in
+    /// the `SymbolTable`, returning an error if the allocation fails.
+    ///
+    /// After calling `try_reserve`, capacity will be greater than or equal to
+    /// `self.len() + additional` on success. Does nothing if capacity is
+    /// already sufficient.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`TryReserveError`] if the allocation fails or if the new
+    /// capacity would overflow `usize`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use intaglio::bstr::SymbolTable;
+    /// # use bstr::BStr;
+    /// # use bstr::BString;
+    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut table = SymbolTable::with_capacity(1);
+    /// table.intern(BStr::new(b"abc"))?;
+    /// table.try_reserve(10)?;
+    /// assert!(table.capacity() >= 11);
+    /// # Ok(())
+    /// # }
+    /// # example().unwrap();
+    /// ```
+    pub fn try_reserve(&mut self, additional: usize) -> Result<(), TryReserveError> {
+        self.map.try_reserve(additional)?;
+        self.vec.try_reserve(additional)
+    }
+
+    /// Shrinks the capacity of the symbol table as much as possible.
+    ///
+    /// It will drop down as close as possible to the length but the allocator
+    /// may still inform the symbol table that there is space for a few more
+    /// elements.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use intaglio::bstr::SymbolTable;
+    /// # use bstr::BStr;
+    /// # use bstr::BString;
+    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut table = SymbolTable::with_capacity(10);
+    /// table.intern(BString::from("abc"));
+    /// table.intern(BString::from("xyz"));
+    /// table.intern(BString::from("123"));
+    /// table.shrink_to_fit();
+    /// assert!(table.capacity() >= 3);
+    /// # Ok(())
+    /// # }
+    /// # example().unwrap();
+    /// ```
+    pub fn shrink_to_fit(&mut self) {
+        self.map.shrink_to_fit();
+        self.vec.shrink_to_fit();
+    }
+
+    /// Shrinks the capacity of the symbol table with a lower bound.
+    ///
+    /// The capacity will remain at least as large as both the length and the
+    /// supplied value.
+    ///
+    /// If the current capacity is less than the lower limit, this is a no-op.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use intaglio::bstr::SymbolTable;
+    /// # use bstr::BStr;
+    /// # use bstr::BString;
+    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut table = SymbolTable::with_capacity(10);
+    /// table.intern(BString::from("abc"))?;
+    /// table.intern(BString::from("xyz"))?;
+    /// table.intern(BString::from("123"))?;
+    /// table.shrink_to(5);
+    /// assert!(table.capacity() >= 5);
+    /// # Ok(())
+    /// # }
+    /// # example().unwrap();
+    /// ```
+    pub fn shrink_to(&mut self, min_capacity: usize) {
+        self.map.shrink_to(min_capacity);
+        self.vec.shrink_to(min_capacity);
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::needless_pass_by_value)]
+mod tests {
+    use ::bstr::{BStr, BString};
+    use quickcheck::quickcheck;
+
+    use super::SymbolTable;
+
+    #[test]
+    fn alloc_drop_new() {
+        let table = SymbolTable::new();
+        drop(table);
+    }
+
+    #[test]
+    fn alloc_drop_with_capacity() {
+        let table = SymbolTable::with_capacity(1 << 14);
+        drop(table);
+    }
+
+    #[test]
+    fn drop_with_true_static_data() {
+        let mut table = SymbolTable::new();
+        table.intern(BStr::new(b"1")).unwrap();
+        table.intern(BStr::new(b"2")).unwrap();
+        table.intern(BStr::new(b"3")).unwrap();
+        table.intern(BStr::new(b"4")).unwrap();
+        table.intern(BStr::new(b"5")).unwrap();
+        drop(table);
+    }
+
+    #[test]
+    fn drop_with_owned_data() {
+        let mut table = SymbolTable::new();
+        table.intern(BString::from("1")).unwrap();
+        table.intern(BString::from("2")).unwrap();
+        table.intern(BString::from("3")).unwrap();
+        table.intern(BString::from("4")).unwrap();
+        table.intern(BString::from("5")).unwrap();
+        drop(table);
+    }
+
+    #[test]
+    fn set_owned_value_and_get_with_owned_and_borrowed() {
+        let mut table = SymbolTable::new();
+        // intern an owned value
+        let sym = table.intern(BString::from("abc")).unwrap();
+        // retrieve bytes
+        assert_eq!(BStr::new(b"abc"), table.get(sym).unwrap());
+        // intern owned value again
+        assert_eq!(sym, table.intern(BString::from("abc")).unwrap());
+        // intern borrowed value
+        assert_eq!(sym, table.intern(BStr::new(b"abc")).unwrap());
+    }
+
+    #[test]
+    fn set_borrowed_value_and_get_with_owned_and_borrowed() {
+        let mut table = SymbolTable::new();
+        // intern a borrowed value
+        let sym = table.intern(BStr::new(b"abc")).unwrap();
+        // retrieve bytes
+        assert_eq!(BStr::new(b"abc"), table.get(sym).unwrap());
+        // intern owned value
+        assert_eq!(sym, table.intern(BString::from("abc")).unwrap());
+        // intern borrowed value again
+        assert_eq!(sym, table.intern(BStr::new(b"abc")).unwrap());
+    }
+
+    #[test]
+    fn try_reserve_grows_capacity() {
+        let mut table = SymbolTable::with_capacity(1);
+        table.intern(BStr::new(b"abc")).unwrap();
+        let len = table.len();
+
+        table.try_reserve(10).unwrap();
+
+        assert!(table.capacity() >= len + 10);
+    }
+
+    #[test]
+    fn try_reserve_overflow_errors() {
+        let mut table = SymbolTable::new();
+
+        let result = table.try_reserve(usize::MAX);
+
+        assert!(result.is_err());
+    }
+
+    quickcheck! {
+        fn intern_twice_symbol_equality(bytes: Vec<u8>) -> bool {
+            let mut table = SymbolTable::new();
+            let sym = table.intern(BString::from(bytes.clone())).unwrap();
+            let sym_again = table.intern(BString::from(bytes)).unwrap();
+            sym == sym_again
+        }
+
+        fn intern_get_roundtrip(bytes: Vec<u8>) -> bool {
+            let mut table = SymbolTable::new();
+            let sym = table.intern(BString::from(bytes.clone())).unwrap();
+            let retrieved_bytes = table.get(sym).unwrap();
+            bytes.as_slice() == &**retrieved_bytes
+        }
+
+        fn table_contains_sym(bytes: Vec<u8>) -> bool {
+            let mut table = SymbolTable::new();
+            let sym = table.intern(BString::from(bytes)).unwrap();
+            table.contains(sym)
+        }
+
+        fn table_does_not_contain_missing_symbol_ids(sym: u32) -> bool {
+            let table = SymbolTable::new();
+            !table.contains(sym.into())
+        }
+
+        fn empty_table_does_not_report_any_interned_byte_strings(bytes: Vec<u8>) -> bool {
+            let table = SymbolTable::new();
+            !table.is_interned(BStr::new(&bytes))
+        }
+
+        fn table_reports_interned_byte_strings_as_interned(bytes: Vec<u8>) -> bool {
+            let mut table = SymbolTable::new();
+            table.intern(BString::from(bytes.clone())).unwrap();
+            table.is_interned(BStr::new(&bytes))
+        }
+    }
+}

--- a/src/bstr.rs
+++ b/src/bstr.rs
@@ -1,4 +1,4 @@
-//! Intern bstr byte strings.
+//! Intern byte strings from the [`bstr` crate][::bstr].
 //!
 //! This module provides a nearly identical API to the one found in the
 //! top-level of this crate. There is one important difference:

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -1,6 +1,8 @@
 //! A Wrapper around interned strings that maintains the safety invariants of
 //! the `'static` slices handed out to the interner.
 
+#[cfg(feature = "bstr")]
+use ::bstr::{BStr, BString};
 use core::fmt;
 use std::borrow::Cow;
 #[cfg(feature = "cstr")]
@@ -27,6 +29,14 @@ impl From<Cow<'static, str>> for Interned<str> {
 impl From<Cow<'static, [u8]>> for Interned<[u8]> {
     #[inline]
     fn from(cow: Cow<'static, [u8]>) -> Self {
+        Self(cow.into())
+    }
+}
+
+#[cfg(feature = "bstr")]
+impl From<Cow<'static, BStr>> for Interned<BStr> {
+    #[inline]
+    fn from(cow: Cow<'static, BStr>) -> Self {
         Self(cow.into())
     }
 }
@@ -89,6 +99,13 @@ impl fmt::Debug for Interned<str> {
 
 #[cfg(feature = "bytes")]
 impl fmt::Debug for Interned<[u8]> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+#[cfg(feature = "bstr")]
+impl fmt::Debug for Interned<BStr> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
     }
@@ -171,6 +188,26 @@ impl From<Vec<u8>> for Slice<[u8]> {
 impl From<Cow<'static, [u8]>> for Slice<[u8]> {
     #[inline]
     fn from(cow: Cow<'static, [u8]>) -> Self {
+        match cow {
+            Cow::Borrowed(slice) => slice.into(),
+            Cow::Owned(owned) => owned.into(),
+        }
+    }
+}
+
+#[cfg(feature = "bstr")]
+impl From<BString> for Slice<BStr> {
+    #[inline]
+    fn from(owned: BString) -> Self {
+        let boxed = Vec::<u8>::from(owned).into_boxed_slice();
+        Self::Owned(PinBox::new(Box::<BStr>::from(boxed)))
+    }
+}
+
+#[cfg(feature = "bstr")]
+impl From<Cow<'static, BStr>> for Slice<BStr> {
+    #[inline]
+    fn from(cow: Cow<'static, BStr>) -> Self {
         match cow {
             Cow::Borrowed(slice) => slice.into(),
             Cow::Owned(owned) => owned.into(),
@@ -303,6 +340,14 @@ impl fmt::Debug for Slice<[u8]> {
         } else {
             write!(f, "{:?}", self.as_slice())
         }
+    }
+}
+
+#[cfg(feature = "bstr")]
+impl fmt::Debug for Slice<BStr> {
+    /// Formats the `BStr` slice using the given formatter.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.as_slice().fmt(f)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,10 @@
     doc = "- [`bytes::SymbolTable`] interns binary strings: [`Vec<u8>`] and `&[u8]`."
 )]
 #![cfg_attr(
+    feature = "bstr",
+    doc = "- [`bstr::SymbolTable`] interns bstr byte strings: `bstr::BString` and `bstr::BStr`."
+)]
+#![cfg_attr(
     feature = "cstr",
     doc = "- [`cstr::SymbolTable`] interns C strings: [`CString`] and [`&CStr`]."
 )]
@@ -86,8 +90,11 @@
 //!
 //! # Crate features
 //!
-//! All features are enabled by default.
+//! All string table features except **bstr** are enabled by default.
 //!
+//! - **bstr** - Enables an additional symbol table implementation for
+//!   interning bstr byte strings (`bstr::BString` and `&'static bstr::BStr`).
+//!   This feature is disabled by default.
 //! - **bytes** - Enables an additional symbol table implementation for interning
 //!   byte strings ([`Vec<u8>`] and `&'static [u8]`).
 //! - **cstr** - Enables an additional symbol table implementation for interning
@@ -114,6 +121,9 @@ use core::fmt;
 use core::num::TryFromIntError;
 use std::error;
 
+#[cfg(feature = "bstr")]
+#[cfg_attr(docsrs, doc(cfg(feature = "bstr")))]
+pub mod bstr;
 #[cfg(feature = "bytes")]
 #[cfg_attr(docsrs, doc(cfg(feature = "bytes")))]
 pub mod bytes;
@@ -347,6 +357,8 @@ mod tests {
         fn constraint<T: RefUnwindSafe + Send + Sync + Unpin + UnwindSafe>(_table: T) {}
 
         constraint(crate::SymbolTable::with_capacity(0));
+        #[cfg(feature = "bstr")]
+        constraint(crate::bstr::SymbolTable::with_capacity(0));
         #[cfg(feature = "bytes")]
         constraint(crate::bytes::SymbolTable::with_capacity(0));
         #[cfg(feature = "cstr")]
@@ -368,6 +380,7 @@ mod tests {
 #[cfg(all(
     doctest,
     feature = "bytes",
+    feature = "bstr",
     feature = "cstr",
     feature = "osstr",
     feature = "path"

--- a/tests/leak_drop/bstr.rs
+++ b/tests/leak_drop/bstr.rs
@@ -1,0 +1,23 @@
+use bstr::{BStr, BString};
+use intaglio::Symbol;
+use intaglio::bstr::SymbolTable;
+
+#[test]
+fn dealloc_owned_data() {
+    let mut table = SymbolTable::with_capacity(0);
+    for sym in crate::vectors::byte_symbols() {
+        let symbol = BString::from(sym);
+
+        let sym_id = table.intern(symbol.clone()).unwrap();
+
+        assert!(table.is_interned(BStr::new(&symbol)));
+        assert!(table.contains(sym_id));
+        assert_eq!(Some(BStr::new(&symbol)), table.get(sym_id));
+        assert_eq!(sym_id, table.intern(symbol.clone()).unwrap());
+        assert!(table.is_interned(BStr::new(&symbol)));
+        assert!(table.contains(sym_id));
+        assert_eq!(Some(BStr::new(&symbol)), table.get(sym_id));
+
+        assert_eq!(table.get(Symbol::new(0)).unwrap().len(), 100);
+    }
+}

--- a/tests/leak_drop/main.rs
+++ b/tests/leak_drop/main.rs
@@ -3,6 +3,8 @@
 #![warn(clippy::cargo)]
 #![allow(unknown_lints)]
 
+#[cfg(feature = "bstr")]
+mod bstr;
 #[cfg(feature = "bytes")]
 mod bytes;
 #[cfg(feature = "cstr")]

--- a/tests/unwind_safety.rs
+++ b/tests/unwind_safety.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "bstr")]
+use bstr::BStr;
 #[cfg(feature = "cstr")]
 use std::ffi::CStr;
 #[cfg(feature = "osstr")]
@@ -85,6 +87,23 @@ fn bytes_symbol_table_rolls_back_after_hasher_panic() {
     assert_eq!(sym, Symbol::new(0));
     assert_eq!(table.get(sym), Some(&b"victim"[..]));
     assert_eq!(table.check_interned(&b"victim"[..]), Some(sym));
+}
+
+#[cfg(feature = "bstr")]
+#[test]
+fn bstr_symbol_table_rolls_back_after_hasher_panic() {
+    let mut table = intaglio::bstr::SymbolTable::with_hasher(panic_build_hasher());
+
+    let result = catch_unwind(AssertUnwindSafe(|| table.intern(BStr::new(b"attacker"))));
+
+    assert!(result.is_err());
+    assert_eq!(table.len(), 0);
+    assert_eq!(table.check_interned(BStr::new(b"attacker")), None);
+
+    let sym = table.intern(BStr::new(b"victim")).unwrap();
+    assert_eq!(sym, Symbol::new(0));
+    assert_eq!(table.get(sym), Some(BStr::new(b"victim")));
+    assert_eq!(table.check_interned(BStr::new(b"victim")), Some(sym));
 }
 
 #[cfg(feature = "cstr")]


### PR DESCRIPTION
## Summary

- add an optional `bstr` crate feature, disabled by default
- add `intaglio::bstr::SymbolTable` for `bstr::BString` and `&'static bstr::BStr`
- wire bstr support through shared interned storage plus leak/drop and unwind-safety coverage
- document the new table in crate docs and README

## Verification

- `cargo fmt --check`
- `cargo test`
- `cargo test --features bstr`
- `cargo test --no-default-features --features bstr`
- `cargo test --all-features`
- `cargo clippy --workspace --all-features --all-targets`

`npm run fmt` could not be run because `npm` is not available on `PATH` in this shell.
