### PR TITLE
chore(deps): update pnpm to 11.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "rust"
   ],
   "repository": "github:artichoke/intaglio",
-  "packageManager": "pnpm@11.11.0+sha512.4463f65fd80ed80d69bc1d4bf163ee94f605c7380fc318bb5b2ebe15f8cd12d49c51a4d59e951b401e764d3b6ca751cbf51bc50ed7001a6bcb4935e684c34882",
+  "packageManager": "pnpm@11.12.0+sha512.820a6fbd0d9f04c226638002aead1e45340a9139dd5dc077c1d83ef44aa2481c8eb6637b4c9aa696a3c7e35ba818e49cf27213e5f2b91138d09b7a3e26e898ba",
   "author": "Ryan Lopopolo <rjl@hyperbo.la> (https://hyperbo.la/)",
   "homepage": "https://www.artichokeruby.org",
   "bugs": "https://github.com/artichoke/intaglio/issues",


### PR DESCRIPTION
## Summary

- update the exact Corepack pnpm pin from 11.11.0 to 11.12.0
- preserve the package-manager-generated lockfile unchanged
- leave all other toolchain and dependency surfaces unchanged

## Upstream review and risk

Reviewed the authoritative [pnpm 11.12.0 release](https://github.com/pnpm/pnpm/releases/tag/v11.12.0) and [v11.11.0...v11.12.0 compare](https://github.com/pnpm/pnpm/compare/v11.11.0...v11.12.0). The release adds optional custom-fetcher delegation and fixes changed-package filtering in worktrees, peer dependency resolution, local-reference handling in `pnpm outdated`, self-update behavior, and install verification outside projects. This repository is a single-package formatting workspace with one direct Node dependency, so the update is low risk.

## Cooldown

pnpm 11.12.0 was published on 2026-07-11 and has completed the required one-week cooldown. pnpm 11.13.0 and newer releases were still inside cooldown when this sweep evaluated them. Node.js 24.18.0, cargo-deny 0.20.2, cargo-mutants 27.1.0, and cargo-outdated 0.19.0 are current. Zizmor 1.27.0 remains in cooldown.

## Validation

- `pnpm --version` → `11.12.0`
- `pnpm install --frozen-lockfile`
- `pnpm exec prettier --check '**/*'`
- `git diff --check`

The frozen install reported the lockfile up to date and the repository supply-chain policies passing.

## Dependabot review

Reviewed open Dependabot PR #396. All checks pass, but the grouped update still contains the semver-major `actions/checkout` 6.0.2 → 7.0.0 ESM/generated-dist rewrite and fork-PR guard. The existing `Codex automation note:` remains accurate, so the PR is intentionally left for human review without a duplicate automation comment.

Change class: Dependencies, CI, and automation.

Compatibility impact: none for the public crate API, token/lookup behavior, feature gates, MSRV, or runtime allocation behavior.