### PR TITLE
Update dependency sweep tooling pins

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,11 +1,11 @@
 [tools]
-node = "24.16.0"
+node = "24.17.0"
 # Rust intentionally tracks the stable channel for this Rust library.
 rust = { version = "stable", profile = "minimal", components = "clippy,rustfmt" }
 zizmor = "1.25.2"
 
-"cargo:cargo-deny" = "0.19.8"
-"cargo:cargo-mutants" = "27.0.0"
+"cargo:cargo-deny" = "0.19.9"
+"cargo:cargo-mutants" = "27.1.0"
 "cargo:cargo-outdated" = "0.19.0"
 
 [hooks]

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "rust"
   ],
   "repository": "github:artichoke/intaglio",
-  "packageManager": "pnpm@11.5.0+sha512.dbfcc4f81cf48597afd4bc391ffdf12c11f1a9fb83a395bfa6b0a2d9cc2fd8ffebafdb1ccbd529632153f793904c2615b7f09fe1a345473fd1c35845172a8eb1",
+  "packageManager": "pnpm@11.8.0+sha512.c1f5e7c4cb241c8f174b743851d82f42b802324afc8b0f116b96adb15aa06664948dde36960a3ba1079ba5b4b29dd0140135b94b5b5f5263592249d68e555f26",
   "author": "Ryan Lopopolo <rjl@hyperbo.la> (https://hyperbo.la/)",
   "homepage": "https://www.artichokeruby.org",
   "bugs": "https://github.com/artichoke/intaglio/issues",


### PR DESCRIPTION
## Summary

Change class: Dependencies, CI, and Automation.

Compatibility impact: no crate API, feature, MSRV, token, lookup, interner behavior, or Rust dependency compatibility impact. This only updates pinned development tooling used by repository maintenance.

This dependency sweep updates automation-owned pins that are past the one-week cooldown:

- Node.js `24.16.0` -> `24.17.0`
- pnpm `11.5.0` -> `11.8.0`
- cargo-deny `0.19.8` -> `0.19.9`
- cargo-mutants `27.0.0` -> `27.1.0`

## Upstream Review

- Dependabot PRs reviewed: none were open.
- Node.js `24.17.0`: reviewed Node release metadata and compare from `v24.16.0...v24.17.0`; this is an LTS security release. Node.js `24.18.0`, published 2026-06-23, remains in cooldown.
- pnpm `11.8.0`: reviewed release `v11.8.0`, npm package metadata, and compare from `v11.5.0...v11.8.0`. The package keeps the same `engines.node >=22.13`, bin entries, and package scripts; changes are install/update/lockfile fixes plus security advisory GHSA-qrv3-253h-g69c.
- cargo-deny `0.19.9`: reviewed crates.io metadata, release notes, and compare from `0.19.8...0.19.9`; changes are low-risk source policy/config and bug fixes.
- cargo-mutants `27.1.0`: reviewed crates.io metadata, release notes, and compare from `v27.0.0...v27.1.0`; changes are TOML 1.1 support, mutation behavior improvements, docs, and scratch-copy mtime fix.
- Direct Prettier `3.8.4` is available but left for Dependabot per the sweep ownership rules.

## Validation

- `corepack pnpm --version` resolved `11.8.0`
- `pnpm install --lockfile-only`
- `pnpm install --frozen-lockfile`
- `pnpm exec prettier --check '**/*'`
- `node --version` resolved `v24.17.0`
- `cargo-deny --version` resolved `0.19.9`
- `cargo mutants --version` resolved `27.1.0`
- `cargo-deny --locked --all-features check bans licenses sources --show-stats`
- `git diff --check`

Note: local branch creation in the Codex worktree was blocked by sandboxed Git worktree metadata, so this PR branch and commit were created through GitHub's Git data API.