### PR TITLE
chore(deps): update pnpm to 11.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "rust"
   ],
   "repository": "github:artichoke/intaglio",
-  "packageManager": "pnpm@11.11.0+sha512.4463f65fd80ed80d69bc1d4bf163ee94f605c7380fc318bb5b2ebe15f8cd12d49c51a4d59e951b401e764d3b6ca751cbf51bc50ed7001a6bcb4935e684c34882",
+  "packageManager": "pnpm@11.15.0+sha512.266f8957a30d2be6e9468e5e66bcdedd35a794175f71b067ba8504d686cce1d0c0f429b33c323c3c569ad4891e667574a49ff71d1b89a22cc66f13c65818c578",
   "author": "Ryan Lopopolo <rjl@hyperbo.la> (https://hyperbo.la/)",
   "homepage": "https://www.artichokeruby.org",
   "bugs": "https://github.com/artichoke/intaglio/issues",


### PR DESCRIPTION
## Summary

- update the exact `packageManager` pin from pnpm 11.11.0 to 11.15.0
- refresh the Corepack SHA-512 integrity digest from authoritative npm registry metadata
- leave `pnpm-lock.yaml` unchanged because a frozen install reports it is current

## Upstream review and risk

Reviewed [pnpm v11.11.0...v11.15.0](https://github.com/pnpm/pnpm/compare/v11.11.0...v11.15.0) and the [pnpm 11.15.0 release](https://github.com/pnpm/pnpm/releases/tag/v11.15.0). The release contains package-resolution fixes, an `adm-zip` security update, versioning-ledger fixes, and workspace-resolution fixes. The published package keeps its Node.js requirement at `>=22.13`, which is satisfied by this repository's Node.js 24.18.0 pin. This is a routine package-manager update with moderate upstream breadth and focused repository impact.

## Cooldown

pnpm 11.15.0 was published at 2026-07-18T12:52:03Z and had completed the required seven-day cooldown when reviewed at 2026-07-27T16:02:07Z. pnpm 11.15.1, 11.16.0, and 11.17.0 remain in cooldown, so this PR intentionally does not adopt them. Deprecated pnpm 11.12.0 and 11.13.0 were excluded.

Node.js 24.18.0, cargo-deny 0.20.2, cargo-mutants 27.1.0, and cargo-outdated 0.19.0 remain current. Zizmor 1.28.0 remains in cooldown; zizmor 1.27.0 is unavailable after a credential-logging security defect.

## Validation

- `COREPACK_HOME=/private/tmp/intaglio-dependency-sweep-corepack mise exec -- corepack pnpm --version` → `11.15.0`
- `COREPACK_HOME=/private/tmp/intaglio-dependency-sweep-corepack mise exec -- corepack pnpm install --frozen-lockfile`
- `COREPACK_HOME=/private/tmp/intaglio-dependency-sweep-corepack mise exec -- corepack pnpm exec prettier --check '**/*'`
- `git diff --check`

## Dependabot review

Reviewed #396. Its checks are green, but the grouped update still includes the non-mechanical `actions/checkout` 6.0.2 → 7.0.0 semver-major ESM/generated-runtime rewrite and fork-PR behavior change. The existing automation note remains accurate, so #396 is intentionally left for human review.