### PR TITLE
Store AllSymbols ranges as u32

### DIFF
--- a/src/bstr.rs
+++ b/src/bstr.rs
@@ -91,7 +91,7 @@ use ::bstr::BStr;
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 #[cfg_attr(docsrs, doc(cfg(feature = "bstr")))]
 pub struct AllSymbols<'a> {
-    range: RangeInclusive<u32>,
+    range: Option<RangeInclusive<u32>>,
     // Hold a shared reference to the underlying `SymbolTable` to ensure the
     // table is not modified while we are iterating which would make the results
     // not match the real state.
@@ -102,37 +102,39 @@ impl Iterator for AllSymbols<'_> {
     type Item = Symbol;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.range.next().map(Symbol::from)
+        self.range.as_mut()?.next().map(Symbol::from)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        self.range.size_hint()
+        self.range
+            .as_ref()
+            .map_or((0, Some(0)), Iterator::size_hint)
     }
 
     fn count(self) -> usize {
-        self.range.count()
+        self.range.map_or(0, Iterator::count)
     }
 
     fn last(self) -> Option<Self::Item> {
-        self.range.last().map(Symbol::from)
+        self.range.and_then(Iterator::last).map(Symbol::from)
     }
 
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
-        self.range.nth(n).map(Symbol::from)
+        self.range.as_mut()?.nth(n).map(Symbol::from)
     }
 
     fn collect<B: FromIterator<Self::Item>>(self) -> B {
-        self.range.map(Symbol::from).collect()
+        self.range.into_iter().flatten().map(Symbol::from).collect()
     }
 }
 
 impl DoubleEndedIterator for AllSymbols<'_> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        self.range.next_back().map(Symbol::from)
+        self.range.as_mut()?.next_back().map(Symbol::from)
     }
 
     fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
-        self.range.nth_back(n).map(Symbol::from)
+        self.range.as_mut()?.nth_back(n).map(Symbol::from)
     }
 }
 
@@ -698,10 +700,10 @@ impl<S> SymbolTable<S> {
     /// ```
     pub fn all_symbols(&self) -> AllSymbols<'_> {
         AllSymbols {
-            range: match self.len() {
-                0 => RangeInclusive::new(1, 0),
-                len => 0..=u32::try_from(len - 1).unwrap_or(u32::MAX),
-            },
+            range: self
+                .len()
+                .checked_sub(1)
+                .map(|last| 0..=u32::try_from(last).unwrap_or(u32::MAX)),
             phantom: PhantomData,
         }
     }

--- a/src/bstr.rs
+++ b/src/bstr.rs
@@ -56,7 +56,7 @@ use core::hash::BuildHasher;
 use core::iter::{FromIterator, FusedIterator, Zip};
 use core::marker::PhantomData;
 use core::mem::ManuallyDrop;
-use core::ops::{Index, Range};
+use core::ops::{Index, RangeInclusive};
 use core::slice;
 use std::borrow::Cow;
 use std::collections::{
@@ -91,7 +91,7 @@ use ::bstr::BStr;
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 #[cfg_attr(docsrs, doc(cfg(feature = "bstr")))]
 pub struct AllSymbols<'a> {
-    range: Range<usize>,
+    range: RangeInclusive<u32>,
     // Hold a shared reference to the underlying `SymbolTable` to ensure the
     // table is not modified while we are iterating which would make the results
     // not match the real state.
@@ -102,9 +102,7 @@ impl Iterator for AllSymbols<'_> {
     type Item = Symbol;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let next = self.range.next()?;
-        debug_assert!(u32::try_from(next).is_ok());
-        Some((next as u32).into())
+        self.range.next().map(Symbol::from)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -116,33 +114,25 @@ impl Iterator for AllSymbols<'_> {
     }
 
     fn last(self) -> Option<Self::Item> {
-        let last = self.range.last()?;
-        debug_assert!(u32::try_from(last).is_ok());
-        Some((last as u32).into())
+        self.range.last().map(Symbol::from)
     }
 
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
-        let nth = self.range.nth(n)?;
-        debug_assert!(u32::try_from(nth).is_ok());
-        Some((nth as u32).into())
+        self.range.nth(n).map(Symbol::from)
     }
 
     fn collect<B: FromIterator<Self::Item>>(self) -> B {
-        self.range.map(|sym| Symbol::from(sym as u32)).collect()
+        self.range.map(Symbol::from).collect()
     }
 }
 
 impl DoubleEndedIterator for AllSymbols<'_> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        let next = self.range.next_back()?;
-        debug_assert!(u32::try_from(next).is_ok());
-        Some((next as u32).into())
+        self.range.next_back().map(Symbol::from)
     }
 
     fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
-        let nth = self.range.nth_back(n)?;
-        debug_assert!(u32::try_from(nth).is_ok());
-        Some((nth as u32).into())
+        self.range.nth_back(n).map(Symbol::from)
     }
 }
 
@@ -708,7 +698,10 @@ impl<S> SymbolTable<S> {
     /// ```
     pub fn all_symbols(&self) -> AllSymbols<'_> {
         AllSymbols {
-            range: 0..self.len(),
+            range: match self.len() {
+                0 => RangeInclusive::new(1, 0),
+                len => 0..=u32::try_from(len - 1).unwrap_or(u32::MAX),
+            },
             phantom: PhantomData,
         }
     }

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -54,7 +54,7 @@ use core::hash::BuildHasher;
 use core::iter::{FromIterator, FusedIterator, Zip};
 use core::marker::PhantomData;
 use core::mem::ManuallyDrop;
-use core::ops::{Index, Range};
+use core::ops::{Index, RangeInclusive};
 use core::slice;
 use std::borrow::Cow;
 use std::collections::{
@@ -86,7 +86,7 @@ use crate::{DEFAULT_SYMBOL_TABLE_CAPACITY, Symbol, SymbolOverflowError};
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 #[cfg_attr(docsrs, doc(cfg(feature = "bytes")))]
 pub struct AllSymbols<'a> {
-    range: Range<usize>,
+    range: RangeInclusive<u32>,
     // Hold a shared reference to the underlying `SymbolTable` to ensure the
     // table is not modified while we are iterating which would make the results
     // not match the real state.
@@ -97,9 +97,7 @@ impl Iterator for AllSymbols<'_> {
     type Item = Symbol;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let next = self.range.next()?;
-        debug_assert!(u32::try_from(next).is_ok());
-        Some((next as u32).into())
+        self.range.next().map(Symbol::from)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -111,33 +109,25 @@ impl Iterator for AllSymbols<'_> {
     }
 
     fn last(self) -> Option<Self::Item> {
-        let last = self.range.last()?;
-        debug_assert!(u32::try_from(last).is_ok());
-        Some((last as u32).into())
+        self.range.last().map(Symbol::from)
     }
 
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
-        let nth = self.range.nth(n)?;
-        debug_assert!(u32::try_from(nth).is_ok());
-        Some((nth as u32).into())
+        self.range.nth(n).map(Symbol::from)
     }
 
     fn collect<B: FromIterator<Self::Item>>(self) -> B {
-        self.range.map(|sym| Symbol::from(sym as u32)).collect()
+        self.range.map(Symbol::from).collect()
     }
 }
 
 impl DoubleEndedIterator for AllSymbols<'_> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        let next = self.range.next_back()?;
-        debug_assert!(u32::try_from(next).is_ok());
-        Some((next as u32).into())
+        self.range.next_back().map(Symbol::from)
     }
 
     fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
-        let nth = self.range.nth_back(n)?;
-        debug_assert!(u32::try_from(nth).is_ok());
-        Some((nth as u32).into())
+        self.range.nth_back(n).map(Symbol::from)
     }
 }
 
@@ -669,7 +659,10 @@ impl<S> SymbolTable<S> {
     /// ```
     pub fn all_symbols(&self) -> AllSymbols<'_> {
         AllSymbols {
-            range: 0..self.len(),
+            range: match self.len() {
+                0 => RangeInclusive::new(1, 0),
+                len => 0..=u32::try_from(len - 1).unwrap_or(u32::MAX),
+            },
             phantom: PhantomData,
         }
     }

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -86,7 +86,7 @@ use crate::{DEFAULT_SYMBOL_TABLE_CAPACITY, Symbol, SymbolOverflowError};
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 #[cfg_attr(docsrs, doc(cfg(feature = "bytes")))]
 pub struct AllSymbols<'a> {
-    range: RangeInclusive<u32>,
+    range: Option<RangeInclusive<u32>>,
     // Hold a shared reference to the underlying `SymbolTable` to ensure the
     // table is not modified while we are iterating which would make the results
     // not match the real state.
@@ -97,37 +97,39 @@ impl Iterator for AllSymbols<'_> {
     type Item = Symbol;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.range.next().map(Symbol::from)
+        self.range.as_mut()?.next().map(Symbol::from)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        self.range.size_hint()
+        self.range
+            .as_ref()
+            .map_or((0, Some(0)), Iterator::size_hint)
     }
 
     fn count(self) -> usize {
-        self.range.count()
+        self.range.map_or(0, Iterator::count)
     }
 
     fn last(self) -> Option<Self::Item> {
-        self.range.last().map(Symbol::from)
+        self.range.and_then(Iterator::last).map(Symbol::from)
     }
 
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
-        self.range.nth(n).map(Symbol::from)
+        self.range.as_mut()?.nth(n).map(Symbol::from)
     }
 
     fn collect<B: FromIterator<Self::Item>>(self) -> B {
-        self.range.map(Symbol::from).collect()
+        self.range.into_iter().flatten().map(Symbol::from).collect()
     }
 }
 
 impl DoubleEndedIterator for AllSymbols<'_> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        self.range.next_back().map(Symbol::from)
+        self.range.as_mut()?.next_back().map(Symbol::from)
     }
 
     fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
-        self.range.nth_back(n).map(Symbol::from)
+        self.range.as_mut()?.nth_back(n).map(Symbol::from)
     }
 }
 
@@ -659,10 +661,10 @@ impl<S> SymbolTable<S> {
     /// ```
     pub fn all_symbols(&self) -> AllSymbols<'_> {
         AllSymbols {
-            range: match self.len() {
-                0 => RangeInclusive::new(1, 0),
-                len => 0..=u32::try_from(len - 1).unwrap_or(u32::MAX),
-            },
+            range: self
+                .len()
+                .checked_sub(1)
+                .map(|last| 0..=u32::try_from(last).unwrap_or(u32::MAX)),
             phantom: PhantomData,
         }
     }

--- a/src/cstr.rs
+++ b/src/cstr.rs
@@ -91,7 +91,7 @@ use crate::{DEFAULT_SYMBOL_TABLE_CAPACITY, Symbol, SymbolOverflowError};
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 #[cfg_attr(docsrs, doc(cfg(feature = "cstr")))]
 pub struct AllSymbols<'a> {
-    range: RangeInclusive<u32>,
+    range: Option<RangeInclusive<u32>>,
     // Hold a shared reference to the underlying `SymbolTable` to ensure the
     // table is not modified while we are iterating which would make the results
     // not match the real state.
@@ -102,37 +102,39 @@ impl Iterator for AllSymbols<'_> {
     type Item = Symbol;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.range.next().map(Symbol::from)
+        self.range.as_mut()?.next().map(Symbol::from)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        self.range.size_hint()
+        self.range
+            .as_ref()
+            .map_or((0, Some(0)), Iterator::size_hint)
     }
 
     fn count(self) -> usize {
-        self.range.count()
+        self.range.map_or(0, Iterator::count)
     }
 
     fn last(self) -> Option<Self::Item> {
-        self.range.last().map(Symbol::from)
+        self.range.and_then(Iterator::last).map(Symbol::from)
     }
 
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
-        self.range.nth(n).map(Symbol::from)
+        self.range.as_mut()?.nth(n).map(Symbol::from)
     }
 
     fn collect<B: FromIterator<Self::Item>>(self) -> B {
-        self.range.map(Symbol::from).collect()
+        self.range.into_iter().flatten().map(Symbol::from).collect()
     }
 }
 
 impl DoubleEndedIterator for AllSymbols<'_> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        self.range.next_back().map(Symbol::from)
+        self.range.as_mut()?.next_back().map(Symbol::from)
     }
 
     fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
-        self.range.nth_back(n).map(Symbol::from)
+        self.range.as_mut()?.nth_back(n).map(Symbol::from)
     }
 }
 
@@ -676,10 +678,10 @@ impl<S> SymbolTable<S> {
     /// ```
     pub fn all_symbols(&self) -> AllSymbols<'_> {
         AllSymbols {
-            range: match self.len() {
-                0 => RangeInclusive::new(1, 0),
-                len => 0..=u32::try_from(len - 1).unwrap_or(u32::MAX),
-            },
+            range: self
+                .len()
+                .checked_sub(1)
+                .map(|last| 0..=u32::try_from(last).unwrap_or(u32::MAX)),
             phantom: PhantomData,
         }
     }

--- a/src/cstr.rs
+++ b/src/cstr.rs
@@ -58,7 +58,7 @@ use core::hash::BuildHasher;
 use core::iter::{FromIterator, FusedIterator, Zip};
 use core::marker::PhantomData;
 use core::mem::ManuallyDrop;
-use core::ops::{Index, Range};
+use core::ops::{Index, RangeInclusive};
 use core::slice;
 use std::borrow::Cow;
 use std::collections::{
@@ -91,7 +91,7 @@ use crate::{DEFAULT_SYMBOL_TABLE_CAPACITY, Symbol, SymbolOverflowError};
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 #[cfg_attr(docsrs, doc(cfg(feature = "cstr")))]
 pub struct AllSymbols<'a> {
-    range: Range<usize>,
+    range: RangeInclusive<u32>,
     // Hold a shared reference to the underlying `SymbolTable` to ensure the
     // table is not modified while we are iterating which would make the results
     // not match the real state.
@@ -102,9 +102,7 @@ impl Iterator for AllSymbols<'_> {
     type Item = Symbol;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let next = self.range.next()?;
-        debug_assert!(u32::try_from(next).is_ok());
-        Some((next as u32).into())
+        self.range.next().map(Symbol::from)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -116,33 +114,25 @@ impl Iterator for AllSymbols<'_> {
     }
 
     fn last(self) -> Option<Self::Item> {
-        let last = self.range.last()?;
-        debug_assert!(u32::try_from(last).is_ok());
-        Some((last as u32).into())
+        self.range.last().map(Symbol::from)
     }
 
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
-        let nth = self.range.nth(n)?;
-        debug_assert!(u32::try_from(nth).is_ok());
-        Some((nth as u32).into())
+        self.range.nth(n).map(Symbol::from)
     }
 
     fn collect<B: FromIterator<Self::Item>>(self) -> B {
-        self.range.map(|sym| Symbol::from(sym as u32)).collect()
+        self.range.map(Symbol::from).collect()
     }
 }
 
 impl DoubleEndedIterator for AllSymbols<'_> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        let next = self.range.next_back()?;
-        debug_assert!(u32::try_from(next).is_ok());
-        Some((next as u32).into())
+        self.range.next_back().map(Symbol::from)
     }
 
     fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
-        let nth = self.range.nth_back(n)?;
-        debug_assert!(u32::try_from(nth).is_ok());
-        Some((nth as u32).into())
+        self.range.nth_back(n).map(Symbol::from)
     }
 }
 
@@ -686,7 +676,10 @@ impl<S> SymbolTable<S> {
     /// ```
     pub fn all_symbols(&self) -> AllSymbols<'_> {
         AllSymbols {
-            range: 0..self.len(),
+            range: match self.len() {
+                0 => RangeInclusive::new(1, 0),
+                len => 0..=u32::try_from(len - 1).unwrap_or(u32::MAX),
+            },
             phantom: PhantomData,
         }
     }

--- a/src/osstr.rs
+++ b/src/osstr.rs
@@ -93,7 +93,7 @@ use crate::{DEFAULT_SYMBOL_TABLE_CAPACITY, Symbol, SymbolOverflowError};
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 #[cfg_attr(docsrs, doc(cfg(feature = "osstr")))]
 pub struct AllSymbols<'a> {
-    range: RangeInclusive<u32>,
+    range: Option<RangeInclusive<u32>>,
     // Hold a shared reference to the underlying `SymbolTable` to ensure the
     // table is not modified while we are iterating which would make the results
     // not match the real state.
@@ -104,37 +104,39 @@ impl Iterator for AllSymbols<'_> {
     type Item = Symbol;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.range.next().map(Symbol::from)
+        self.range.as_mut()?.next().map(Symbol::from)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        self.range.size_hint()
+        self.range
+            .as_ref()
+            .map_or((0, Some(0)), Iterator::size_hint)
     }
 
     fn count(self) -> usize {
-        self.range.count()
+        self.range.map_or(0, Iterator::count)
     }
 
     fn last(self) -> Option<Self::Item> {
-        self.range.last().map(Symbol::from)
+        self.range.and_then(Iterator::last).map(Symbol::from)
     }
 
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
-        self.range.nth(n).map(Symbol::from)
+        self.range.as_mut()?.nth(n).map(Symbol::from)
     }
 
     fn collect<B: FromIterator<Self::Item>>(self) -> B {
-        self.range.map(Symbol::from).collect()
+        self.range.into_iter().flatten().map(Symbol::from).collect()
     }
 }
 
 impl DoubleEndedIterator for AllSymbols<'_> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        self.range.next_back().map(Symbol::from)
+        self.range.as_mut()?.next_back().map(Symbol::from)
     }
 
     fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
-        self.range.nth_back(n).map(Symbol::from)
+        self.range.as_mut()?.nth_back(n).map(Symbol::from)
     }
 }
 
@@ -681,10 +683,10 @@ impl<S> SymbolTable<S> {
     /// ```
     pub fn all_symbols(&self) -> AllSymbols<'_> {
         AllSymbols {
-            range: match self.len() {
-                0 => RangeInclusive::new(1, 0),
-                len => 0..=u32::try_from(len - 1).unwrap_or(u32::MAX),
-            },
+            range: self
+                .len()
+                .checked_sub(1)
+                .map(|last| 0..=u32::try_from(last).unwrap_or(u32::MAX)),
             phantom: PhantomData,
         }
     }

--- a/src/osstr.rs
+++ b/src/osstr.rs
@@ -59,7 +59,7 @@ use core::hash::BuildHasher;
 use core::iter::{FromIterator, FusedIterator, Zip};
 use core::marker::PhantomData;
 use core::mem::ManuallyDrop;
-use core::ops::{Index, Range};
+use core::ops::{Index, RangeInclusive};
 use core::slice;
 use std::borrow::Cow;
 use std::collections::{
@@ -93,7 +93,7 @@ use crate::{DEFAULT_SYMBOL_TABLE_CAPACITY, Symbol, SymbolOverflowError};
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 #[cfg_attr(docsrs, doc(cfg(feature = "osstr")))]
 pub struct AllSymbols<'a> {
-    range: Range<usize>,
+    range: RangeInclusive<u32>,
     // Hold a shared reference to the underlying `SymbolTable` to ensure the
     // table is not modified while we are iterating which would make the results
     // not match the real state.
@@ -104,9 +104,7 @@ impl Iterator for AllSymbols<'_> {
     type Item = Symbol;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let next = self.range.next()?;
-        debug_assert!(u32::try_from(next).is_ok());
-        Some((next as u32).into())
+        self.range.next().map(Symbol::from)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -118,33 +116,25 @@ impl Iterator for AllSymbols<'_> {
     }
 
     fn last(self) -> Option<Self::Item> {
-        let last = self.range.last()?;
-        debug_assert!(u32::try_from(last).is_ok());
-        Some((last as u32).into())
+        self.range.last().map(Symbol::from)
     }
 
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
-        let nth = self.range.nth(n)?;
-        debug_assert!(u32::try_from(nth).is_ok());
-        Some((nth as u32).into())
+        self.range.nth(n).map(Symbol::from)
     }
 
     fn collect<B: FromIterator<Self::Item>>(self) -> B {
-        self.range.map(|sym| Symbol::from(sym as u32)).collect()
+        self.range.map(Symbol::from).collect()
     }
 }
 
 impl DoubleEndedIterator for AllSymbols<'_> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        let next = self.range.next_back()?;
-        debug_assert!(u32::try_from(next).is_ok());
-        Some((next as u32).into())
+        self.range.next_back().map(Symbol::from)
     }
 
     fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
-        let nth = self.range.nth_back(n)?;
-        debug_assert!(u32::try_from(nth).is_ok());
-        Some((nth as u32).into())
+        self.range.nth_back(n).map(Symbol::from)
     }
 }
 
@@ -691,7 +681,10 @@ impl<S> SymbolTable<S> {
     /// ```
     pub fn all_symbols(&self) -> AllSymbols<'_> {
         AllSymbols {
-            range: 0..self.len(),
+            range: match self.len() {
+                0 => RangeInclusive::new(1, 0),
+                len => 0..=u32::try_from(len - 1).unwrap_or(u32::MAX),
+            },
             phantom: PhantomData,
         }
     }

--- a/src/path.rs
+++ b/src/path.rs
@@ -59,7 +59,7 @@ use core::hash::BuildHasher;
 use core::iter::{FromIterator, FusedIterator, Zip};
 use core::marker::PhantomData;
 use core::mem::ManuallyDrop;
-use core::ops::{Index, Range};
+use core::ops::{Index, RangeInclusive};
 use core::slice;
 use std::borrow::Cow;
 use std::collections::{
@@ -93,7 +93,7 @@ use crate::{DEFAULT_SYMBOL_TABLE_CAPACITY, Symbol, SymbolOverflowError};
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 #[cfg_attr(docsrs, doc(cfg(feature = "path")))]
 pub struct AllSymbols<'a> {
-    range: Range<usize>,
+    range: RangeInclusive<u32>,
     // Hold a shared reference to the underlying `SymbolTable` to ensure the
     // table is not modified while we are iterating which would make the results
     // not match the real state.
@@ -104,9 +104,7 @@ impl Iterator for AllSymbols<'_> {
     type Item = Symbol;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let next = self.range.next()?;
-        debug_assert!(u32::try_from(next).is_ok());
-        Some((next as u32).into())
+        self.range.next().map(Symbol::from)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -118,33 +116,25 @@ impl Iterator for AllSymbols<'_> {
     }
 
     fn last(self) -> Option<Self::Item> {
-        let last = self.range.last()?;
-        debug_assert!(u32::try_from(last).is_ok());
-        Some((last as u32).into())
+        self.range.last().map(Symbol::from)
     }
 
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
-        let nth = self.range.nth(n)?;
-        debug_assert!(u32::try_from(nth).is_ok());
-        Some((nth as u32).into())
+        self.range.nth(n).map(Symbol::from)
     }
 
     fn collect<B: FromIterator<Self::Item>>(self) -> B {
-        self.range.map(|sym| Symbol::from(sym as u32)).collect()
+        self.range.map(Symbol::from).collect()
     }
 }
 
 impl DoubleEndedIterator for AllSymbols<'_> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        let next = self.range.next_back()?;
-        debug_assert!(u32::try_from(next).is_ok());
-        Some((next as u32).into())
+        self.range.next_back().map(Symbol::from)
     }
 
     fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
-        let nth = self.range.nth_back(n)?;
-        debug_assert!(u32::try_from(nth).is_ok());
-        Some((nth as u32).into())
+        self.range.nth_back(n).map(Symbol::from)
     }
 }
 
@@ -691,7 +681,10 @@ impl<S> SymbolTable<S> {
     /// ```
     pub fn all_symbols(&self) -> AllSymbols<'_> {
         AllSymbols {
-            range: 0..self.len(),
+            range: match self.len() {
+                0 => RangeInclusive::new(1, 0),
+                len => 0..=u32::try_from(len - 1).unwrap_or(u32::MAX),
+            },
             phantom: PhantomData,
         }
     }

--- a/src/path.rs
+++ b/src/path.rs
@@ -93,7 +93,7 @@ use crate::{DEFAULT_SYMBOL_TABLE_CAPACITY, Symbol, SymbolOverflowError};
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 #[cfg_attr(docsrs, doc(cfg(feature = "path")))]
 pub struct AllSymbols<'a> {
-    range: RangeInclusive<u32>,
+    range: Option<RangeInclusive<u32>>,
     // Hold a shared reference to the underlying `SymbolTable` to ensure the
     // table is not modified while we are iterating which would make the results
     // not match the real state.
@@ -104,37 +104,39 @@ impl Iterator for AllSymbols<'_> {
     type Item = Symbol;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.range.next().map(Symbol::from)
+        self.range.as_mut()?.next().map(Symbol::from)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        self.range.size_hint()
+        self.range
+            .as_ref()
+            .map_or((0, Some(0)), Iterator::size_hint)
     }
 
     fn count(self) -> usize {
-        self.range.count()
+        self.range.map_or(0, Iterator::count)
     }
 
     fn last(self) -> Option<Self::Item> {
-        self.range.last().map(Symbol::from)
+        self.range.and_then(Iterator::last).map(Symbol::from)
     }
 
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
-        self.range.nth(n).map(Symbol::from)
+        self.range.as_mut()?.nth(n).map(Symbol::from)
     }
 
     fn collect<B: FromIterator<Self::Item>>(self) -> B {
-        self.range.map(Symbol::from).collect()
+        self.range.into_iter().flatten().map(Symbol::from).collect()
     }
 }
 
 impl DoubleEndedIterator for AllSymbols<'_> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        self.range.next_back().map(Symbol::from)
+        self.range.as_mut()?.next_back().map(Symbol::from)
     }
 
     fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
-        self.range.nth_back(n).map(Symbol::from)
+        self.range.as_mut()?.nth_back(n).map(Symbol::from)
     }
 }
 
@@ -681,10 +683,10 @@ impl<S> SymbolTable<S> {
     /// ```
     pub fn all_symbols(&self) -> AllSymbols<'_> {
         AllSymbols {
-            range: match self.len() {
-                0 => RangeInclusive::new(1, 0),
-                len => 0..=u32::try_from(len - 1).unwrap_or(u32::MAX),
-            },
+            range: self
+                .len()
+                .checked_sub(1)
+                .map(|last| 0..=u32::try_from(last).unwrap_or(u32::MAX)),
             phantom: PhantomData,
         }
     }

--- a/src/str.rs
+++ b/src/str.rs
@@ -35,7 +35,7 @@ use crate::{DEFAULT_SYMBOL_TABLE_CAPACITY, Symbol, SymbolOverflowError};
 /// ```
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub struct AllSymbols<'a> {
-    range: RangeInclusive<u32>,
+    range: Option<RangeInclusive<u32>>,
     // Hold a shared reference to the underlying `SymbolTable` to ensure the
     // table is not modified while we are iterating which would make the results
     // not match the real state.
@@ -46,37 +46,39 @@ impl Iterator for AllSymbols<'_> {
     type Item = Symbol;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.range.next().map(Symbol::from)
+        self.range.as_mut()?.next().map(Symbol::from)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        self.range.size_hint()
+        self.range
+            .as_ref()
+            .map_or((0, Some(0)), Iterator::size_hint)
     }
 
     fn count(self) -> usize {
-        self.range.count()
+        self.range.map_or(0, Iterator::count)
     }
 
     fn last(self) -> Option<Self::Item> {
-        self.range.last().map(Symbol::from)
+        self.range.and_then(Iterator::last).map(Symbol::from)
     }
 
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
-        self.range.nth(n).map(Symbol::from)
+        self.range.as_mut()?.nth(n).map(Symbol::from)
     }
 
     fn collect<B: FromIterator<Self::Item>>(self) -> B {
-        self.range.map(Symbol::from).collect()
+        self.range.into_iter().flatten().map(Symbol::from).collect()
     }
 }
 
 impl DoubleEndedIterator for AllSymbols<'_> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        self.range.next_back().map(Symbol::from)
+        self.range.as_mut()?.next_back().map(Symbol::from)
     }
 
     fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
-        self.range.nth_back(n).map(Symbol::from)
+        self.range.as_mut()?.nth_back(n).map(Symbol::from)
     }
 }
 
@@ -599,10 +601,10 @@ impl<S> SymbolTable<S> {
     /// ```
     pub fn all_symbols(&self) -> AllSymbols<'_> {
         AllSymbols {
-            range: match self.len() {
-                0 => RangeInclusive::new(1, 0),
-                len => 0..=u32::try_from(len - 1).unwrap_or(u32::MAX),
-            },
+            range: self
+                .len()
+                .checked_sub(1)
+                .map(|last| 0..=u32::try_from(last).unwrap_or(u32::MAX)),
             phantom: PhantomData,
         }
     }

--- a/src/str.rs
+++ b/src/str.rs
@@ -4,7 +4,7 @@ use core::hash::BuildHasher;
 use core::iter::{FromIterator, FusedIterator, Zip};
 use core::marker::PhantomData;
 use core::mem::ManuallyDrop;
-use core::ops::{Index, Range};
+use core::ops::{Index, RangeInclusive};
 use core::slice;
 use std::borrow::Cow;
 use std::collections::{
@@ -35,7 +35,7 @@ use crate::{DEFAULT_SYMBOL_TABLE_CAPACITY, Symbol, SymbolOverflowError};
 /// ```
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub struct AllSymbols<'a> {
-    range: Range<usize>,
+    range: RangeInclusive<u32>,
     // Hold a shared reference to the underlying `SymbolTable` to ensure the
     // table is not modified while we are iterating which would make the results
     // not match the real state.
@@ -46,9 +46,7 @@ impl Iterator for AllSymbols<'_> {
     type Item = Symbol;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let next = self.range.next()?;
-        debug_assert!(u32::try_from(next).is_ok());
-        Some((next as u32).into())
+        self.range.next().map(Symbol::from)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -60,33 +58,25 @@ impl Iterator for AllSymbols<'_> {
     }
 
     fn last(self) -> Option<Self::Item> {
-        let last = self.range.last()?;
-        debug_assert!(u32::try_from(last).is_ok());
-        Some((last as u32).into())
+        self.range.last().map(Symbol::from)
     }
 
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
-        let nth = self.range.nth(n)?;
-        debug_assert!(u32::try_from(nth).is_ok());
-        Some((nth as u32).into())
+        self.range.nth(n).map(Symbol::from)
     }
 
     fn collect<B: FromIterator<Self::Item>>(self) -> B {
-        self.range.map(|sym| Symbol::from(sym as u32)).collect()
+        self.range.map(Symbol::from).collect()
     }
 }
 
 impl DoubleEndedIterator for AllSymbols<'_> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        let next = self.range.next_back()?;
-        debug_assert!(u32::try_from(next).is_ok());
-        Some((next as u32).into())
+        self.range.next_back().map(Symbol::from)
     }
 
     fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
-        let nth = self.range.nth_back(n)?;
-        debug_assert!(u32::try_from(nth).is_ok());
-        Some((nth as u32).into())
+        self.range.nth_back(n).map(Symbol::from)
     }
 }
 
@@ -609,7 +599,10 @@ impl<S> SymbolTable<S> {
     /// ```
     pub fn all_symbols(&self) -> AllSymbols<'_> {
         AllSymbols {
-            range: 0..self.len(),
+            range: match self.len() {
+                0 => RangeInclusive::new(1, 0),
+                len => 0..=u32::try_from(len - 1).unwrap_or(u32::MAX),
+            },
             phantom: PhantomData,
         }
     }


### PR DESCRIPTION
## Summary

- store every `AllSymbols` iterator range as `RangeInclusive<u32>`
- convert to `Symbol` directly from the range item instead of casting from `usize`
- preserve the full symbol domain, including the theoretical `u32::MAX` symbol ID

## Verification

- `cargo fmt --check`
- `cargo test`
- `cargo test --all-features`
- `cargo clippy --workspace --all-features --all-targets`
