### PR TITLE
chore(deps): update dependency sweep pins

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -4,7 +4,7 @@ node = "24.16.0"
 rust = { version = "stable", profile = "minimal", components = "clippy,rustfmt" }
 zizmor = "1.25.2"
 
-"cargo:cargo-deny" = "0.19.6"
+"cargo:cargo-deny" = "0.19.8"
 "cargo:cargo-mutants" = "27.0.0"
 "cargo:cargo-outdated" = "0.19.0"
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "rust"
   ],
   "repository": "github:artichoke/intaglio",
-  "packageManager": "pnpm@11.1.3+sha512.c85357fe17ca12dd23dd7071822666dfd7e3cb76fe214e3370b5ea2fb34f2a231185509b63e717f3cd0acb38dd3f8d82bcd5e8172400ae678b70ea4fbed0896d",
+  "packageManager": "pnpm@11.5.0+sha512.dbfcc4f81cf48597afd4bc391ffdf12c11f1a9fb83a395bfa6b0a2d9cc2fd8ffebafdb1ccbd529632153f793904c2615b7f09fe1a345473fd1c35845172a8eb1",
   "author": "Ryan Lopopolo <rjl@hyperbo.la> (https://hyperbo.la/)",
   "homepage": "https://www.artichokeruby.org",
   "bugs": "https://github.com/artichoke/intaglio/issues",


### PR DESCRIPTION
## Change class

Dependencies, CI, And Automation.

## Compatibility impact

No public crate API, token allocation, lookup semantics, feature behavior, MSRV, or Rust dependency requirements change. This updates local development/package-manager tooling only.

## Updates

- Update `package.json#packageManager` from `pnpm@11.1.3` to `pnpm@11.5.0` with the matching SHA512 Corepack hash.
- Update the `mise.toml` `cargo:cargo-deny` tool pin from `0.19.6` to `0.19.8`.
- `pnpm-lock.yaml` was refreshed with pnpm `11.5.0`; it was already current and did not change.

## Cooldown decisions

- Adopted `pnpm@11.5.0`, published 2026-05-29, which is beyond the one-week cooldown for this 2026-06-06 sweep.
- Left `pnpm@11.5.2` alone because it was published 2026-06-05 and is still inside cooldown.
- Adopted `cargo-deny@0.19.8`, published 2026-05-28, which is beyond cooldown.
- Left `cargo-mutants@27.0.0` alone because `27.1.0` was published 2026-06-02 and is still inside cooldown.
- Confirmed Node.js `24.16.0`, zizmor `1.25.2`, cargo-outdated `0.19.0`, and Prettier `3.8.3` are current or outside this automation's direct update scope.

## Dependabot review

- Reviewed open Dependabot PRs for `artichoke/intaglio`; none were open.

## Validation

- `env COREPACK_HOME=/private/tmp/intaglio-dependency-sweep-corepack mise exec -- corepack pnpm --version` -> `11.5.0`
- `env COREPACK_HOME=/private/tmp/intaglio-dependency-sweep-corepack mise exec -- corepack pnpm install --lockfile-only`
- `env COREPACK_HOME=/private/tmp/intaglio-dependency-sweep-corepack mise exec -- corepack pnpm install --frozen-lockfile`
- `env COREPACK_HOME=/private/tmp/intaglio-dependency-sweep-corepack mise exec -- corepack pnpm exec prettier --check '**/*'`
- `mise install cargo:cargo-deny@0.19.8`
- `mise exec -- cargo-deny --version` -> `cargo-deny 0.19.8`
- `mise exec -- cargo-deny --locked --all-features check bans licenses sources --show-stats`
