### PR TITLE
Run macOS 26 ARM and Intel in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,13 +21,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, windows-2025-vs2026, macos-26]
+        os: [ubuntu-24.04, windows-2025-vs2026, macos-26, macos-26-intel]
         include:
           - os: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
           - os: windows-2025-vs2026
             target: x86_64-pc-windows-msvc
           - os: macos-26
+            target: aarch64-apple-darwin
+          - os: macos-26-intel
             target: x86_64-apple-darwin
     env:
       RUSTFLAGS: -D warnings


### PR DESCRIPTION
## Summary

- Change class: Dependencies, CI, and automation.
- Compatibility impact: CI runner-image coverage only; crate API and Rust behavior are unchanged.
- Keep the normal `macos-26` CI job and add a separate `macos-26-intel` job.
- Build `aarch64-apple-darwin` on `macos-26` and `x86_64-apple-darwin` on `macos-26-intel`.

## Runner Image Review

Reviewed workflow runner labels under `.github/workflows/`:

- `ubuntu-24.04`
- `windows-2025-vs2026`
- `macos-26`
- `macos-26-intel`

Current upstream support state checked on 2026-06-02:

- GitHub's runner-images README lists `ubuntu-24.04` as x64 GA and the `ubuntu-latest` target.
- It lists `windows-2025-vs2026` as x64 GA for Windows Server 2025 with Visual Studio 2026.
- It lists `macos-26` as arm64 and `macos-26-intel` / `macos-26-large` as x64.
- `windows-latest` and `windows-2025` migrate to the VS 2026 image from 2026-06-08 through 2026-06-15, but this repo already pins `windows-2025-vs2026` explicitly.
- `macos-latest` migrates to macOS 26 from 2026-06-15 through 2026-07-15; this repo uses explicit macOS labels.
- macOS 14 deprecation begins 2026-07-06, brownouts begin 2026-10-05, and retirement is 2026-11-02; this repo does not use macOS 14 labels.

Sources:

- https://github.com/actions/runner-images
- https://github.com/actions/runner-images/issues/14017
- https://github.com/actions/runner-images/issues/14167
- https://github.com/actions/runner-images/issues/13518

## Branch Ruleset

Checked repository ruleset `protect default branch from destructive actions`. CI remains gated on the normal `Build (macos-26)` status check only; `Build (macos-26-intel)` is intentionally not required.

## Validation

- `git diff --check`
- `env COREPACK_HOME=/private/tmp/intaglio-runner-images-corepack mise exec -- corepack pnpm exec prettier --check '**/*'`

`actionlint` was checked but is not installed in the local PATH or configured `mise` toolchain, so it was skipped.
