### PR TITLE
Add intaglio runner image automation

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   rust:
     name: Audit Rust Dependencies
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         checks:
@@ -53,7 +53,7 @@ jobs:
 
   zizmor:
     name: Run zizmor 🌈
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read # required to checkout repository
       security-events: write # required to add findings via sarif

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,13 +21,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-24.04, windows-2025-vs2026, macos-26]
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
-          - os: windows-latest
+          - os: windows-2025-vs2026
             target: x86_64-pc-windows-msvc
-          - os: macos-latest
+          - os: macos-26
             target: x86_64-apple-darwin
     env:
       RUSTFLAGS: -D warnings
@@ -64,11 +64,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-24.04, windows-2025-vs2026]
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             target: i686-unknown-linux-gnu
-          - os: windows-latest
+          - os: windows-2025-vs2026
             target: i686-pc-windows-msvc
     env:
       RUSTFLAGS: -D warnings
@@ -87,7 +87,7 @@ jobs:
         shell: bash
 
       - name: Install 32-bit platform support
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-24.04'
         run: sudo apt-get update && sudo apt install gcc-multilib
 
       - name: Compile
@@ -112,7 +112,7 @@ jobs:
 
   build-msrv:
     name: Build (MSRV)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       CARGO_INCREMENTAL: 0
       RUSTFLAGS: -D warnings
@@ -150,9 +150,9 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-latest
+          - ubuntu-24.04
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
     env:
       RUSTFLAGS: -D warnings
@@ -180,7 +180,7 @@ jobs:
 
   rust:
     name: Lint and format Rust
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       RUSTFLAGS: -D warnings
       RUST_BACKTRACE: 1
@@ -218,7 +218,7 @@ jobs:
 
   text:
     name: Lint and format text
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/code-coverage.yaml
+++ b/.github/workflows/code-coverage.yaml
@@ -18,7 +18,7 @@ jobs:
     permissions:
       id-token: write # needed to do OIDC dance with AWS
       contents: read # needed to checkout contents
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       RUST_BACKTRACE: 1
       CARGO_NET_GIT_FETCH_WITH_CLI: true

--- a/.github/workflows/miri.yaml
+++ b/.github/workflows/miri.yaml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   miri:
     name: Test with Miri
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       RUST_BACKTRACE: 1
       MIRIFLAGS: "-Zmiri-strict-provenance -Zmiri-symbolic-alignment-check -Zrandomize-layout"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -14,7 +14,7 @@ jobs:
   crates-io:
     name: Publish to crates.io
     if: github.event.created == true
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment:
       name: crates-io-publish
     permissions:

--- a/.github/workflows/repo-labels.yaml
+++ b/.github/workflows/repo-labels.yaml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   labels:
     name: Synchronize repository labels
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read # required to checkout
       issues: write # required to create and destroy labels

--- a/docs/automations/README.md
+++ b/docs/automations/README.md
@@ -1,0 +1,16 @@
+# Automation Conventions
+
+Automations should keep machine-authored output distinguishable from human
+feedback so follow-up runs can learn from the right signals.
+
+Automation-authored pull request comments must start with the stable prefix
+`Codex automation note:`. Treat comments with that prefix as automation state,
+not human feedback for automation learning loops.
+
+Document each scheduled automation in this directory and keep the actual
+automation prompt slim. The prompt should identify the role and tell the
+automation to read and follow its documentation in this repository.
+
+Current automations:
+
+- [GitHub Actions Runner Images](./github-actions-runner-images.md)

--- a/docs/automations/github-actions-runner-images.md
+++ b/docs/automations/github-actions-runner-images.md
@@ -1,0 +1,150 @@
+# GitHub Actions Runner Images Automation
+
+The GitHub Actions runner images automation is a scheduled repository
+maintenance role for keeping workflow runner labels aligned with GitHub-hosted
+runner image support status. It should catch upcoming image migrations,
+deprecations, brownouts, and retirements early enough that this repository's CI
+keeps exercising maintained Linux, Windows, and macOS targets.
+
+The automation must read `docs/automations/README.md` and this document before
+running. Human feedback on any output it produces, including inbox follow-ups,
+pull request comments, review decisions, failed validation, or missed runner
+image changes, should be reviewed and used to update this document before
+repeating the same class of issue. Automation-authored pull request comments
+must start with the stable prefix `Codex automation note:`. Treat comments with
+that prefix as automation state, not human feedback for this learning loop.
+
+## Schedule
+
+Run once per week against this repository. GitHub runner image changes are
+announced with lead time, so a weekly cadence is enough.
+
+## Scope
+
+Review GitHub Actions workflow files under `.github/workflows/`, with emphasis
+on `runs-on` labels and runner-image-sensitive assumptions.
+
+This repository is a portable Rust string interner crate. The most important
+coverage is:
+
+- current generally available Ubuntu, Windows, and macOS images;
+- explicit OS labels where stable, explainable coverage matters;
+- 64-bit Linux, Windows, and macOS build coverage;
+- 32-bit Linux and Windows build coverage;
+- MSRV, Miri, leak sanitizer, coverage, publish, repository label, lint, and
+  formatting jobs that should avoid surprise OS changes unless the workflow
+  intentionally tracks `*-latest`.
+
+Do not update pinned GitHub Actions versions in this automation. Dependabot owns
+GitHub Actions dependency updates.
+
+## Sources
+
+Use authoritative current sources. Do not rely on memory for runner image state.
+At minimum, inspect:
+
+- the `actions/runner-images` README for currently available image labels;
+- open issues in `actions/runner-images` with the `Announcement` label;
+- GitHub-hosted runner documentation when label semantics or hardware
+  availability are unclear;
+- this repository's recent CI runs if a label appears questionable.
+
+When a source is date-sensitive, include concrete dates in the inbox summary and
+pull request description.
+
+## Decision Rules
+
+Prefer explicit OS labels over `*-latest` for jobs where stable, explainable
+coverage matters. `*-latest` is acceptable only when the job is intentionally
+exercising GitHub's moving default.
+
+For cross-platform build coverage, keep the matrix on maintained GA images for
+Ubuntu, Windows, and macOS. When a new OS image becomes GA, add it before the
+previous default migrates. When an older image enters deprecation, remove it
+before brownouts begin unless there is a documented compatibility reason to keep
+it.
+
+For MSRV, Miri, leak sanitizer, coverage, publish, repository label, lint,
+formatting, and documentation jobs, prefer explicit maintained labels unless the
+workflow intentionally follows a moving default.
+
+## Changes
+
+If runner image state indicates no repository change is needed, do not create a
+branch, commit, push, or pull request. Open an inbox item with the checked
+labels, source links, and next relevant dates.
+
+If changes are needed, edit the relevant workflow files and keep the diff scoped
+to runner image maintenance. Then create one commit and one pull request.
+
+If workflow matrix labels change, check whether required status-check contexts
+in GitHub branch rulesets also need to change. The `gh ruleset` command can list
+and view rulesets, but ruleset updates currently go through `gh api`:
+
+```sh
+gh ruleset list --repo artichoke/intaglio
+gh api repos/artichoke/intaglio/rulesets/<ruleset-id> \
+  --jq '.rules[] | select(.type == "required_status_checks").parameters.required_status_checks[].context'
+```
+
+When the required-check list needs updating, fetch the full ruleset, build an
+update payload from its editable fields, update the `required_status_checks`
+contexts, and put the ruleset back:
+
+```sh
+gh api repos/artichoke/intaglio/rulesets/<ruleset-id> > /tmp/intaglio-ruleset.json
+jq '{name, target, enforcement, conditions, bypass_actors, rules}' \
+  /tmp/intaglio-ruleset.json > /tmp/intaglio-ruleset.update.json
+# Edit /tmp/intaglio-ruleset.update.json so required check contexts match the
+# workflow job names produced by the new matrix.
+gh api -X PUT repos/artichoke/intaglio/rulesets/<ruleset-id> \
+  --input /tmp/intaglio-ruleset.update.json
+```
+
+Ruleset edits are repository configuration changes, not git changes. Mention any
+ruleset contexts inspected or updated in the pull request and inbox summary. If
+the automation cannot update the ruleset because of permissions, open the pull
+request anyway and lead the inbox item with the exact required-check contexts
+that need manual ruleset changes.
+
+Pull requests from this automation must include the `A-build` and `C-automation`
+labels, plus the `codex` label. Include source links for runner image
+announcements and explain any upcoming deprecation, brownout, or latest label
+migration dates.
+
+Do not enable auto-merge if:
+
+- a runner label is in beta or preview;
+- a change drops an OS family without replacement;
+- a recent CI run failed for reasons that could be related to the runner image;
+- the source announcements are ambiguous or internally inconsistent.
+
+For low-risk mechanical label updates with passing validation, enabling
+auto-merge is acceptable.
+
+## Validation and Summary
+
+For workflow-only edits, run:
+
+```sh
+git diff --check
+npx prettier --check '**/*'
+```
+
+If `actionlint` is available, run it against the changed workflows. If it is not
+available, say so in the inbox summary and pull request.
+
+If Rust code or manifests are touched, also run the relevant Rust checks for the
+touched files. Runner image maintenance should not normally require Rust source
+changes.
+
+Open an inbox item after every run summarizing:
+
+- runner labels reviewed;
+- current GitHub support state for those labels;
+- source links used;
+- upcoming migration, deprecation, brownout, or retirement dates;
+- changes made or why no change was needed;
+- branch ruleset required-check contexts inspected or updated;
+- validation run and any skipped checks;
+- pull request and auto-merge status, if a pull request was opened.


### PR DESCRIPTION
**Summary**
- Add repo-local automation conventions plus a GitHub Actions runner image maintenance runbook.
- Pin GitHub-hosted runner labels across workflows to explicit current GA labels: ubuntu-24.04, windows-2025-vs2026, and macos-26.
- Install the app automation as a thin weekly dispatch to the repo runbook.

**Runner image notes**
- actions/runner-images lists ubuntu-24.04, windows-2025-vs2026, and macos-26 as available labels.
- GitHub announced windows-latest and windows-2025 migration to the VS 2026 image from June 8, 2026 through June 15, 2026.
- GitHub announced macos-latest migration to macOS 26 beginning June 15, 2026 over 30 days.
- macOS 26 became generally available on February 26, 2026; Windows Server 2025 with Visual Studio 2026 became generally available on May 7, 2026.

Sources:
- https://github.com/actions/runner-images
- https://github.blog/changelog/2026-05-14-github-actions-upcoming-image-migrations/
- https://github.blog/changelog/2026-02-26-macos-26-is-now-generally-available-for-github-hosted-runners/
- https://github.com/actions/runner-images/issues/14016

**Repository configuration**
- Updated ruleset 16558264 required check contexts from Build (macos-latest), Build (ubuntu-latest), Build (windows-latest), Build 32-bit (ubuntu-latest), and Build 32-bit (windows-latest) to Build (macos-26), Build (ubuntu-24.04), Build (windows-2025-vs2026), Build 32-bit (ubuntu-24.04), and Build 32-bit (windows-2025-vs2026).

**Automation setup**
- Installed intaglio-github-actions-runner-images as a weekly Tuesday 12:00 dispatch to docs/automations/github-actions-runner-images.md.

**Validation**
- git diff --check
- ruby -ryaml -e ARGV.each... for .github/workflows/*.yaml and .github/labels.yaml
- npx prettier --check "**/*"
- GitHub commit signature verification is valid
- actionlint was not available in this environment.