### PR TITLE
chore(deps): update dependency toolchain pins

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -235,7 +235,7 @@ jobs:
       - name: Setup Node.js runtime
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "24.16.0"
+          node-version: "24.18.0"
           cache: pnpm
 
       - name: Install toolchain

--- a/mise.toml
+++ b/mise.toml
@@ -4,7 +4,7 @@ node = "24.18.0"
 rust = { version = "stable", profile = "minimal", components = "clippy,rustfmt" }
 zizmor = "1.26.1"
 
-"cargo:cargo-deny" = "0.19.9"
+"cargo:cargo-deny" = "0.20.2"
 "cargo:cargo-mutants" = "27.1.0"
 "cargo:cargo-outdated" = "0.19.0"
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "rust"
   ],
   "repository": "github:artichoke/intaglio",
-  "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b",
+  "packageManager": "pnpm@11.11.0+sha512.4463f65fd80ed80d69bc1d4bf163ee94f605c7380fc318bb5b2ebe15f8cd12d49c51a4d59e951b401e764d3b6ca751cbf51bc50ed7001a6bcb4935e684c34882",
   "author": "Ryan Lopopolo <rjl@hyperbo.la> (https://hyperbo.la/)",
   "homepage": "https://www.artichokeruby.org",
   "bugs": "https://github.com/artichoke/intaglio/issues",


### PR DESCRIPTION
## Summary

- Update CI Node.js runtime from 24.16.0 to 24.18.0 so CI matches the canonical mise LTS pin.
- Update packageManager from pnpm 11.9.0 to 11.11.0, the latest eligible release after the cooldown window.
- Update the local cargo-deny tool pin from 0.19.9 to 0.20.2.

## Dependency Review

Change class: Dependencies, CI, and automation.

Compatibility impact: CI and development tooling only. No public crate API, interner behavior, token allocation, lookup semantics, feature behavior, MSRV, or runtime dependency changes.

Upstream reviewed:

- Node.js v24.16.0...v24.18.0. v24.18.0 was published on 2026-06-23, and v24.17.0 was a security release included in this range. Repo impact is limited to the text-formatting CI runtime, and mise already pins 24.18.0.
- pnpm v11.9.0...v11.11.0. v11.11.0 was published on 2026-07-09; 11.12+ and 11.13+ remain inside the cooldown window. The release includes supply-chain/path traversal fixes and metadata memory-reduction work; the lockfile is unchanged.
- cargo-deny 0.19.9...0.20.2. 0.20.2 was published on 2026-07-09. The release includes CLI cleanup and `bans.std-replacements`; this repository's cargo-deny command shape validated unchanged.

Dependabot PR reviewed:

- #396 is green, but left for human review because actions/checkout 6.0.2 -> 7.0.0 is semver-major with a large generated ESM/dist diff.

## Validation

- `CI=true COREPACK_HOME=... mise exec -- corepack pnpm install --frozen-lockfile --store-dir ...`
- `mise exec -- cargo deny --version`
- `mise exec -- cargo deny --locked --all-features check advisories --show-stats`
- `mise exec -- cargo deny --locked --all-features check bans licenses sources --show-stats`
- `mise exec -- zizmor --pedantic .github/workflows/ci.yaml`
- `mise exec -- zizmor --pedantic .`
- `git diff --check origin/trunk...HEAD`
- `CI=true COREPACK_HOME=... npm_config_store_dir=... mise exec -- corepack pnpm exec prettier --check '**/*'`
