### PR TITLE
ci: reduce redundant workflow jobs

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -62,11 +62,6 @@ jobs:
       always() &&
       (github.event_name == 'schedule' || needs.changes.outputs.rust == 'true')
     runs-on: ubuntu-24.04
-    # Preserve the existing matrix-suffixed check context for merge policy.
-    strategy:
-      matrix:
-        checks:
-          - bans licenses sources
     permissions:
       contents: read # required to checkout repository
 
@@ -99,7 +94,7 @@ jobs:
         uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
         with:
           arguments: --locked --all-features
-          command: check ${{ matrix.checks }}
+          command: check bans licenses sources
           command-arguments: --show-stats
 
   zizmor:

--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -1,9 +1,6 @@
 ---
 name: Audit
 "on":
-  push:
-    branches:
-      - trunk
   pull_request:
     branches:
       - trunk
@@ -14,19 +11,64 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 jobs:
+  changes:
+    name: Detect relevant changes
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read # required to checkout repository
+    outputs:
+      rust: ${{ steps.changes.outputs.rust }}
+      workflows: ${{ steps.changes.outputs.workflows }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Detect relevant changes
+        id: changes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          changed_files="$(git diff --name-only "$BASE_SHA...$HEAD_SHA")"
+          rust=false
+          workflows=false
+
+          while IFS= read -r file; do
+            if [[ "$file" == *.rs ||
+                  "$file" == "Cargo.toml" ||
+                  "$file" == "Cargo.lock" ||
+                  "$file" == "deny.toml" ||
+                  "$file" == "mise.toml" ||
+                  "$file" == ".github/workflows/audit.yaml" ]]; then
+              rust=true
+            fi
+            if [[ "$file" == .github/workflows/* ||
+                  "$file" == "mise.toml" ]]; then
+              workflows=true
+            fi
+          done <<< "$changed_files"
+
+          printf 'rust=%s\n' "$rust" >> "$GITHUB_OUTPUT"
+          printf 'workflows=%s\n' "$workflows" >> "$GITHUB_OUTPUT"
+
   rust:
     name: Audit Rust Dependencies
+    needs: changes
+    if: >-
+      always() &&
+      (github.event_name == 'schedule' || needs.changes.outputs.rust == 'true')
     runs-on: ubuntu-24.04
+    # Preserve the existing matrix-suffixed check context for merge policy.
     strategy:
       matrix:
         checks:
-          - advisories
           - bans licenses sources
     permissions:
       contents: read # required to checkout repository
-
-    # Prevent sudden announcement of a new advisory from failing ci:
-    continue-on-error: ${{ matrix.checks == 'advisories' }}
 
     steps:
       - name: Checkout repository
@@ -45,7 +87,16 @@ jobs:
             cargo generate-lockfile --verbose
           fi
 
-      - uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
+      - name: Audit advisories
+        continue-on-error: true
+        uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
+        with:
+          arguments: --locked --all-features
+          command: check advisories
+          command-arguments: --show-stats
+
+      - name: Audit bans, licenses, and sources
+        uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
         with:
           arguments: --locked --all-features
           command: check ${{ matrix.checks }}
@@ -53,6 +104,11 @@ jobs:
 
   zizmor:
     name: Run zizmor 🌈
+    needs: changes
+    if: >-
+      always() &&
+      (github.event_name == 'schedule' ||
+      needs.changes.outputs.workflows == 'true')
     runs-on: ubuntu-24.04
     permissions:
       contents: read # required to checkout repository

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -145,41 +145,6 @@ jobs:
       - name: Test with no default features
         run: cargo test --no-default-features
 
-  leaksan:
-    name: Leak sanitizer
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - ubuntu-24.04
-        include:
-          - os: ubuntu-24.04
-            target: x86_64-unknown-linux-gnu
-    env:
-      RUSTFLAGS: -D warnings
-      RUST_BACKTRACE: 1
-      CI_TARGET_TRIPLE: ${{ matrix.target }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - name: Install Rust toolchain
-        run: |
-          rustup toolchain install nightly --profile minimal --target "$CI_TARGET_TRIPLE"
-          rustup default nightly
-        shell: bash
-
-      - name: Test with leak sanitizer and all features
-        # LeakSanitzier is broken: https://github.com/rust-lang/rust/issues/111073
-        if: false
-        run: cargo test --all-features --target "$CI_TARGET_TRIPLE"
-        env:
-          RUSTFLAGS: "-Z sanitizer=leak"
-          CI_TARGET_TRIPLE: ${{ matrix.target }}
-
   rust:
     name: Lint and format Rust
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Summary

- run Rust and Actions audits only for relevant pull request changes
- combine advisory and policy cargo-deny checks on one runner while retaining the weekly sweep
- preserve the existing matrix-suffixed check context
- remove the leak-sanitizer runner whose test step is permanently disabled

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm exec prettier --check '**/*'`
- `zizmor --pedantic .github/workflows`
- workflow trigger, matrix, and required-context assertions
