### PR TITLE
Prepare 1.15.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "intaglio"
-version = "1.14.0" # remember to set `html_root_url` in `src/lib.rs`.
+version = "1.15.0" # remember to set `html_root_url` in `src/lib.rs`.
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "Apache-2.0 OR MIT"
 edition = "2024"

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-intaglio = "1.14.0"
+intaglio = "1.15.0"
 ```
 
 Then intern UTF-8 strings like:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,7 +115,7 @@
 //! [`&Path`]: std::path::Path
 //! [`&'static Path`]: std::path::Path
 
-#![doc(html_root_url = "https://docs.rs/intaglio/1.14.0")]
+#![doc(html_root_url = "https://docs.rs/intaglio/1.15.0")]
 
 use core::fmt;
 use core::num::TryFromIntError;


### PR DESCRIPTION
## Summary

- bump crate version to `1.15.0`
- update the README dependency snippet to `1.15.0`
- update `html_root_url` for docs.rs `1.15.0`

## Release notes

This release includes the optional `bstr` symbol table, the recently added
symbol table container APIs, and the `AllSymbols` iterator cleanup.

## Verification

- `cargo fmt --check`
- `cargo test`
- `cargo test --all-features`
- `cargo clippy --workspace --all-features --all-targets`
- `mise exec -- pnpm run fmt`
- `cargo package --allow-dirty`

`npm run fmt` could not be run directly because `npm` is not available on `PATH`;
the same formatter was run through `mise exec -- pnpm run fmt`.
