### PR TITLE
Add Rust guardrails and agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,60 +1,62 @@
-# Repository Guidelines
+# Repository Map
 
-## Project Structure & Modules
+This file is a map for agents working in this repository. It points to the
+source-of-truth docs, configuration, and code landmarks; it should not duplicate
+the policy held by those files.
 
-- `src/` holds the library; key tables live in `bytes.rs`, `cstr.rs`,
-  `osstr.rs`, and `path.rs`, with shared internals in `internal.rs` and exports
-  in `lib.rs`.
-- `tests/` contains integration tests; the `leak_drop/` suite exercises drop
-  safety across symbol table types.
-- Tooling configs: `Cargo.toml` for Rust deps, `deny.toml` for cargo-deny,
-  `.config/spellcheck.toml` for spellchecking, and `package.json` for optional
-  prettier tooling.
+## Start Here
 
-## Build, Test, and Development Commands
+- `README.md`: crate purpose, supported interned value types, and public
+  examples.
+- `CONTRIBUTING.md`: local development setup and command expectations.
+- `Cargo.toml`: crate metadata, feature flags, MSRV, dependency ranges, and
+  docs.rs metadata.
+- `docs/guardrails/README.md`: index for Rust, OSS, unsafe, platform, testing,
+  API, FFI, and performance guardrails.
+- `docs/dependencies.md`: dependency and supply-chain posture.
+- `docs/automations/README.md`: recurring maintenance map.
+- `.github/labels.yaml`: PR label vocabulary for this repository.
 
-- `cargo build` – compile the crate with default features.
-- `cargo test` – run the full test suite; append a filter (e.g.,
-  `cargo test drop`) to target specific cases.
-- `cargo fmt` – format Rust sources with rustfmt.
-- `cargo clippy --workspace --all-features --all-targets` – lint Rust sources.
-- `pnpm run fmt` – format text, YAML, and Markdown sources with prettier.
-- `cargo doc --open` – build and open API docs locally.
+## Change Map
 
-## Coding Style & Naming
+- Public API, semver, features, MSRV, or publishing:
+  `docs/guardrails/api-stability-semver-and-msrv.md`,
+  `docs/guardrails/working-in-public-and-publishing-oss-crates.md`,
+  `Cargo.toml`, `README.md`, and `src/lib.rs`.
+- Rust implementation quality, lints, error handling, or docs:
+  `docs/guardrails/high-quality-rust-code.md`, `CONTRIBUTING.md`, `src/lib.rs`,
+  and `.github/workflows/ci.yaml`.
+- Unsafe, lifetime, allocation, panic, or rollback behavior:
+  `docs/guardrails/unsafe-code.md`,
+  `docs/guardrails/performance-allocation-and-memory-behavior.md`,
+  `src/internal.rs`, `src/rollback.rs`, and `.github/workflows/miri.yaml`.
+- Tests, feature matrix, or compatibility coverage:
+  `docs/guardrails/testing-compatibility-and-conformance.md`,
+  `tests/leak_drop/`, `tests/unwind_safety.rs`, and `.github/workflows/ci.yaml`.
+- Dependency, audit, or runner maintenance: `docs/dependencies.md`,
+  `docs/automations/dependency-sweep.md`,
+  `docs/automations/github-actions-runner-images.md`, `.github/dependabot.yml`,
+  `.github/workflows/audit.yaml`, and `.github/workflows/repo-labels.yaml`.
+- Markdown, YAML, JSON, or generated formatting changes: `package.json`,
+  `.prettierrc.yaml`, and `pnpm-lock.yaml`.
 
-- Rust code is formatted with `rustfmt`; use 4-space indents, `snake_case` for
-  functions/modules, `CamelCase` for types, and `SCREAMING_SNAKE_CASE` for
-  consts.
-- Avoid unsafe unless justified; keep `unsafe` blocks small and commented.
-- Prefer `?` for error propagation and `Result<T, E>` returns over panics in
-  library code.
-- Keep public API docs (`///`) concise; add examples when behavior is subtle.
+## Code Map
 
-## Testing Guidelines
+- `src/lib.rs`: crate-level docs, feature gates, lint configuration, and public
+  exports.
+- `src/str.rs`, `src/bytes.rs`, `src/bstr.rs`, `src/cstr.rs`, `src/osstr.rs`,
+  and `src/path.rs`: type-specific interner implementations.
+- `src/internal.rs`: shared interner internals and the main unsafe boundary.
+- `src/rollback.rs`: rollback helpers for partially completed insertions.
+- `src/convert.rs` and `src/eq.rs`: conversion and equality support shared by
+  the public interners.
+- `tests/leak_drop/`: drop and leak behavior coverage by interned type.
+- `tests/unwind_safety.rs`: panic and unwind-safety coverage.
 
-- Default to `cargo test`; integration tests live under `tests/`.
-- Add focused tests near regressions; mirror naming like `*_drop` for
-  drop-behavior cases.
-- When changing internals, cover both borrowed and owned symbol paths and check
-  token stability.
-- Run tests with `MIRI_SYSROOT` in CI is handled; local Miri runs are optional
-  but welcome.
+## Pull Request Map
 
-## Commit & Pull Request Guidelines
-
-- Commit messages follow imperative tone with a short summary (≈50 chars) and
-  optional body explaining the why.
-- For PRs: describe the change, note user-visible API impacts, link issues, and
-  mention new tests. Include screenshots only if docs/UI artifacts change (rare
-  here).
-- Ensure `cargo fmt`, `cargo clippy --workspace --all-features --all-targets`,
-  `pnpm run fmt`, and `cargo test` pass before requesting review; CI must be
-  green.
-
-## Security & Configuration Tips
-
-- Keep toolchains in sync with `mise.toml` and Rust stable (see README); bump
-  MSRV only with justification.
-- Use `cargo deny check` before dependency updates; update the advisory DB with
-  `cargo deny --all-features --locked check` if needed.
+- Use labels from `.github/labels.yaml`; lopopolo-owned repositories require at
+  least one `A-*` label.
+- For automation-generated work, use `C-automation` and add the `codex` label.
+  Keep `codex` as the last label definition in `.github/labels.yaml`.
+- Do not add a Codex tag to PR titles or descriptions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,62 +1,130 @@
-# Repository Map
+# Agent Instructions
 
-This file is a map for agents working in this repository. It points to the
-source-of-truth docs, configuration, and code landmarks; it should not duplicate
-the policy held by those files.
+You are working in `artichoke/intaglio`, a Rust crate that provides symbol
+interners for strings, bytes, C strings, OS strings, and paths.
 
-## Start Here
+Users rely on stable token and lookup behavior, feature-gated interner families,
+panic rollback behavior, allocation behavior, MSRV, and the public crate API.
+Treat those as compatibility surfaces.
 
-- `README.md`: crate purpose, supported interned value types, and public
-  examples.
-- `CONTRIBUTING.md`: local development setup and command expectations.
-- `Cargo.toml`: crate metadata, feature flags, MSRV, dependency ranges, and
-  docs.rs metadata.
-- `docs/guardrails/README.md`: index for Rust, OSS, unsafe, platform, testing,
-  API, FFI, and performance guardrails.
-- `docs/dependencies.md`: dependency and supply-chain posture.
-- `docs/automations/README.md`: recurring maintenance map.
-- `.github/labels.yaml`: PR label vocabulary for this repository.
+## Operating Loop
 
-## Change Map
+1. Classify the change before editing.
+2. Use the matching workflow section below to choose the guardrails and runbooks
+   to consult.
+3. Keep the diff narrow. Do not mix behavior, dependency posture, release
+   metadata, formatting, and automation cleanup unless the task requires it.
+4. Add or update focused tests for behavior changes, especially changes that can
+   affect interning, lookup, rollback, or drop behavior.
+5. Run checks that match the risk of the change; use
+   [CONTRIBUTING.md](CONTRIBUTING.md) for local command expectations. If a
+   relevant check is skipped, explain why in the PR.
+6. Update README, crate docs, guardrails, or runbooks when public behavior,
+   compatibility claims, feature behavior, MSRV, dependency policy, or release
+   process changes.
 
-- Public API, semver, features, MSRV, or publishing:
-  `docs/guardrails/api-stability-semver-and-msrv.md`,
-  `docs/guardrails/working-in-public-and-publishing-oss-crates.md`,
-  `Cargo.toml`, `README.md`, and `src/lib.rs`.
-- Rust implementation quality, lints, error handling, or docs:
-  `docs/guardrails/high-quality-rust-code.md`, `CONTRIBUTING.md`, `src/lib.rs`,
-  and `.github/workflows/ci.yaml`.
-- Unsafe, lifetime, allocation, panic, or rollback behavior:
-  `docs/guardrails/unsafe-code.md`,
-  `docs/guardrails/performance-allocation-and-memory-behavior.md`,
-  `src/internal.rs`, `src/rollback.rs`, and `.github/workflows/miri.yaml`.
-- Tests, feature matrix, or compatibility coverage:
-  `docs/guardrails/testing-compatibility-and-conformance.md`,
-  `tests/leak_drop/`, `tests/unwind_safety.rs`, and `.github/workflows/ci.yaml`.
-- Dependency, audit, or runner maintenance: `docs/dependencies.md`,
-  `docs/automations/dependency-sweep.md`,
-  `docs/automations/github-actions-runner-images.md`, `.github/dependabot.yml`,
-  `.github/workflows/audit.yaml`, and `.github/workflows/repo-labels.yaml`.
-- Markdown, YAML, JSON, or generated formatting changes: `package.json`,
-  `.prettierrc.yaml`, and `pnpm-lock.yaml`.
+## Interner Behavior And Compatibility
 
-## Code Map
+Use this workflow for changes to token allocation, lookup semantics, insertion,
+rollback on panic, drop behavior, or feature-gated interner behavior.
 
-- `src/lib.rs`: crate-level docs, feature gates, lint configuration, and public
-  exports.
-- `src/str.rs`, `src/bytes.rs`, `src/bstr.rs`, `src/cstr.rs`, `src/osstr.rs`,
-  and `src/path.rs`: type-specific interner implementations.
-- `src/internal.rs`: shared interner internals and the main unsafe boundary.
-- `src/rollback.rs`: rollback helpers for partially completed insertions.
-- `src/convert.rs` and `src/eq.rs`: conversion and equality support shared by
-  the public interners.
-- `tests/leak_drop/`: drop and leak behavior coverage by interned type.
-- `tests/unwind_safety.rs`: panic and unwind-safety coverage.
+Consult:
 
-## Pull Request Map
+- [Testing and conformance](docs/guardrails/testing-compatibility-and-conformance.md),
+  for regression coverage and feature-matrix expectations.
+- [Performance, allocation, and memory behavior](docs/guardrails/performance-allocation-and-memory-behavior.md),
+  for allocation and hot-path behavior.
+- [API stability, semver, and MSRV](docs/guardrails/api-stability-semver-and-msrv.md),
+  if behavior changes affect public expectations.
 
-- Use labels from `.github/labels.yaml`; lopopolo-owned repositories require at
-  least one `A-*` label.
-- For automation-generated work, use `C-automation` and add the `codex` label.
-  Keep `codex` as the last label definition in `.github/labels.yaml`.
-- Do not add a Codex tag to PR titles or descriptions.
+Preserve existing token and lookup semantics unless the task explicitly asks for
+a breaking compatibility change.
+
+## Public API, Features, MSRV, And Releases
+
+Use this workflow for API shape, feature flags, docs.rs metadata, crate
+metadata, MSRV, semver, publishing, changelog, and release-readiness changes.
+
+Consult:
+
+- [API stability, semver, and MSRV](docs/guardrails/api-stability-semver-and-msrv.md),
+  for public contract and compatibility impact.
+- [Working in public and publishing](docs/guardrails/working-in-public-and-publishing-oss-crates.md),
+  for OSS release and communication expectations.
+
+Call out compatibility impact in the PR. Keep release-prep changes separate from
+unrelated implementation cleanup.
+
+## Unsafe, Lifetimes, And Memory Safety
+
+Use this workflow for unsafe internals, lifetime relationships, pointer or slice
+handling, panic paths, and changes that affect drop or leak behavior.
+
+Consult:
+
+- [Unsafe code](docs/guardrails/unsafe-code.md), for safety documentation,
+  containment, and review expectations.
+- [Performance, allocation, and memory behavior](docs/guardrails/performance-allocation-and-memory-behavior.md),
+  for allocation and memory-behavior expectations.
+- [Testing and conformance](docs/guardrails/testing-compatibility-and-conformance.md),
+  for Miri and targeted regression coverage.
+
+Keep unsafe boundaries small and explain any new unsafe requirement in code and
+in the PR.
+
+## Implementation Quality
+
+Use this workflow for refactors, lint posture, error handling, documentation
+quality, crate attributes, and maintainability changes that do not intentionally
+change behavior.
+
+Consult:
+
+- [High-quality Rust code](docs/guardrails/high-quality-rust-code.md), for lint,
+  documentation, and maintainability expectations.
+- [Testing and conformance](docs/guardrails/testing-compatibility-and-conformance.md),
+  if the refactor touches behavior-sensitive paths.
+
+Prefer mechanical refactors that preserve behavior and are easy to review.
+
+## Dependencies, CI, And Automation
+
+Use this workflow for dependency ranges, audits, Dependabot, GitHub Actions,
+runner image updates, labels, and recurring maintenance.
+
+Consult:
+
+- [Dependency posture](docs/dependencies.md), for supply-chain expectations.
+- [Dependency sweep automation](docs/automations/dependency-sweep.md), for
+  dependency update procedure.
+- [GitHub Actions runner images](docs/automations/github-actions-runner-images.md),
+  for runner maintenance.
+- [Working in public and publishing](docs/guardrails/working-in-public-and-publishing-oss-crates.md),
+  if the change affects release or user-facing maintenance policy.
+
+Keep mechanical dependency and automation updates separate from behavior
+changes.
+
+## Documentation-Only Changes
+
+Use this workflow for README, crate docs, guardrails, runbooks, and PR/process
+documentation.
+
+Consult:
+
+- [High-quality Rust code](docs/guardrails/high-quality-rust-code.md), for
+  documentation quality expectations.
+- [Working in public and publishing](docs/guardrails/working-in-public-and-publishing-oss-crates.md),
+  for public-facing OSS communication.
+- The guardrail for the topic being documented when docs describe API, unsafe
+  code, compatibility, dependency, performance, or release behavior.
+
+Docs-only PRs may skip Rust tests when the PR explains why. Still run the repo
+formatter.
+
+## Pull Requests
+
+- State the change class and compatibility impact.
+- Use labels from `.github/labels.yaml`; include at least one `A-*` label.
+- For automation-generated work, use `C-automation` and the `codex` label.
+- Do not add a Codex tag to the title or description.

--- a/docs/guardrails/README.md
+++ b/docs/guardrails/README.md
@@ -1,0 +1,30 @@
+# Artichoke Rust Guardrails
+
+These documents are operating guardrails for maintaining Artichoke Rust crates.
+They are written to make project judgment explicit enough for humans and coding
+agents to apply consistently.
+
+Read the guardrails that match the change before editing code, tests,
+documentation, automation, or release metadata.
+
+## Guardrails
+
+- [Working in Public and Publishing OSS Crates](working-in-public-and-publishing-oss-crates.md)
+- [High Quality Rust Code](high-quality-rust-code.md)
+- [Testing, Compatibility, and Conformance](testing-compatibility-and-conformance.md)
+- [API Stability, SemVer, and MSRV](api-stability-semver-and-msrv.md)
+- [Working with Unsafe Code](unsafe-code.md)
+- [FFI, Bindings, and Foreign Runtime Integration](ffi-bindings-and-foreign-runtime-integration.md)
+- [Platform Specific Code](platform-specific-code.md)
+- [Performance, Allocation, and Memory Behavior](performance-allocation-and-memory-behavior.md)
+
+## Repository Posture
+
+This repository also has dependency and automation posture docs:
+
+- [Dependency and Supply Chain Posture](../dependencies.md)
+- [Dependency Sweep Automation](../automations/dependency-sweep.md)
+
+Treat these docs as part of the same maintenance harness. If a change violates
+one of these guardrails, update the guardrail in the same pull request or
+explain the exception in the pull request body.

--- a/docs/guardrails/api-stability-semver-and-msrv.md
+++ b/docs/guardrails/api-stability-semver-and-msrv.md
@@ -1,0 +1,286 @@
+# API Stability, SemVer, and MSRV
+
+Artichoke crates should make compatibility decisions deliberately. A crate's
+public contract includes more than public Rust items. It includes feature flags,
+trait impls, target support, error behavior, panic behavior, docs.rs output,
+dependency ranges, and the minimum supported Rust version.
+
+This guardrail is grounded in active crates such as `rand_mt`, `intaglio`,
+`sysdir`, and `known-folders`, plus historical crates such as `boba`,
+`raw-parts`, `qed`, `strudel`, and `cactusref`.
+
+## Default Stance
+
+- Treat published APIs as permanent until a major release removes or changes
+  them.
+- Make public APIs smaller than internal implementations.
+- Assume feature flags are public API.
+- Assume target support is public API.
+- Assume MSRV is public API.
+- Prefer compatibility-preserving additions over behavior-changing edits.
+- Use deprecation before removal when the old API is not actively harmful.
+
+The goal is not to avoid change. The goal is to make change legible to
+downstream users.
+
+## What Counts as Public API
+
+Public API includes:
+
+- public modules, types, traits, functions, constants, and macros
+- public fields and enum variants
+- trait impls, including auto traits when they are observable
+- blanket impl behavior
+- feature flag names and meanings
+- default feature sets
+- `no_std`, `alloc`, and `std` support
+- supported target triples and off-target behavior
+- error types and error detail
+- documented panic behavior
+- docs.rs target and feature presentation
+- Cargo metadata such as `rust-version`, license, and dependency ranges
+
+Do not rely only on Rust visibility to decide whether a change is breaking.
+Downstream users also depend on behavior and build configuration.
+
+## SemVer Classification
+
+Patch releases are appropriate for:
+
+- compatible bug fixes
+- documentation fixes
+- CI and publish workflow fixes
+- internal cleanup with no public behavior change
+- tightening tests around existing behavior
+- compatible dependency patch updates
+
+Minor releases are appropriate for:
+
+- adding public API
+- adding feature flags
+- adding supported platforms
+- widening dependency ranges
+- changing MSRV when the README says MSRV may move in minor releases
+- adding error detail without breaking existing matching
+- improving behavior in a way downstream code can absorb safely
+
+Major releases are required for:
+
+- removing public API
+- renaming public API
+- changing function signatures
+- changing trait bounds in a breaking direction
+- removing or changing feature flag meaning
+- removing target support
+- changing documented panic or error behavior incompatibly
+- changing `no_std`, `alloc`, or `std` promises incompatibly
+
+Some behavior changes are judgment calls. When in doubt, write the release notes
+as if explaining the change to a downstream maintainer. If the explanation says
+"you may need to change your code," it is probably not a patch release.
+
+## MSRV Policy
+
+`rust-version` is a promise. Keep it in `Cargo.toml`, document it in the README,
+and test it in CI.
+
+An MSRV bump should:
+
+- be intentional
+- appear in release notes
+- update README text when present
+- update CI and local setup docs
+- be classified according to the crate policy
+- be justified by a concrete dependency, language feature, or maintenance need
+
+For Artichoke crates, MSRV bumps may be minor releases when the README says so.
+Do not make an MSRV bump in a patch release unless the previous release could
+not actually build on the documented MSRV and the patch is correcting that bug.
+
+## Cargo Metadata
+
+Cargo metadata should match the compatibility story.
+
+- Keep `edition` and `rust-version` synchronized with the code.
+- Keep `include` small and intentional.
+- Keep `documentation`, `homepage`, and `repository` live.
+- Keep README dependency snippets synchronized with release versions.
+- Keep `html_root_url` synchronized with published versions.
+- Keep docs.rs target metadata aligned with supported platforms.
+
+Metadata drift creates user confusion even when the Rust code is correct.
+
+## Feature Flags
+
+Feature flags are public configuration API.
+
+Adding a feature is usually minor. Removing a feature, changing a feature's
+meaning, or moving API between features is usually major.
+
+Feature flags should:
+
+- be named after user-visible capability
+- avoid exposing dependency implementation details when possible
+- document default behavior
+- avoid surprising semantic changes
+- compose with other features
+- be covered by CI
+- be shown in docs.rs with `doc(cfg)` when practical
+
+Avoid feature flags that cause the same public function to mean materially
+different things unless the crate's purpose requires it and the docs say so.
+
+## Target Support
+
+Supported targets are public API.
+
+Adding a target is usually minor. Removing a target is usually major. Changing
+off-target behavior may be breaking if downstream users rely on the crate
+compiling or being empty off-target.
+
+For platform-specific crates:
+
+- document supported OSes and triples
+- document off-target behavior
+- gate modules at obvious `cfg` boundaries
+- test real supported runners
+- test off-target builds
+- configure docs.rs to show the intended target story
+
+Do not claim cross-platform support when the real promise is target-gated
+compilation.
+
+## Error and Panic Stability
+
+Errors and panics are observable behavior.
+
+Changing from `Option` to `Result` is breaking. Changing an error enum can be
+breaking unless the enum is `#[non_exhaustive]` and downstream matching remains
+compatible. Removing a panic can be compatible, but changing a panic into silent
+wrong behavior is not.
+
+Public error types should:
+
+- expose only details the crate is willing to stabilize
+- use `#[non_exhaustive]` when future cases are likely
+- avoid leaking platform implementation details unintentionally
+- document expected absence versus exceptional failure
+
+Public panic behavior should:
+
+- be rare in library APIs
+- be documented when it is part of an indexing or assertion contract
+- be tested when it protects an invariant
+
+## Trait Impl Stability
+
+Trait impls can be breaking in both directions.
+
+Adding an impl is usually compatible, but it can break downstream code through
+method resolution or coherence. Removing an impl is usually breaking. Changing
+auto-trait behavior such as `Send`, `Sync`, `UnwindSafe`, or `RefUnwindSafe` can
+be breaking and should be treated carefully.
+
+For unsafe or ownership-sensitive types:
+
+- document intentional auto-trait behavior
+- add compile-fail tests for negative auto-trait promises when important
+- avoid unsafe impls unless the proof is written down
+- use `#[repr(transparent)]` or `#[repr(C)]` only when layout is part of the
+  contract
+
+## Type Evolution
+
+Design public types so they can evolve.
+
+Prefer:
+
+- private fields with constructors and accessors
+- `#[non_exhaustive]` for public enums likely to grow
+- newtypes for values that are easy to mix up
+- sealed traits when downstream implementation would freeze internals
+- error types that can grow without breaking exhaustive matches
+
+Avoid:
+
+- public fields that expose internal representation
+- public helper types that exist only to simplify implementation
+- trait methods that require future implementations to preserve accidental
+  behavior
+- making allocation strategy or storage layout public unless that is the point
+  of the crate
+
+`raw-parts` is a good example of making a risky representation visible without
+pretending conversion back into a `Vec` is safe.
+
+## Dependency Ranges
+
+Dependency ranges are compatibility promises.
+
+When widening a dependency range:
+
+- test the oldest supported version
+- test the newest supported version
+- document the policy when the range crosses semver-incompatible versions
+- make the release at least minor if downstream compatibility changes
+
+When tightening a dependency range:
+
+- explain why older versions no longer work
+- classify the change according to downstream impact
+- update automation runbooks when present
+
+For target-specific dependencies such as `windows-sys`, do not publish a range
+wider than CI proves.
+
+## Deprecation
+
+Use deprecation when users need time to move.
+
+Deprecation should:
+
+- name the replacement
+- explain why the old API is deprecated
+- avoid breaking builds by default
+- be followed by a major release before removal when removal is still desired
+
+Do not deprecate as a substitute for making a decision. If an API remains useful
+and supportable, keep it.
+
+## Compatibility Tooling
+
+Use tools to find obvious breakage, but do not outsource judgment.
+
+Useful checks include:
+
+- `cargo semver-checks` for Rust API compatibility
+- `cargo test` for behavior compatibility
+- doctests for examples and compile-fail contracts
+- MSRV CI for `rust-version`
+- platform CI for target support
+- dependency lower-bound checks for published ranges
+
+SemVer tools cannot fully understand behavior, feature meanings, platform
+semantics, performance promises, or upstream Ruby compatibility. Review still
+has to make those calls.
+
+## Release Checklist
+
+- Does the release classification match the public impact?
+- Did public API change?
+- Did feature flags change?
+- Did target support or off-target behavior change?
+- Did MSRV change?
+- Did dependency ranges change?
+- Did error or panic behavior change?
+- Did docs.rs output change materially?
+- Did README, `html_root_url`, and Cargo metadata stay synchronized?
+- Do release notes explain migration work when users need it?
+
+## References
+
+- [Cargo Book: SemVer compatibility](https://doc.rust-lang.org/cargo/reference/semver.html)
+- [Cargo Book: Manifest `rust-version`](https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field)
+- [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/)
+- [cargo-semver-checks](https://docs.rs/cargo-semver-checks/latest/cargo_semver_checks/)
+- [Cargo Book: Features](https://doc.rust-lang.org/cargo/reference/features.html)

--- a/docs/guardrails/ffi-bindings-and-foreign-runtime-integration.md
+++ b/docs/guardrails/ffi-bindings-and-foreign-runtime-integration.md
@@ -1,0 +1,292 @@
+# FFI, Bindings, and Foreign Runtime Integration
+
+FFI code is a compatibility boundary between Rust and another runtime, operating
+system, ABI, allocator, or language. It needs stronger guardrails than ordinary
+Rust because neither side can see the other side's invariants.
+
+This guardrail is grounded in active platform crates such as `sysdir` and
+`known-folders`, historical FFI-heavy work in `strudel`, and Artichoke VM work
+that integrates Rust with Ruby and C APIs.
+
+## Default Stance
+
+- Decide whether the crate exposes raw bindings, safe wrappers, or both.
+- Keep the raw boundary small and obvious.
+- Preserve upstream ABI and semantics exactly at the binding layer.
+- Convert into Rust types only at a documented wrapper boundary.
+- Match allocation and deallocation APIs.
+- Never unwind across an FFI boundary.
+- Treat generated bindings as reviewed source code.
+
+FFI is not only unsafe Rust. It is also build metadata, symbol names, linkers,
+headers, encodings, callbacks, runtime initialization, and teardown.
+
+## Boundary Model
+
+Every FFI module should answer four questions:
+
+- Who calls whom?
+- Who owns each pointer, buffer, handle, and callback?
+- Which allocator frees each allocation?
+- Which runtime invariants must already be initialized?
+
+Common boundary shapes:
+
+- Rust calls a platform C API and exposes a safe Rust wrapper.
+- Rust exposes C ABI symbols for a foreign runtime to call.
+- Rust ports a foreign data structure but keeps ABI-compatible layout.
+- Rust embeds a foreign runtime and must follow its initialization rules.
+- Rust consumes generated bindings from upstream headers.
+
+The boundary model should be visible in module names, docs, and tests.
+
+## Raw Bindings
+
+Raw binding modules should preserve upstream names and signatures.
+
+Raw bindings should:
+
+- use `unsafe extern` blocks
+- use `repr(C)` for public layout types
+- use `core::ffi` or `std::ffi` C types
+- keep constants and type aliases close to upstream naming
+- include upstream header, man page, or API links when possible
+- avoid adding safe behavior at the raw layer
+- be target-gated when the symbols do not exist everywhere
+
+`sysdir` is a good model for keeping bindgen output isolated in a raw module and
+documenting local edits.
+
+## Safe Wrappers
+
+Safe wrappers should absorb foreign obligations so safe callers cannot trigger
+undefined behavior.
+
+Safe wrappers should:
+
+- validate inputs before calling foreign code
+- initialize out pointers correctly
+- free foreign allocations exactly once
+- convert strings and paths explicitly
+- map expected absence or error states deliberately
+- hide ABI details from safe callers
+- document any preserved platform oddities
+
+`known-folders` is a good model: the wrapper calls a Windows API, guards the
+returned pointer, converts UTF-16 to `OsString`, and exposes `PathBuf` rather
+than raw allocation ownership.
+
+## ABI and Symbols
+
+ABI is public API.
+
+For Rust functions exported to foreign code:
+
+- use the correct `extern "C"` ABI or the documented platform ABI
+- keep exported symbol names intentional
+- namespace symbols when possible
+- document whether the crate builds as `cdylib`, `staticlib`, or Rust library
+- avoid exposing Rust layout or Rust panics through C ABI
+- keep callback signatures exact
+
+For Rust 2024 and later, unsafe attributes such as `no_mangle`, `export_name`,
+and `link_section` should be treated as explicit safety obligations. The symbol
+namespace and linker behavior are part of the proof.
+
+## Layout
+
+Layout assumptions must be tested or generated from upstream.
+
+Use `repr(C)` when layout is shared with C. Use `repr(transparent)` only when a
+single-field wrapper intentionally has the same ABI as its field. Avoid relying
+on Rust field order, enum layout, niche optimization, or padding unless the
+layout is documented and tested.
+
+For ABI-compatible structs:
+
+- test `size_of`
+- test `align_of`
+- test important field offsets
+- test integer widths
+- test pointer-width-sensitive types on 32-bit and 64-bit targets when relevant
+
+`strudel`'s FFI-compatible `st_table` work is the kind of code that needs these
+tests.
+
+## Ownership and Allocation
+
+Allocation ownership must cross the boundary in one direction at a time.
+
+For every pointer crossing FFI, document:
+
+- who allocated it
+- whether it may be null
+- whether it points to one value, an array, or a sentinel-terminated sequence
+- whether the memory is mutable
+- who frees it
+- which function frees it
+- whether the caller may retain it after the call returns
+
+Never free memory with a different allocator than the one that allocated it.
+Rust `Box`, `Vec`, and `String` memory must not be freed by C unless the API is
+explicitly designed around Rust allocation and exposes the matching destructor.
+
+## Strings, Paths, and Bytes
+
+String conversion is part of the API contract.
+
+Document and test:
+
+- UTF-8 versus platform-native encoding
+- UTF-16 and surrogate handling
+- interior NUL behavior
+- lossy versus lossless conversion
+- byte paths on Unix
+- `OsString` and `PathBuf` conversion boundaries
+- null-terminated versus length-delimited buffers
+
+Do not convert to `String` when the platform can return non-UTF-8 paths.
+`sysdir` correctly preserves the possibility of non-UTF-8 Darwin paths.
+
+## Error Handling
+
+Foreign APIs often expose error state outside the return value.
+
+Error handling should:
+
+- capture `errno`, `GetLastError`, HRESULT, or platform status immediately when
+  the API requires it
+- distinguish expected absence from exceptional failure when callers need that
+  distinction
+- avoid collapsing all failures into `None` unless that is the documented API
+- preserve unknown error codes conservatively
+- document which upstream errors are expected
+
+Changing error detail can be semver-relevant when downstream code observes it.
+
+## Callbacks
+
+Callbacks are FFI in both directions.
+
+For callback APIs:
+
+- document who owns callback data
+- document whether callbacks may be null
+- document reentrancy
+- document mutation rules while iterating
+- forbid unwinding across the callback boundary
+- handle callback panics before returning to foreign code
+- preserve upstream return-code semantics
+
+If a callback can mutate the structure being iterated, tests should cover
+insert, delete, stop, and error paths.
+
+## Unwinding
+
+Rust panics must not cross a non-unwinding FFI boundary.
+
+For exported C ABI functions:
+
+- keep panics impossible, or catch them before returning
+- translate panic or internal failure into a documented error code
+- ensure partially mutated state is rolled back or left valid
+- test callback panic behavior when callbacks are allowed
+
+For imported foreign functions:
+
+- assume foreign exceptions cannot safely enter Rust unless the ABI and runtime
+  explicitly support that behavior
+- keep unwinding assumptions local and documented
+
+## Runtime Integration
+
+Foreign runtimes have global invariants that ordinary Rust APIs do not.
+
+For Ruby and C runtime integration, document:
+
+- initialization requirements
+- shutdown requirements
+- global state
+- thread and lock requirements
+- garbage collection ownership
+- value lifetime and rooting rules
+- encoding state
+- allocator boundaries
+- callback and reentrancy rules
+
+Do not model a foreign runtime handle as an ordinary Rust value unless the type
+enforces the runtime invariant.
+
+## Generated Bindings
+
+Generated bindings are source code after they are committed.
+
+Generated binding updates should:
+
+- document the generator and version
+- document the exact command
+- document the SDK or header source
+- preserve local lint and license edits
+- be reviewed as code
+- be separated from unrelated cleanup
+- include tests or diff notes for API changes
+
+`sysdir`'s bindings freshness runbook is the right shape: it names the header,
+the bindgen command, manual edits, and the expected PR contents.
+
+## Vendored Foreign Source
+
+Vendored foreign source should be intentional and traceable.
+
+For vendored source:
+
+- record upstream project, version, and license
+- separate local patches from upstream code when possible
+- avoid modifying vendored code in behavior PRs unless the PR is about the
+  vendored code
+- document whether vendored files are included in published crates
+- keep compatibility tests that compare against upstream behavior
+
+`strudel` documents its vendored Ruby `st.c` and `st.h` sources and the fact
+that they are not distributed on crates.io. That distinction should remain
+visible.
+
+## Testing
+
+FFI tests should prove both Rust behavior and foreign boundary behavior.
+
+Use:
+
+- real target OS runners for platform APIs
+- layout tests for ABI-compatible structs
+- smoke tests that call exported symbols from C or the foreign runtime
+- Miri where it can model the unsafe code
+- leak tests for ownership transfer
+- panic-injection tests for rollback behavior
+- upstream fixtures for behavior compatibility
+- 32-bit jobs for width-sensitive ABI code
+
+Do not rely only on Rust unit tests for a C ABI surface. The foreign caller's
+view is part of the API.
+
+## Review Checklist
+
+- Is the boundary raw bindings, safe wrappers, or both?
+- Is every FFI call target-gated correctly?
+- Are ABI, symbol, and layout assumptions documented?
+- Are pointer ownership and allocator rules clear?
+- Are strings, paths, and bytes converted losslessly when required?
+- Are errors captured and mapped deliberately?
+- Can a panic or foreign exception cross the boundary?
+- Are callbacks reentrancy and mutation rules tested?
+- Are generated bindings reviewed as source?
+- Are vendored sources traceable to upstream?
+- Does CI exercise the real foreign boundary?
+
+## References
+
+- [Rustonomicon: FFI](https://doc.rust-lang.org/nomicon/ffi.html)
+- [Rust Reference: external blocks](https://doc.rust-lang.org/reference/items/external-blocks.html)
+- [Rust Edition Guide: unsafe attributes](https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-attributes.html)
+- [Cargo Book: Build scripts](https://doc.rust-lang.org/cargo/reference/build-scripts.html)
+- [bindgen user guide](https://rust-lang.github.io/rust-bindgen/)

--- a/docs/guardrails/high-quality-rust-code.md
+++ b/docs/guardrails/high-quality-rust-code.md
@@ -1,0 +1,249 @@
+# High Quality Rust Code
+
+High quality Artichoke Rust code is small in surface area, explicit about its
+contracts, strict in CI, and boring to maintain. It should be clear which
+behavior is public API, which behavior is an implementation detail, and which
+behavior is inherited from Ruby, Rust, an operating system, or an upstream C
+API.
+
+This document is grounded in patterns across active Artichoke crates such as
+`rand_mt`, `intaglio`, `sysdir`, and `known-folders`, plus historical crates
+such as `boba`, `qed`, `raw-parts`, `strudel`, and `cactusref`.
+
+## Design Principles
+
+- Prefer small crates with a narrow purpose.
+- Make the public API harder to misuse than the underlying primitive.
+- Use `Result` or `Option` for expected failure. Avoid panics in library APIs
+  unless the panic is part of an intentionally documented indexing or assertion
+  contract.
+- Keep unsafe code out of crates that do not need it.
+- Prefer `no_std` when it is true and useful, but do not contort APIs to claim
+  `no_std`.
+- Preserve upstream semantics when implementing Ruby compatibility, platform
+  bindings, or C-compatible APIs. Do not normalize behavior unless the API says
+  it normalizes.
+- Favor direct tool invocations over custom wrappers.
+
+The goal is not maximal abstraction. The goal is code that makes its invariants
+obvious and keeps compatibility promises verifiable.
+
+## Crate Root Policy
+
+Active Artichoke crates should have crate-level lints that make maintenance fail
+loudly:
+
+```rust
+#![warn(clippy::all)]
+#![warn(clippy::pedantic)]
+#![warn(clippy::cargo)]
+#![warn(missing_copy_implementations)]
+#![warn(missing_debug_implementations)]
+#![warn(missing_docs)]
+#![warn(rust_2018_idioms)]
+#![warn(trivial_casts, trivial_numeric_casts)]
+#![warn(unused_qualifications)]
+#![warn(variant_size_differences)]
+```
+
+Use `deny` sparingly for individual lints that encode a stable project
+invariant. Keep broad Clippy groups at `warn` in crate attributes so toolchain
+and lint-set drift does not unexpectedly make the crate unusable for downstream
+builds. CI may still promote warnings to errors for repository validation.
+
+If a crate should have no unsafe code, add:
+
+```rust
+#![forbid(unsafe_code)]
+```
+
+If a crate contains unsafe code, add:
+
+```rust
+#![warn(unsafe_op_in_unsafe_fn)]
+#![warn(clippy::undocumented_unsafe_blocks)]
+```
+
+Every `allow` should be local or justified. Avoid broad `allow` blocks that make
+future review harder.
+
+## Public API Quality
+
+Public APIs should be:
+
+- Minimal: expose what downstream users need, not every helper the
+  implementation has.
+- Typed: prefer newtypes, enums, and named fields over positional tuples when
+  values are easy to mix up.
+- Documented: every public item has a useful doc comment.
+- Example-backed: subtle APIs have doctests or README examples.
+- Semver-aware: avoid public helper types that would be hard to change later.
+- Feature-aware: optional modules and APIs are behind documented features.
+- Target-aware: platform-specific APIs are compiled and documented only where
+  they exist.
+
+`raw-parts` is a good model for avoiding hidden risk: it gives names to the
+components of a `Vec`, but it does not implement `From<RawParts<T>> for Vec<T>`
+because rebuilding the `Vec` must remain visibly unsafe.
+
+## Documentation Quality
+
+The crate docs and README should tell the same story. In active crates, prefer
+including the README in doctests when examples are intended to compile.
+
+Docs should cover:
+
+- Purpose.
+- Quick installation.
+- Minimal usage.
+- Feature flags.
+- Platform behavior.
+- MSRV.
+- License.
+- Safety or maturity caveats.
+
+Docs should not overclaim:
+
+- Do not call deterministic RNG constructors "random entropy".
+- Do not call raw platform paths normalized filesystem paths.
+- Do not describe an empty off-target crate as cross-platform behavior.
+- Do not hide experimental or potentially unsound status.
+
+Use `#[cfg_attr(docsrs, doc(cfg(...)))]` for optional modules and platform
+modules so docs.rs reflects feature and target gates.
+
+## Error Handling and Panics
+
+Library code should not panic for normal user input. Prefer:
+
+- `Result<T, E>` when the caller needs a reason.
+- `Option<T>` when the platform API or lookup is naturally absent and the crate
+  intentionally collapses reasons.
+- Dedicated error enums when the crate exposes a meaningful failure taxonomy.
+
+Panics are acceptable for:
+
+- Test code.
+- Compile-time assertion macros.
+- Documented indexing operations where the caller has already supplied an
+  invalid symbol or key.
+- Internal invariant failures that indicate a bug in the crate.
+
+When a panic path protects an invariant, add tests that exercise surrounding
+state. `intaglio`'s rollback tests are a strong pattern: they trigger a panic in
+hashing and then prove the symbol table can continue to operate correctly.
+
+## Tests
+
+Tests should prove contracts, not just lines.
+
+At minimum, active crates should run:
+
+- `cargo build --workspace`
+- `cargo test --workspace`
+- `cargo test --workspace --all-features`
+- `cargo test --workspace --no-default-features`
+- `cargo fmt --check`
+- `cargo clippy --workspace --all-features --all-targets`
+- documentation builds with warnings denied
+
+Add focused coverage when the crate has extra risk:
+
+- MSRV jobs for the declared `rust-version`.
+- 32-bit target jobs for pointer-width logic.
+- Target OS jobs for platform crates.
+- Miri jobs for unsafe code and drop/lifetime invariants.
+- Fuzz jobs for parsers, encoders, and decoders.
+- Reproducibility vectors for compatibility with Ruby or upstream specs.
+- Compile-fail doctests for auto-trait, lifetime, or target-gate invariants.
+
+Use tests to encode compatibility facts. `rand_mt` carries Ruby reproducibility
+tests; `known-folders` tests minimum and latest `windows-sys` versions; `sysdir`
+tests both target and non-target behavior; `boba` fuzzes encode, decode, and
+roundtrip.
+
+## CI Quality
+
+CI is part of the code quality standard. It should be strict enough that a green
+branch means something.
+
+- Set `RUSTFLAGS=-D warnings` in build, test, and lint jobs.
+- Build and test default, all-feature, and no-default-feature configurations
+  when the crate has features.
+- Run docs with rustdoc warnings denied.
+- Keep formatting and text formatting checks separate from build tests.
+- Use explicit runner labels when runner version matters.
+- Keep workflow permissions minimal.
+- Use `persist-credentials: false` for checkout.
+- Run scheduled CI to catch runner and toolchain drift.
+
+CI should not silently stop testing a contract because a platform moved, a
+feature was added, or a dependency range widened.
+
+## Dependency Quality
+
+Dependencies should earn their place.
+
+- Prefer no dependencies for small crates when the standard library or `core` is
+  enough.
+- Use `default-features = false` when a dependency does not need its defaults.
+- Keep platform dependencies under target-specific dependency sections.
+- Document semver-incompatible dependency policy in the README when relevant.
+- Test the dependency range you advertise.
+- Run `cargo deny` for advisories, licenses, bans, and sources.
+
+For `no_std` crates, verify every dependency is compatible with the claimed
+`no_std` mode and does not accidentally pull in `std`.
+
+## Feature Flags
+
+Feature flags are public API.
+
+- Name features after the user-visible capability they enable.
+- Document default features and non-default features.
+- Avoid feature flags that change semantics in surprising ways.
+- Test default, all-features, and no-default-features.
+- Use docs.rs `doc(cfg)` to show feature gates.
+
+Adding a feature is usually a minor release. Removing or changing the meaning of
+a feature is usually a major release.
+
+## Performance and Memory
+
+Performance work should be tied to a contract:
+
+- Compatibility with Ruby behavior.
+- Bounded allocation.
+- `no_std` support.
+- FFI compatibility.
+- Reduced copying.
+- Proven drop or leak behavior.
+
+Avoid clever code that only improves a benchmark no one runs. If performance is
+important, add a benchmark or reproducibility test that explains what is being
+protected.
+
+For allocation-sensitive crates:
+
+- Document capacity behavior.
+- Prefer `try_reserve` variants when callers may need fallible allocation.
+- Test drop paths, rollback paths, and panic paths.
+- Be explicit about internal pointer, lifetime, and ownership invariants.
+
+## Review Checklist
+
+- Is the public API smaller or clearer than the implementation?
+- Are all new public items documented?
+- Do examples compile on the targets where they are shown?
+- Does CI cover default, all-feature, and no-default-feature builds?
+- Does the change affect MSRV, semver, docs.rs output, or platform support?
+- Are new dependencies justified, minimal, and allowed by `deny.toml`?
+- Are panics limited to documented contracts or internal bugs?
+- Is unsafe code absent, or isolated and justified?
+- Do tests cover the behavior that could regress?
+
+## References
+
+- [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/)
+- [Cargo Book: Manifest format](https://doc.rust-lang.org/cargo/reference/manifest.html)
+- [Cargo Book: Features](https://doc.rust-lang.org/cargo/reference/features.html)

--- a/docs/guardrails/performance-allocation-and-memory-behavior.md
+++ b/docs/guardrails/performance-allocation-and-memory-behavior.md
@@ -1,0 +1,269 @@
+# Performance, Allocation, and Memory Behavior
+
+Performance work in Artichoke Rust code should be tied to a user-visible or
+runtime-visible contract. Speed, allocation behavior, memory footprint, and drop
+behavior matter, but they should not become folklore or speculative complexity.
+
+This guardrail is grounded in active crates such as `intaglio` and `rand_mt`,
+plus historical performance-sensitive work in `strudel`, `raw-parts`, and
+`cactusref`.
+
+## Default Stance
+
+- Correctness and compatibility come first.
+- Measure before adding complexity for performance.
+- Keep benchmarks close to the behavior they protect.
+- Document allocation and capacity behavior when callers can observe it.
+- Prefer simple safe Rust unless measurements justify a sharper tool.
+- Treat memory leaks, double frees, and panic-corrupted state as correctness
+  bugs, not only performance bugs.
+
+The goal is not maximum speed in every path. The goal is predictable behavior
+for the paths the crate asks users to care about.
+
+## Performance Contracts
+
+Performance is a contract when the crate documents or implies:
+
+- bounded allocation
+- `no_std` or `alloc` behavior
+- low-copy or zero-copy behavior
+- deterministic output
+- stable state size
+- FFI compatibility
+- drop behavior for large graphs or tables
+- compatibility with an upstream runtime benchmark
+
+If a PR changes one of these properties, it needs a test, benchmark, or explicit
+release note.
+
+## Benchmarks
+
+Benchmarks should answer a concrete question.
+
+Good benchmark questions:
+
+- Did an interner lookup regress?
+- Did table insertion allocate more often?
+- Did a drop path become nonlinear?
+- Did a Ruby compatibility path get slower than the upstream baseline?
+- Did avoiding a copy matter for realistic input sizes?
+- Did a platform wrapper add hidden allocation?
+
+Poor benchmark questions:
+
+- Is this new abstraction faster in isolation?
+- Does this micro-optimization improve a synthetic loop?
+- Can unsafe code beat safe code on one local machine?
+
+Use Criterion or another stable harness when benchmark history matters. Keep
+inputs realistic and named. Include edge cases, but do not let edge cases be the
+only benchmark.
+
+## Benchmark Hygiene
+
+Benchmarks should be reviewable.
+
+- Use stable fixtures.
+- Use `black_box` where the optimizer would otherwise remove the work.
+- Separate setup from measured work.
+- Report throughput when input size matters.
+- Compare against the current implementation when possible.
+- Avoid benchmarking debug builds.
+- Avoid host-specific file paths, clocks, network, and random inputs.
+- Record command lines for nonstandard benchmarks.
+
+Do not commit benchmark results as proof without explaining the environment and
+why the numbers are meaningful.
+
+## Allocation Behavior
+
+Allocation behavior is often more important than raw instruction count.
+
+Document and test when public APIs promise:
+
+- no allocation
+- one allocation
+- capacity reuse
+- fallible reservation
+- exact capacity
+- bounded state size
+- ownership transfer without copying
+- caller-controlled buffers
+
+Use `try_reserve` or fallible constructors when callers may need to handle
+allocation failure. Use `reserve` when panic-on-allocation-failure is acceptable
+and documented by ordinary Rust collection semantics.
+
+## Capacity and State
+
+Capacity is observable when callers can ask for it, reuse it, or pay for it.
+
+For capacity-sensitive APIs:
+
+- document whether capacity is retained after clear or rollback
+- test that rollback does not leak partially inserted state
+- test that panic paths leave structures usable
+- avoid exposing exact internal capacity unless it is part of the contract
+- prefer approximate or qualitative docs when implementation freedom matters
+
+`intaglio`'s rollback tests are a useful pattern: they prove that a panic during
+hashing does not corrupt the table.
+
+## Memory Footprint
+
+Memory footprint should be explicit when it affects embedding.
+
+`rand_mt` documents that each RNG uses approximately 2.5 kilobytes of state and
+suggests boxing when embedding the RNG in other structs. This is the right level
+of user-facing memory guidance.
+
+Document memory footprint when:
+
+- the type is large
+- the type is commonly embedded in other types
+- the crate is useful in constrained environments
+- state size is inherited from an upstream algorithm
+- allocation strategy affects FFI or runtime integration
+
+Avoid freezing private layout to document memory usage unless layout is already
+public API.
+
+## Copies and Borrowing
+
+Avoiding copies is useful only when it preserves a real contract.
+
+Prefer:
+
+- borrowed inputs when ownership is not needed
+- `Cow` only when both borrowed and owned paths are common
+- caller-provided buffers when allocation control matters
+- explicit ownership transfer for FFI or raw-parts APIs
+
+Avoid:
+
+- unsafe lifetime extension to skip a measured-insignificant clone
+- returning references into storage that can be invalidated by ordinary safe
+  calls
+- storing borrowed data when owned data would make the API sound and simple
+
+When avoiding a copy requires unsafe code, the benchmark and the safety proof
+both need to exist.
+
+## Data Structures
+
+Data structure choices should match the public workload.
+
+For hash tables, interners, and graph-like structures:
+
+- document expected big-O behavior when users care
+- test insertion, lookup, deletion, and iteration edge cases
+- benchmark realistic sizes
+- test panic or callback behavior during mutation
+- consider deterministic output when compatibility requires it
+- do not expose internal storage order unless it is intentional
+
+`strudel` exists because Ruby hash table behavior and performance mattered. That
+kind of work should stay tied to upstream behavior, not just isolated Rust
+microbenchmarks.
+
+## Drop and Leak Behavior
+
+Drop behavior is both performance and correctness.
+
+Test drop paths when code manages:
+
+- graphs
+- cycles
+- arenas
+- interners
+- FFI handles
+- raw allocations
+- rollback guards
+- foreign runtime values
+
+Use leak tests when ownership transfer is subtle. Use Miri when pointer or
+lifetime invariants are involved. Use benchmarks when drop cost is part of the
+crate's purpose, as in `cactusref`'s drop benchmarks.
+
+## `no_std`, `alloc`, and Embedded Use
+
+`no_std` claims are memory behavior claims.
+
+For `no_std` crates:
+
+- keep `std` behind an explicit feature or test-only gate
+- test `no-default-features`
+- document whether `alloc` is required
+- avoid dependencies that accidentally reintroduce `std`
+- keep examples honest about heap usage
+
+Do not contort an API to claim `no_std`. Prefer an honest `std` crate over a
+fragile compatibility story.
+
+## FFI and Runtime Performance
+
+FFI performance work must account for boundary costs.
+
+When optimizing FFI or runtime integration:
+
+- measure the full boundary, not only the Rust function
+- include conversion costs for strings, paths, and buffers
+- include allocation and deallocation costs
+- account for callback overhead
+- preserve upstream ABI and error semantics
+- avoid batching or caching that changes observable behavior
+
+A fast wrapper that changes platform or Ruby semantics is a bug.
+
+## CI and Regression Detection
+
+Most benchmarks should not block every PR unless they are stable enough to
+signal real regressions. Use the right enforcement level.
+
+Good CI patterns:
+
+- run correctness tests on every PR
+- run Miri or leak tests for unsafe memory behavior
+- run benchmark smoke tests to keep harnesses compiling
+- run full benchmarks on demand or scheduled jobs
+- record baseline changes in performance PRs
+
+Do not let a benchmark harness rot because it is too slow for every PR. Move it
+to a scheduled or manual job and keep it visible.
+
+## Performance PRs
+
+A performance PR should explain:
+
+- which workload is improved
+- why that workload matters
+- which benchmark or measurement was used
+- what changed in allocation behavior
+- what complexity or unsafe code was added
+- what compatibility risk was considered
+- whether release notes should mention the change
+
+If the PR cannot name the workload, it probably should be a cleanup PR or not be
+done.
+
+## Review Checklist
+
+- Is there a concrete workload or compatibility contract?
+- Is the change measured?
+- Are benchmark inputs realistic and reviewable?
+- Does allocation behavior change?
+- Does memory footprint change?
+- Does the change affect `no_std`, `alloc`, or feature behavior?
+- Does the change add unsafe code only for measured benefit?
+- Are panic, rollback, and drop paths still tested?
+- Does FFI or platform conversion cost matter?
+- Do docs need to mention new performance or memory behavior?
+
+## References
+
+- [Rust Performance Book: Benchmarking](https://nnethercote.github.io/perf-book/benchmarking.html)
+- [Cargo Book: cargo bench](https://doc.rust-lang.org/cargo/commands/cargo-bench.html)
+- [Criterion.rs](https://bheisler.github.io/criterion.rs/book/)
+- [std::hint::black_box](https://doc.rust-lang.org/std/hint/fn.black_box.html)
+- [std::collections::TryReserveError](https://doc.rust-lang.org/std/collections/struct.TryReserveError.html)

--- a/docs/guardrails/platform-specific-code.md
+++ b/docs/guardrails/platform-specific-code.md
@@ -1,0 +1,209 @@
+# Platform Specific Code
+
+Platform specific Rust code is not second-class code. It is a public
+compatibility statement about operating systems, targets, linkers, encodings,
+error codes, filesystem semantics, and CI coverage.
+
+This guardrail is grounded in the active `sysdir` and `known-folders` crates,
+plus FFI-heavy historical work in `strudel`.
+
+## Platform Support Must Be Explicit
+
+Every platform-specific crate or module should document:
+
+- supported operating systems
+- supported Rust target triples when the distinction matters
+- minimum OS or API version
+- off-target behavior
+- required system libraries or frameworks
+- path, string, and encoding semantics
+- whether the crate is raw bindings or a safe wrapper
+
+`sysdir` states that it is empty on non-Apple platforms. `known-folders` states
+that it is empty on non-Windows platforms. This is good. Empty off-target crates
+are a valid design when they compile cleanly and the README says so.
+
+Do not imply "cross-platform" when the real promise is "compiles off-target but
+does nothing."
+
+## Use `cfg` as an API Boundary
+
+Keep platform gates simple and visible:
+
+- Gate whole modules with `#[cfg(...)]`.
+- Re-export platform modules only on supported targets.
+- Prefer target-specific dependencies in `Cargo.toml`.
+- Use `cfg_attr` in docs so examples compile only where they should.
+- Add off-target examples or tests that prove unsupported targets fail in the
+  documented way.
+
+Avoid scattering target checks through business logic. A user should be able to
+find the platform boundary quickly.
+
+## Cargo and docs.rs
+
+Cargo metadata should match the platform story.
+
+- Use `categories` such as `os::windows-apis` or `os::macos-apis` only when the
+  crate really targets those APIs.
+- Put platform dependencies under target-specific dependency sections.
+- Configure `package.metadata.docs.rs.targets` to build the targets users care
+  about.
+- Use `rustdoc-args = ["--cfg", "docsrs"]` when docs use `doc(cfg)`.
+- Keep README examples and `html_root_url` current during release prep.
+
+For platform crates, docs.rs is a compatibility artifact. If docs.rs builds only
+one target, that target should be an intentional supported target.
+
+## Preserve Platform Semantics
+
+Do not clean up platform behavior unless the crate explicitly promises a
+normalized abstraction.
+
+`sysdir` correctly documents that Darwin search-path results:
+
+- may contain a literal `~`
+- may be prefixed by `NEXT_ROOT`
+- may not be valid UTF-8
+
+`known-folders` correctly converts Windows UTF-16 paths into `OsString` and then
+`PathBuf`, while keeping the Win32 API boundary in one module.
+
+Platform path code should avoid assuming:
+
+- UTF-8
+- `/` or `\` as universal separators
+- normalized or absolute paths
+- environment variable expansion
+- case sensitivity
+- stable folder presence across OS versions
+- success for every documented folder ID
+
+When exposing raw bindings, document that callers own normalization and
+validation.
+
+## Safe Wrappers and Raw Bindings
+
+Choose one public story.
+
+Safe wrapper crates should:
+
+- expose Rust types such as `PathBuf`, `OsString`, `Option`, or `Result`
+- manage raw pointer ownership internally
+- map documented expected errors
+- cite upstream API docs near the FFI call
+- use guards for platform-owned allocations
+- hide ABI details from safe callers
+
+Raw binding crates should:
+
+- expose C-compatible names and types intentionally
+- preserve upstream constants and signatures
+- avoid pretending raw pointers are safe
+- include upstream headers or man pages when they are part of the source of
+  truth
+- document linker and OS availability
+
+Do not mix the two stories accidentally. A crate can expose both raw bindings
+and safe wrappers, but the boundary between them must be visible.
+
+## CI Coverage
+
+CI should prove the support matrix.
+
+For target platforms:
+
+- Build on real target runners.
+- Run tests on real target runners.
+- Build and run examples on real target runners.
+- Test MSRV on a representative supported runner.
+- Test dependency lower and upper bounds when a target-specific dependency range
+  is intentionally wide.
+
+For off-target platforms:
+
+- Build the crate.
+- Compile tests and examples when they are supposed to compile.
+- Run tests that prove the crate is empty or returns the documented failure.
+- Ensure docs still build or are gated correctly.
+
+Prefer explicit runner labels when stable coverage matters. `ubuntu-latest`,
+`windows-latest`, and `macos-latest` are useful only when the goal is to follow
+GitHub's moving default. For MSRV, publish, docs, and platform-API coverage,
+explicit labels are easier to audit.
+
+## Dependency Ranges
+
+Platform crates often depend on generated or externally versioned bindings.
+Treat those ranges as public support promises.
+
+For `windows-sys` style dependencies:
+
+- Prefer widening an upper bound when source compatibility allows it.
+- Test the oldest version in the range.
+- Test the newest version in the range.
+- Treat semver-incompatible binding upgrades as minor releases when the crate
+  README documents that policy.
+- Keep a maintenance runbook if the dependency needs repeated freshness checks.
+
+Do not publish a range wider than CI proves.
+
+## Generated and Vendored Bindings
+
+Generated bindings are source code after they are checked in.
+
+- Review generated diffs.
+- Preserve local edits such as license headers and lint allowances.
+- Do not combine binding refreshes with unrelated cleanup.
+- Keep upstream source references and generation commands documented.
+- Treat generated-content changes as release-relevant when users consume those
+  bindings.
+
+Vendored upstream sources need clear license treatment. `strudel` documents the
+Ruby `st.c` and `st.h` sources and states that they are not distributed on
+crates.io. That distinction matters.
+
+## Linkage
+
+Document what the crate links to and why.
+
+- `sysdir` relies on `libSystem` and explicitly does not link to CoreFoundation,
+  Foundation, or other frameworks.
+- Windows APIs should list the relevant `windows-sys` feature groups.
+- FFI crates should make C ABI entry points and exported symbols easy to audit.
+
+Avoid adding build scripts for platform linkage unless they are necessary.
+
+## Error Semantics
+
+Platform APIs often expose many error reasons. Decide what the Rust API
+promises.
+
+- Use `Option` only when the crate intentionally treats all failures as absence.
+- Use `Result` when callers need to distinguish permission, missing API, missing
+  folder, invalid argument, unsupported OS, or buffer problems.
+- Document expected error codes near the FFI call.
+- Treat unknown error codes conservatively.
+
+Changing error detail can be a semver-relevant API change.
+
+## Review Checklist
+
+- Does the README state supported platforms and off-target behavior?
+- Are platform modules gated at the module boundary?
+- Are target-specific dependencies scoped in `Cargo.toml`?
+- Does docs.rs build the right targets?
+- Do examples compile only where they should?
+- Does CI run on real target OS runners?
+- Are off-target builds tested?
+- Are path and string encodings documented?
+- Are upstream API versions and docs linked?
+- Are generated bindings reviewed as source?
+- Does dependency range policy match CI?
+- Does the release need README, `html_root_url`, or docs.rs target updates?
+
+## References
+
+- [Cargo Book: Platform-specific dependencies](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#platform-specific-dependencies)
+- [Rust Reference: Conditional compilation](https://doc.rust-lang.org/reference/conditional-compilation.html)
+- [docs.rs metadata](https://docs.rs/about/metadata)

--- a/docs/guardrails/testing-compatibility-and-conformance.md
+++ b/docs/guardrails/testing-compatibility-and-conformance.md
@@ -1,0 +1,291 @@
+# Testing, Compatibility, and Conformance
+
+Artichoke Rust code should treat behavior as a public contract. Tests are not
+only a way to catch mistakes. They are the project memory for Ruby
+compatibility, platform semantics, crate feature behavior, unsafe invariants,
+and release promises.
+
+This guardrail is grounded in active crates such as `rand_mt`, `intaglio`,
+`sysdir`, and `known-folders`, plus historical crates such as `boba`,
+`cactusref`, `raw-parts`, and `strudel`.
+
+## Default Stance
+
+- Every bug fix should add or update a regression test unless the existing test
+  already fails for the bug.
+- Every public example should either compile as a doctest or clearly state why
+  it is not executable.
+- Every compatibility claim should have a fixture, upstream spec, golden vector,
+  platform test, or explicit manual verification note.
+- Every feature flag and supported target should be exercised in CI.
+- Tests should protect behavior, not implementation accidents.
+
+The target is not maximal test count. The target is a suite that makes it hard
+to accidentally change a documented contract.
+
+## Test Layers
+
+Use the smallest test layer that can prove the contract.
+
+Unit tests are appropriate for:
+
+- pure algorithms
+- boundary conditions
+- internal invariants
+- error conversions
+- panic and rollback behavior
+
+Integration tests are appropriate for:
+
+- public crate workflows
+- feature combinations
+- platform behavior
+- compatibility fixtures
+- API examples that need a real downstream crate boundary
+
+Doctests are appropriate for:
+
+- README snippets
+- crate-level examples
+- subtle public API usage
+- target-gated examples
+- compile-fail examples for intentional misuse
+
+Fuzz tests are appropriate for:
+
+- parsers
+- encoders and decoders
+- round trips
+- byte-oriented APIs
+- APIs that consume external or untrusted input
+
+Miri and sanitizer-style checks are appropriate for:
+
+- unsafe code
+- pointer and lifetime invariants
+- drop behavior
+- leak behavior
+- unwind rollback
+- layout assumptions
+
+## Compatibility Tests
+
+Compatibility tests should name the external behavior they are preserving.
+
+Good Artichoke patterns include:
+
+- `rand_mt` carries Ruby reproducibility tests for MT19937 output.
+- `boba` keeps an upstream Bubble Babble encoding spec and fuzz targets for
+  encode, decode, and roundtrip.
+- `intaglio` tests unwind rollback after hasher panics.
+- `intaglio` tests leak and drop behavior under Miri.
+- `known-folders` tests both minimum and latest supported `windows-sys`
+  versions.
+- `sysdir` tests Darwin-specific path behavior, including `NEXT_ROOT`.
+- `strudel` compares a Rust port of Ruby's `st_table` behavior against Ruby
+  benchmark and API expectations.
+
+When importing an upstream fixture, preserve enough context to explain where it
+came from and what version of upstream behavior it represents.
+
+## Ruby Conformance
+
+For Artichoke VM work, conformance means behavior matches the documented MRI
+target, not that the implementation resembles MRI internally.
+
+Use Ruby conformance tests for:
+
+- parser behavior
+- core and stdlib methods
+- exception classes and messages when they are externally visible
+- encoding behavior
+- path and filesystem behavior
+- numeric edge cases
+- object identity and mutation semantics
+- random number generator output when MRI compatibility requires it
+
+A Ruby compatibility feature is not done until:
+
+- the relevant upstream spec passes
+- the implementation has direct tests for Artichoke-specific edge cases
+- any known divergence is documented
+- the spec is added to the enforced set when appropriate
+
+Prefer adding a narrow spec for each fixed bug. A broad spec import is useful
+only when CI can keep it enforced.
+
+## Regression Tests
+
+A regression test should fail before the fix and pass after the fix.
+
+Good regression tests:
+
+- use the public API when the bug is public
+- include the smallest input that demonstrates the issue
+- name the behavior being protected
+- avoid sleeping, networking, clocks, randomness, and host-specific paths unless
+  those are the behavior under test
+- include comments only when the expected behavior is not obvious from the
+  assertion
+
+Do not add weak tests that only execute code. Assert the result, error, panic,
+drop, allocation, output vector, or platform behavior that could regress.
+
+## Feature Matrix
+
+Feature flags are public API, so they need tests.
+
+For active crates, CI should cover:
+
+- default features
+- all features
+- no default features
+- each major optional integration feature when interactions matter
+- docs for feature-gated APIs
+
+When a crate supports `no_std`, the `no_std` configuration must compile in CI.
+If the crate uses `alloc`, document and test the distinction between `core`,
+`alloc`, and `std`.
+
+Do not add a feature flag without adding at least one test or doctest that
+proves the public behavior it enables.
+
+## Platform Matrix
+
+Platform behavior should be tested on real target runners when the crate calls
+real platform APIs.
+
+For supported platforms:
+
+- build the crate
+- run unit and integration tests
+- compile examples
+- build docs when docs are target-specific
+- test minimum dependency versions when platform bindings have a wide range
+
+For unsupported platforms:
+
+- prove the crate compiles off-target when that is the promise
+- prove modules are absent or empty when that is the promise
+- prove examples are gated correctly
+- prove docs do not claim support that is not compiled
+
+An off-target build is still a compatibility promise. Keep it intentional.
+
+## Unsafe Verification
+
+Unsafe code should have tests that target the unsafe invariant, not just the
+safe API happy path.
+
+Use:
+
+- Miri for aliasing, lifetime, and provenance-sensitive code
+- leak tests for ownership and drop paths
+- panic-injection tests for rollback behavior
+- compile-fail tests for lifetime and auto-trait invariants
+- 32-bit target tests for pointer-width assumptions
+- real OS tests for platform FFI
+- fuzzing when unsafe code consumes bytes or parsed input
+
+When a test exists because of unsafe code, say which invariant it protects in
+the test name or nearby comment.
+
+## Golden Fixtures
+
+Golden fixtures are useful when the upstream output is the contract.
+
+Use golden fixtures for:
+
+- Ruby compatibility output
+- encoded and decoded byte streams
+- RNG sequences
+- generated binding snapshots
+- CLI output when the output format is public
+- platform constants when upstream headers are the source of truth
+
+Golden fixtures should be small, named, and traceable. Avoid fixtures so large
+that reviewers stop reading diffs. When a fixture changes, the PR should explain
+which upstream behavior changed and why the new fixture is correct.
+
+## Compile-Fail Tests
+
+Some contracts are negative:
+
+- a value must not be `Send`
+- a lifetime must not escape
+- an API must not exist off-target
+- a feature-gated item must not compile without the feature
+- an unsafe API must require an explicit unsafe call
+
+Use doctest `compile_fail` examples or a compile-test harness when the negative
+contract is important. Prefer compile-fail coverage for unsafe abstractions and
+target-gated APIs.
+
+## Flaky Tests
+
+Flaky tests are bugs in the project infrastructure.
+
+When a test is flaky:
+
+- identify whether the flake is timing, ordering, randomness, platform drift,
+  resource exhaustion, or upstream service behavior
+- narrow the assertion to the real contract
+- replace sleeps with synchronization where possible
+- seed randomness or record the failing seed
+- quarantine only with an issue and a path back to enforcement
+
+Do not silently delete a flaky test that was protecting a real contract.
+
+## CI Expectations
+
+CI should make local expectations public.
+
+For active Rust crates, the normal CI shape should include:
+
+- `cargo build --workspace`
+- `cargo test --workspace`
+- `cargo test --workspace --all-features`
+- `cargo test --workspace --no-default-features`
+- `cargo fmt --check`
+- `cargo clippy --workspace --all-features --all-targets`
+- rustdoc with warnings denied
+- MSRV checks for the declared `rust-version`
+- platform jobs for supported platform APIs
+- Miri, fuzz, or benchmark jobs when the crate needs them
+
+CI may promote warnings to errors for repository validation. Avoid exporting
+that policy through broad crate attributes that affect downstream builds.
+
+## Test Data and Maintenance
+
+Test data should be maintainable.
+
+- Keep fixtures close to the tests that consume them unless they are reused.
+- Document upstream source and version for imported fixtures.
+- Avoid generated fixture churn in behavior PRs.
+- Keep slow tests marked or separated so they can run in scheduled CI.
+- Keep automation runbooks when fixture refreshes require judgment.
+
+Test maintenance is code maintenance. A test that no one can understand will
+eventually stop protecting the project.
+
+## Review Checklist
+
+- Does the change add or update a regression test?
+- Does the test fail without the fix?
+- Is the test at the right layer?
+- Are feature combinations covered?
+- Are supported and unsupported platforms covered?
+- Are README examples compiled as doctests where practical?
+- Are compatibility fixtures traceable to upstream behavior?
+- Does unsafe code have Miri, leak, panic, or compile-fail coverage?
+- Does a dependency range change test both ends of the supported range?
+- Does CI still prove the README and Cargo metadata claims?
+
+## References
+
+- [Cargo Book: cargo test](https://doc.rust-lang.org/cargo/commands/cargo-test.html)
+- [rustdoc book: documentation tests](https://doc.rust-lang.org/rustdoc/write-documentation/documentation-tests.html)
+- [Cargo Book: Features](https://doc.rust-lang.org/cargo/reference/features.html)
+- [Miri](https://github.com/rust-lang/miri)
+- [cargo-fuzz](https://github.com/rust-fuzz/cargo-fuzz)

--- a/docs/guardrails/unsafe-code.md
+++ b/docs/guardrails/unsafe-code.md
@@ -1,0 +1,237 @@
+# Working with Unsafe Code
+
+Unsafe Rust is allowed in Artichoke only when it buys something concrete:
+binding to an operating system API, preserving an FFI ABI, expressing an
+ownership primitive Rust cannot express safely, or avoiding copies where the
+crate's purpose depends on that representation. Unsafe is never a shortcut for
+making the borrow checker quiet.
+
+The active Artichoke examples are `intaglio`, `sysdir`, and `known-folders`.
+Historical examples include `raw-parts`, `strudel`, and `cactusref`.
+
+## Default Rule
+
+If a crate does not need unsafe code, forbid it:
+
+```rust
+#![forbid(unsafe_code)]
+```
+
+`rand_mt` and `boba` follow this rule. Keep it that way unless the crate's
+purpose changes enough to justify a design review.
+
+If a crate does need unsafe code, make that fact visible at the crate root:
+
+```rust
+#![warn(unsafe_op_in_unsafe_fn)]
+#![warn(clippy::undocumented_unsafe_blocks)]
+```
+
+Unsafe operations inside `unsafe fn` still need explicit `unsafe` blocks. This
+keeps the proof obligation attached to the operation, not hidden by the function
+signature.
+
+## Acceptable Uses
+
+Unsafe code may be appropriate for:
+
+- Raw FFI bindings to C or platform APIs.
+- Safe wrappers around platform APIs that transfer ownership through raw
+  pointers.
+- Rebuilding standard-library ownership primitives with explicit public safety
+  contracts.
+- Internal pointer/lifetime representations that are fully encapsulated behind a
+  safe API and verified by tests.
+- Macros that produce compile-time values through unsafe constructors after
+  proving their inputs.
+
+Unsafe code is not appropriate for:
+
+- Avoiding a clone without proving aliasing and lifetime invariants.
+- Speeding up a path that is not measured or user-visible.
+- Replacing straightforward safe Rust with pointer arithmetic.
+- Making public safe APIs depend on caller behavior that is not checked or
+  encoded in the type system.
+
+## Required Documentation
+
+Every public `unsafe fn`, unsafe trait, unsafe impl, and unsafe constructor must
+have a `# Safety` section. The section must name the caller obligations in terms
+that can be checked during review.
+
+Every unsafe block needs a nearby comment explaining why that specific operation
+is sound. Good comments name the relevant invariant:
+
+- pointer origin
+- non-nullness
+- alignment
+- allocation layout
+- initialization
+- aliasing
+- lifetime
+- ownership transfer
+- drop order
+- thread-safety
+- FFI ABI
+- platform API contract
+
+Avoid comments such as "Safety: trusted" or "Safety: obvious". They do not carry
+proof.
+
+## Encapsulation
+
+Unsafe code should be concentrated in small modules with safe APIs around them.
+
+Good local patterns:
+
+- `known-folders` uses a guard around the `SHGetKnownFolderPath` out pointer so
+  `CoTaskMemFree` runs on every return path.
+- `sysdir` exposes raw bindings only on Apple targets and compiles to an empty
+  crate elsewhere.
+- `intaglio` keeps static-lifetime tricks inside internal symbol-table storage
+  and tests drop behavior under Miri.
+- `raw-parts` exposes `into_vec` as `unsafe` instead of hiding it in `From`.
+- `strudel` isolates C ABI functions and raw table conversions in FFI modules.
+
+Do not let unsafe assumptions leak into ordinary callers. If a safe function can
+cause undefined behavior when called with ordinary safe values, the API is
+unsound.
+
+## Proof Obligations
+
+Before adding or changing unsafe code, write down the proof. Use this checklist.
+
+Pointers:
+
+- Where did each pointer come from?
+- Can it be null?
+- Is it aligned for the pointee type?
+- Is it valid for reads, writes, or both?
+- Is it valid for the requested length?
+- Is the computed offset within one allocation?
+
+Allocation and ownership:
+
+- Which allocator allocated the memory?
+- Which value owns deallocation?
+- Is the deallocation layout exactly the allocation layout?
+- Can the memory be freed twice?
+- Can the memory leak on panic or early return?
+
+Initialization:
+
+- Are all read bytes initialized?
+- Are `MaybeUninit` values converted only after initialization?
+- Are partially initialized structures cleaned up correctly?
+
+Aliasing and lifetimes:
+
+- Can a mutable reference coexist with any shared reference?
+- Does an internal `'static` reference escape the type that owns the backing
+  allocation?
+- Does moving a wrapper retag or invalidate references under Stacked Borrows?
+- Are drop order assumptions enforced by fields, guards, or `Drop`?
+
+Unwinding:
+
+- What happens if hashing, allocation, comparison, callback execution, or a
+  user-provided function panics?
+- Is partially inserted state rolled back?
+- Are FFI callbacks unwind-safe, or is unwinding across the boundary impossible?
+
+Thread-safety:
+
+- Are `Send` and `Sync` inherited correctly?
+- If there is an unsafe impl, does it have the same bounds as the safe owner it
+  models?
+- Are compile-fail tests needed to prevent accidental auto-trait widening?
+
+FFI:
+
+- Is the ABI correct?
+- Are `repr(C)` types used where layout is public?
+- Are callbacks and function pointers nullable or non-null?
+- Is string encoding documented?
+- Does ownership of out pointers match upstream docs?
+- Are platform APIs available on every target where they are linked?
+
+## Verification
+
+Unsafe code needs more than ordinary unit tests.
+
+Use the strongest applicable checks:
+
+- Miri with strict provenance, symbolic alignment checks, and randomized layout.
+- Leak tests for ownership and drop behavior.
+- Panic-injection tests for rollback behavior.
+- Compile-fail doctests for lifetime and auto-trait invariants.
+- 32-bit target tests for pointer-width-sensitive code.
+- Platform CI on the real OS when unsafe code calls OS APIs.
+- Fuzzing when unsafe code consumes parsed, decoded, or external input.
+- Sanitizers when they are available and not known-broken for the scenario.
+
+When a sanitizer is disabled because the toolchain is broken, keep the disabled
+job visible with a link to the upstream issue. Do not silently delete the intent
+to test.
+
+## Safe Wrappers Around Platform APIs
+
+Safe platform wrappers must absorb the platform's raw-pointer obligations.
+
+For a function like `SHGetKnownFolderPath`, the wrapper is responsible for:
+
+- passing valid input pointers
+- initializing out pointers correctly
+- freeing returned memory exactly once
+- measuring returned strings safely
+- checking length conversions
+- converting encoding explicitly
+- mapping expected error codes to the documented Rust return type
+
+The safe wrapper should not expose raw pointers unless raw pointers are the
+point of the crate.
+
+## Public Unsafe APIs
+
+A public unsafe API is a compatibility contract. It must be worth carrying.
+
+For each public unsafe API, document:
+
+- why the API cannot be safe
+- what the caller must guarantee
+- what the function guarantees on success
+- what remains true on panic or error
+- whether calling it twice is valid
+- how it interacts with ownership and drop
+
+If the API mirrors `std`, cite the corresponding `std` safety contract and list
+any differences. `raw-parts` mirrors `Vec::from_raw_parts`; this is the right
+level of explicitness.
+
+## Experimental Unsafe Code
+
+If a crate is not proven sound, say so in the README and crate docs. Do not ask
+users to infer risk from a version number or from the existence of Miri tests.
+
+`cactusref` is the model here: it explains that cycle detection requires unsafe
+bookkeeping and that the crate may be unsound. That disclosure is part of the
+crate's safety story.
+
+## Review Checklist
+
+- Can this be written in safe Rust without unacceptable API or performance cost?
+- Is unsafe code isolated to the smallest practical scope?
+- Do all public unsafe items have `# Safety` docs?
+- Does every unsafe block name the invariant it relies on?
+- Are lifetime, aliasing, drop, and allocation assumptions tested?
+- Is panic or callback failure handled?
+- Are `Send` and `Sync` correct?
+- Is off-target compilation safe and explicit?
+- Has Miri or the relevant platform CI run?
+- Does the README disclose the risk if users must uphold safety invariants?
+
+## References
+
+- [Rust Reference: Behavior considered undefined](https://doc.rust-lang.org/reference/behavior-considered-undefined.html)
+- [Rust Edition Guide: unsafe operations in unsafe functions](https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html)
+- [Rustonomicon](https://doc.rust-lang.org/nomicon/)

--- a/docs/guardrails/working-in-public-and-publishing-oss-crates.md
+++ b/docs/guardrails/working-in-public-and-publishing-oss-crates.md
@@ -1,0 +1,215 @@
+# Working in Public and Publishing OSS Crates
+
+Artichoke Rust repositories are public project infrastructure. Treat every
+repository as something a downstream user may copy from, depend on, or audit
+without asking first. The public surface is not only the Rust API. It includes
+issues, pull requests, release notes, CI, README examples, docs.rs output,
+crates.io metadata, licenses, and automation prompts.
+
+These guardrails are written for Artichoke crates such as `rand_mt`, `intaglio`,
+`sysdir`, and `known-folders`, and they also reflect lessons from older crates
+such as `boba`, `raw-parts`, `strudel`, `qed`, and `cactusref`.
+
+## Default Stance
+
+- Work in public by default. Prefer issues, pull requests, and documented
+  automation runbooks over private notes.
+- Make narrow changes. A PR should have one intent: a bug fix, feature,
+  dependency update, CI update, docs update, or release prep.
+- Assume published crates are permanent. Do not publish exploratory APIs unless
+  the crate clearly describes its maturity and limitations.
+- Prefer boring project mechanics. Users should not need to learn a custom task
+  runner to build, test, audit, or publish a crate.
+- Let Codex prepare routine changes, but review the diff as authored code. The
+  human maintainer owns issue selection, release decisions, CI interpretation,
+  and the public contract.
+
+## Repository Shape
+
+Every public Rust crate repository should have:
+
+- `Cargo.toml` with accurate `name`, `version`, `rust-version`, `edition`,
+  `license`, `repository`, `documentation`, `homepage`, `description`,
+  `keywords`, `categories`, `readme`, and `include`.
+- A README that can stand alone on GitHub, crates.io, and docs.rs.
+- License files matching the Cargo manifest.
+- CI for build, test, formatting, linting, documentation, audit, and publish.
+- `deny.toml` that restricts licenses and sources.
+- A contribution guide that describes local setup, common commands, testing
+  expectations, dependency updates, and the Codex maintenance workflow.
+- Automation runbooks only when they encode repeatable maintenance decisions
+  that should survive across runs.
+
+README files should include:
+
+- What the crate does in one sentence.
+- A minimal dependency stanza.
+- A small, compiling example.
+- Feature flags and default features.
+- Platform support and off-target behavior, if relevant.
+- MSRV and when it can be bumped.
+- License.
+- Maturity or soundness caveats when applicable.
+
+Do not rely on badges, repository topics, or crates.io metadata to carry meaning
+that belongs in the README.
+
+## Public Issue and PR Discipline
+
+Open or reuse an issue before larger work unless the change is purely routine
+maintenance. The issue should explain the user-visible problem or maintenance
+goal. Avoid vague issues such as "clean up code" unless they list concrete
+outcomes.
+
+Pull requests should:
+
+- Link the issue or maintenance runbook.
+- Explain what changed and why.
+- Call out public API, MSRV, platform, dependency, unsafe, and release impacts.
+- Include tests or explicitly explain why existing coverage is sufficient.
+- Keep generated or mechanical churn separate from handwritten changes.
+- Wait for CI to finish before merge.
+
+Avoid mixing release prep with unrelated implementation work. Release prep is
+its own PR unless the repository runbook explicitly says otherwise.
+
+## Cargo Metadata
+
+Cargo metadata is a user-facing API. Keep it precise.
+
+- `description` should describe the crate, not the parent Artichoke project.
+- `keywords` and `categories` should match the real public use case.
+- `repository`, `homepage`, and `documentation` must point to live public URLs.
+- `include` should be explicit and small. Library crates usually include source,
+  tests, README, licenses, examples when useful, and generated bindings only
+  when those bindings are intentionally part of the crate.
+- Do not package vendored upstream source unless redistributing it is
+  intentional and its license is documented.
+- Keep `html_root_url` synchronized with `Cargo.toml` during release prep.
+
+Library crates should generally not commit `Cargo.lock` unless there is a
+specific reason. CI should generate a lockfile when tools require locked audits.
+
+## Versioning and MSRV
+
+Use semver as the public compatibility language.
+
+- Patch releases are for compatible bug fixes, docs fixes, CI-only publish
+  fixes, and low-risk internal cleanup.
+- Minor releases may add API, widen supported dependency ranges, change MSRV, or
+  change documented platform coverage.
+- Major releases are required for semver-incompatible API removals or behavior
+  changes that downstream code cannot absorb safely.
+- MSRV bumps are public compatibility changes. In Artichoke crates, they may be
+  made in minor releases when the README says so.
+- Keep MSRV tests in CI. A crate is not MSRV-compatible unless CI proves it.
+
+Dependency ranges are also compatibility promises. Prefer the narrowest range
+that expresses what CI actually tests. For target-specific dependencies, test
+the minimum supported version and the latest supported version when the range is
+wider than one exact version.
+
+## Publishing
+
+Publishing should be tag-driven and repeatable.
+
+Before tagging:
+
+- Check that `Cargo.toml` version, README dependency examples, and
+  `html_root_url` agree.
+- Run the repository's build, test, formatting, linting, docs, and audit
+  commands.
+- Run `cargo package --allow-dirty` during release prep when the repository
+  runbook requests it, and inspect the package file list.
+- Confirm `cargo publish --dry-run` or equivalent package validation succeeds
+  when practical.
+- Confirm CI is green on the exact commit to be tagged.
+
+The publish workflow should:
+
+- Trigger only on `vX.Y.Z` tags.
+- Validate that the tag version matches `Cargo.toml`.
+- Wait for the CI workflow on the tagged commit.
+- Use crates.io trusted publishing through OIDC instead of long-lived
+  `CARGO_REGISTRY_TOKEN` secrets.
+- Request only the permissions it needs, normally `contents: read`,
+  `actions: read`, and `id-token: write` for the publish job.
+- Use `persist-credentials: false` on checkout.
+
+Never republish from a dirty or reconstructed tree. Publish what was reviewed,
+merged, and tagged.
+
+## CI and Supply Chain
+
+CI should be a public statement of what the crate supports.
+
+- Pin GitHub Actions by commit SHA for active repositories.
+- Keep top-level workflow permissions empty or read-only and grant write
+  permissions only to jobs that need them.
+- Run `cargo deny` for advisories, licenses, bans, and sources.
+- Treat new advisories as triage events. It is acceptable for advisory-only
+  checks to report without blocking surprise breakage, but the result must be
+  reviewed.
+- Run `zizmor` or equivalent workflow linting for GitHub Actions.
+- Keep `dependabot` or equivalent dependency automation scoped to useful
+  updates.
+- Keep automation prompts in `docs/automations/` when the decision process is
+  more important than the schedule.
+
+Generated maintenance PRs must be reviewed like hand-authored PRs. Confirm the
+change is necessary, scoped, and validated before merging.
+
+## Documentation Is Part of the Release
+
+docs.rs is the public API reader for Rust users. It must build cleanly.
+
+- Use
+  `RUSTDOCFLAGS="-D warnings -D rustdoc::broken_intra_doc_links --cfg docsrs"`
+  in CI for active crates.
+- Configure `package.metadata.docs.rs` to build the targets that match the crate
+  story.
+- Use `doc(cfg(...))` for optional features and platform-specific modules when
+  possible.
+- Include README snippets in doctests when the crate presents examples as
+  copy-pasteable code.
+- Use `compile_fail` examples for off-target or misuse examples.
+
+Do not publish docs that overclaim platform support, soundness, cryptographic
+suitability, dependency compatibility, or MSRV.
+
+## Maturity and Limitations
+
+If a crate is experimental, say so plainly. `cactusref` is a good model: it
+describes the idea, lists limitations, and warns that the crate may be unsound.
+That is better than allowing users to infer maturity from badges or a version
+number.
+
+Limitations that should be documented include:
+
+- Unsafe API obligations.
+- Known unsoundness risk.
+- Off-target empty crates.
+- Deterministic but non-cryptographic randomness.
+- Raw platform path semantics.
+- Dependency range compatibility policy.
+- Vendored upstream source and license treatment.
+
+## Release Prep Checklist
+
+- `Cargo.toml` version is final.
+- README dependency stanza uses the final version.
+- `src/lib.rs` `html_root_url` uses the final version.
+- Changelog or release notes, if present, describe user-visible changes.
+- MSRV policy still matches README and CI.
+- Feature docs match `Cargo.toml`.
+- docs.rs target config matches supported platforms.
+- `cargo package` file list is correct.
+- Publish workflow uses trusted publishing and minimal permissions.
+- CI is green on the exact tagged commit.
+
+## References
+
+- [OpenAI Harness Engineering](https://openai.com/index/harness-engineering/)
+- [Cargo Book: Publishing on crates.io](https://doc.rust-lang.org/cargo/reference/publishing.html)
+- [crates.io trusted publishing](https://crates.io/docs/trusted-publishing)
+- [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/)


### PR DESCRIPTION
## Summary

- Add docs/guardrails with the Artichoke Rust maintenance guardrails.
- Rewrite AGENTS.md as injected agent workflow guidance for intaglio: repo identity, operating loop, common change classes, and direct links to the relevant guardrails and runbooks.
- Link the guardrails to the dependency and supply-chain posture docs added by the base branch.

## Validation

- pnpm run fmt
- pnpm exec prettier --check "**/*"
- git diff --check
- AGENTS.md scan confirmed no source-file inventory, repository-map wording, Project Contract wording, or bracketed Codex title/body tag remains

Rust tests were not run for the latest follow-up because it only changes AGENTS.md.