### PR TITLE
chore(deps): update dependency toolchain pins

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -63,7 +63,19 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Resolve zizmor version
+        id: zizmor-version
+        shell: bash
+        run: |
+          version="$(awk -F '"' '/^[[:space:]]*zizmor[[:space:]]*=/{ print $2; exit }' mise.toml)"
+          if [[ ! "${version}" =~ ^[0-9]+[.][0-9]+[.][0-9]+$ ]]; then
+            echo "Unable to resolve exact zizmor version from mise.toml" >&2
+            exit 1
+          fi
+          printf 'version=%s\n' "${version}" >> "${GITHUB_OUTPUT}"
+
       - name: Run zizmor 🌈
-        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
         with:
           persona: "pedantic"
+          version: ${{ steps.zizmor-version.outputs.version }}

--- a/mise.toml
+++ b/mise.toml
@@ -1,8 +1,8 @@
 [tools]
-node = "24.17.0"
+node = "24.18.0"
 # Rust intentionally tracks the stable channel for this Rust library.
 rust = { version = "stable", profile = "minimal", components = "clippy,rustfmt" }
-zizmor = "1.25.2"
+zizmor = "1.26.1"
 
 "cargo:cargo-deny" = "0.19.9"
 "cargo:cargo-mutants" = "27.1.0"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "rust"
   ],
   "repository": "github:artichoke/intaglio",
-  "packageManager": "pnpm@11.8.0+sha512.c1f5e7c4cb241c8f174b743851d82f42b802324afc8b0f116b96adb15aa06664948dde36960a3ba1079ba5b4b29dd0140135b94b5b5f5263592249d68e555f26",
+  "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b",
   "author": "Ryan Lopopolo <rjl@hyperbo.la> (https://hyperbo.la/)",
   "homepage": "https://www.artichokeruby.org",
   "bugs": "https://github.com/artichoke/intaglio/issues",


### PR DESCRIPTION
## Summary

Change class: Dependencies, CI, and automation.

Compatibility impact: development tooling only. This does not change the public crate API, Rust dependency requirements, interner behavior, MSRV policy, or feature behavior.

Updates automation-owned pins:

- Node.js `24.17.0` to `24.18.0`
- pnpm package-manager pin `11.8.0` to `11.9.0`
- zizmor `1.25.2` to `1.26.1` in `mise.toml`
- CI derives the `zizmorcore/zizmor-action` `version` input from the canonical `mise.toml` pin and fails if it cannot resolve an exact version.
- `zizmorcore/zizmor-action` `0.5.6` to `0.5.7` because `0.5.6` rejects `zizmor 1.26.1` as an unknown version.

`pnpm-lock.yaml` was regenerated/checked with pnpm `11.9.0` and did not change.

## Upstream Review

- Node.js `24.18.0` is the latest 24.x LTS release from 2026-06-23. The local install verified the upstream GPG signature.
- pnpm `11.9.0` was published on 2026-06-23. The package-manager pin uses the registry sha512 digest converted to the existing Corepack hex form.
- zizmor `1.26.1` was published on 2026-06-21. The local install verified GitHub artifact attestations. The CI workflow passes the version resolved from `mise.toml`; `zizmor-action` is updated only to the release whose `support/versions` allowlist includes `1.26.1`.
- `cargo-deny 0.19.9`, `cargo-mutants 27.1.0`, and `cargo-outdated 0.19.0` are already current in the crate index.

All adopted versions satisfy the one-week cooldown as of the 2026-07-01 dependency sweep.

## Dependabot Review

- Merged #394, `prettier` `3.8.3` to `3.8.4`, after reviewing the upstream compare and confirming green CI. The release was published on 2026-06-09, so cooldown was satisfied.
- Left #393 open for human review with an automation note. The group includes `actions/checkout` `6.0.2` to `7.0.0`, a semver-major action update with behavior changes and a large generated `dist/index.js` diff.

## Validation

- `git diff --check origin/trunk...HEAD`
- `mise exec -- node --version` -> `v24.18.0`
- `mise exec -- pnpm --version` -> `11.9.0`
- `mise exec -- zizmor --version` -> `zizmor 1.26.1`
- `pnpm install --frozen-lockfile --store-dir /private/tmp/intaglio-dependency-sweep-pnpm-store`
- `pnpm exec prettier --check '**/*'`
- `zizmor --pedantic --no-progress --cache-dir /private/tmp/intaglio-dependency-sweep-zizmor-cache .`
- local check that the CI `awk` expression resolves `version=1.26.1` from `mise.toml`
- checked `zizmor-action@0.5.7` `support/versions` contains `1.26.1`
- `pnpm exec prettier --check .github/workflows/audit.yaml`
- `zizmor --pedantic --no-progress --cache-dir /private/tmp/intaglio-dependency-sweep-zizmor-cache .github/workflows/audit.yaml`

Rust tests were not run because this change only updates development tool and package-manager pins.
